### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -44,6 +44,9 @@ on:
       - 'CONTRIBUTING.md'
       - '.github/workflows/sync-check.yml'
 
+permissions:
+  contents: read
+
 jobs:
   sync-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gosha70/code-copilot-team/security/code-scanning/1](https://github.com/gosha70/code-copilot-team/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required by this workflow. Because this workflow only checks out code and runs shell scripts/tests, it appears to need only read access to repository contents (and possibly packages, though nothing here uses them). The safest minimal starting point recommended by CodeQL is `permissions: contents: read`.

The single best way to fix this file without changing behavior is to add a top-level `permissions` block so it applies to all jobs in the workflow. Insert it after the `on:` block (line 45–46) and before `jobs:` (line 47). Set `contents: read`, which is sufficient for `actions/checkout` and for reading the repository contents that the scripts operate on. No imports or additional definitions are required elsewhere; this is purely a YAML configuration change inside `.github/workflows/sync-check.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
