### PR TITLE
Add /review-submit, /review-decide commands and review-loop protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ All tools share the same rules from `shared/rules/always/`. Each adapter formats
 code-copilot-team/
 ├── shared/                              ← Single source of truth
 │   ├── rules/always/                    4 global rules (always loaded)
-│   ├── rules/on-demand/                 13 rules loaded by phase agents
+│   ├── rules/on-demand/                 14 rules loaded by phase agents
 │   ├── docs/                            7 tool-agnostic reference docs
 │   ├── templates/                       9 stacks × PROJECT.md + commands/
 │   ├── templates/sdd/                   5 SDD templates (spec, plan, tasks, lessons-learned, collaboration)
@@ -417,7 +417,7 @@ code-copilot-team/
 │   └── setup.sh                         Unified install entry point
 ├── tests/
 │   ├── test-hooks.sh                    188 hook tests
-│   ├── test-generate.sh                 269 generation + adapter tests
+│   ├── test-generate.sh                 273 generation + adapter tests
 │   ├── test-shared-structure.sh         659 structure + content tests
 │   ├── test-sync.sh                     61 sync + init metadata tests
 │   └── test-peer-review.sh             54 peer-review runner tests

--- a/adapters/claude-code/.claude/commands/phase-complete.md
+++ b/adapters/claude-code/.claude/commands/phase-complete.md
@@ -12,28 +12,23 @@ Determine from the current session:
 - `review_scope` — from `CCT_PEER_REVIEW_SCOPE` env var, or `both`
 - `target_ref` — current git branch or HEAD commit
 
-### 2. Check Peer Review Status
+### 2. Check Review Loop Completion
 
-- If `CCT_PEER_REVIEW_ENABLED` is not `true`, inform the user that peer review is disabled and skip marker creation. Still proceed with post-phase checklist.
+If `CCT_PEER_REVIEW_ENABLED` is `true`:
 
-### 3. Create Marker
+**Build phase** — review is gating:
+- Check if `.cct/review/loop-summary.json` exists with `verdict: "PASS"` or `bypass: true`.
+  - If yes: review completed. Proceed to post-phase checklist.
+  - If no: inform the user that peer review has not completed. Tell them to run `/review-submit` before `/phase-complete`.
 
-Write `.cct/review/pending.json` in the project root:
+**Plan phase** — review is advisory:
+- If `loop-summary.json` exists, note the verdict but proceed regardless (even on FAIL).
+- If `loop-summary.json` does not exist, proceed without review — plan review is optional.
+- A plan-phase FAIL is logged but does **not** block `/phase-complete`.
 
-```json
-{
-  "feature_id": "<feature-id>",
-  "phase": "<plan|build>",
-  "target_ref": "<branch-or-sha>",
-  "subject_provider": "claude",
-  "peer_provider": "<provider-name-or-empty>",
-  "review_scope": "<code|design|both>",
-  "request_id": "<uuid>",
-  "requested_at": "<ISO-8601>"
-}
-```
+If `CCT_PEER_REVIEW_ENABLED` is not `true`, skip review checks entirely. Proceed to post-phase checklist.
 
-### 4. Run Post-Phase Checklist
+### 3. Run Post-Phase Checklist
 
 Reference the post-phase steps from `phase-workflow.md`:
 
@@ -42,11 +37,9 @@ Reference the post-phase steps from `phase-workflow.md`:
 3. Present summary — files changed, decisions made
 4. Commit gate — ask user before committing
 
-### 5. Inform User
+### 4. Inform User
 
 Tell the user:
-- Marker created at `.cct/review/pending.json`
-- Peer review will execute when the session stops (or on next `/stop`)
-- The session will block until review completes (fail-closed)
-- Collaboration artifact will be written to `specs/<feature-id>/collaboration/` using the schema from `shared/templates/sdd/collaboration-template.md`
-- To bypass: set `CCT_PEER_BYPASS=true` or use `--peer-review-off`
+- Phase complete
+- If review passed: collaboration artifact at `specs/<feature-id>/collaboration/`
+- If review was bypassed: bypass is logged and CI will flag it

--- a/adapters/claude-code/.claude/commands/review-decide.md
+++ b/adapters/claude-code/.claude/commands/review-decide.md
@@ -1,0 +1,61 @@
+Resolve a circuit breaker in the review loop. Accepts exactly one argument: approve, reject, or retry.
+
+## Usage
+
+```
+/review-decide approve
+/review-decide reject
+/review-decide retry
+```
+
+## Prerequisites
+
+- `.cct/review/breaker-tripped.json` must exist (a circuit breaker has fired)
+- This command is run by the **human**, not the agent
+
+## Steps
+
+### 1. Validate Breaker State
+
+Check that `.cct/review/breaker-tripped.json` exists:
+- If missing, inform the user: "No active circuit breaker. Nothing to decide."
+- If present, read and display the breaker context (type, rounds completed, unresolved findings).
+
+### 2. Parse Decision
+
+The argument must be exactly one of: `approve`, `reject`, or `retry`.
+- If missing or invalid, show usage and stop.
+
+### 3. Write Decision
+
+Write `.cct/review/decision.json`:
+
+```json
+{
+  "decision": "<approve|reject|retry>",
+  "timestamp": "<ISO-8601>",
+  "breaker_type": "<from breaker-tripped.json>"
+}
+```
+
+Remove `.cct/review/breaker-tripped.json` after writing the decision.
+
+### 4. Execute Decision Path
+
+**approve**:
+- Write `.cct/review/loop-summary.json` with `bypass: true`, the breaker type, and all unresolved findings from `state.json`.
+- Write the collaboration artifact to `specs/<feature-id>/collaboration/build-review.md` with `bypass: true` in frontmatter.
+- Inform the user: "Review bypassed. Proceeding to `/phase-complete`. CI will flag the bypass."
+- Proceed to `/phase-complete`.
+
+**reject**:
+- Write `.cct/review/loop-summary.json` with `verdict: "REJECTED"` and all context.
+- Inform the user: "Review rejected. No merge. Session can be ended."
+- Do not proceed to `/phase-complete`.
+
+**retry**:
+- Read `state.json` and increment the `attempt` counter.
+- Reset breaker state: set `loop_start` to current time (resets wall-clock timer).
+- Round numbering continues monotonically — if the breaker fired after round 5, the next round is 6, not 1.
+- Inform the user: "Breaker reset. Run `/review-submit` to continue the review loop."
+- The agent should then run `/review-submit` to start the next round.

--- a/adapters/claude-code/.claude/commands/review-submit.md
+++ b/adapters/claude-code/.claude/commands/review-submit.md
@@ -1,0 +1,99 @@
+Submit work for peer review. Validates clean worktree, initializes or continues the review loop, invokes review-round-runner.sh, and returns the verdict.
+
+## Prerequisites
+
+- `CCT_PEER_REVIEW_ENABLED` must be `true` (set by `--peer-review` launcher flag)
+- Working tree must have no uncommitted changes (except `.cct/` review state)
+- `jq` must be installed
+
+## Steps
+
+### 1. Validate Environment
+
+Check that peer review is enabled:
+- If `CCT_PEER_REVIEW_ENABLED` is not `true`, inform the user and stop.
+
+### 2. Validate Clean Worktree
+
+Run `git status --porcelain` and check for uncommitted changes (excluding `.cct/`):
+- If dirty, tell the user: "Commit or stash your changes before submitting for review."
+- Do not proceed until the worktree is clean.
+
+### 3. Check for Active Breaker
+
+If `.cct/review/breaker-tripped.json` exists:
+- Read and display the breaker context to the user.
+- Tell the user: "A circuit breaker has fired. Run `/review-decide approve|reject|retry` to proceed."
+- Do not invoke the runner. Stop here.
+
+### 4. Initialize or Continue State
+
+If `.cct/review/state.json` does not exist, create it:
+
+```json
+{
+  "current_round": 0,
+  "attempt": 1,
+  "loop_start": <current-unix-timestamp>,
+  "feature_id": "<from specs/*/plan.md or ask user>",
+  "phase": "<plan|build — infer from current agent or ask>",
+  "subject_provider": "claude",
+  "peer_provider": "<from CCT_PEER_PROVIDER env or empty for profile default>",
+  "review_scope": "<from CCT_PEER_REVIEW_SCOPE env or 'both'>",
+  "target_ref": "<current git branch or HEAD>",
+  "last_verdict": null,
+  "findings": {}
+}
+```
+
+If `state.json` already exists, the runner will read it and continue from the current round.
+
+### 5. Invoke the Runner
+
+Run `review-round-runner.sh <project-dir>` as a synchronous subprocess.
+
+The runner exits with:
+- **0** = PASS — review passed. Read `.cct/review/loop-summary.json` and inform the user. Proceed to `/phase-complete`.
+- **1** = FAIL — review failed. Read `.cct/review/findings-round-N.json` (where N is the current round from `state.json`). Present each finding to the user. For blocking findings, address them (fix, dispute, defer, or mark not-applicable), write `.cct/review/resolution-round-N.json`, commit fixes, then run `/review-submit` again.
+- **2** = BREAKER — circuit breaker tripped. Read `.cct/review/breaker-tripped.json` and present the context. Tell the user to run `/review-decide approve|reject|retry`. Stop and wait.
+
+### 6. On FAIL — Address Findings
+
+Read `findings-round-N.json` and for each blocking finding:
+1. Assess whether it is valid
+2. If valid: fix the code
+3. If invalid: prepare a dispute with explanation
+
+Then write `.cct/review/resolution-round-N.json`:
+
+```json
+{
+  "round": N,
+  "resolutions": [
+    {
+      "finding_id": "f-xxxxxxxx",
+      "disposition": "fixed|disputed|deferred|not-applicable",
+      "detail": "<explanation>",
+      "commit_ref": "<sha — required for 'fixed' disposition>"
+    }
+  ]
+}
+```
+
+Commit the fixes, then run `/review-submit` again for the next round.
+
+### 7. On PASS — Proceed
+
+Inform the user:
+- Review passed after N rounds
+- `loop-summary.json` written
+- Collaboration artifact written to `specs/<feature-id>/collaboration/`
+- Proceed to `/phase-complete`
+
+### Plan-Phase Behavior
+
+For plan-phase review (`phase: plan`):
+- Run exactly one round (advisory only)
+- A FAIL verdict is logged but does **not** trigger a fix loop
+- Write the result as `plan-consult.md` artifact
+- Proceed regardless of verdict — this is a product decision, not a missing feature

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -233,6 +233,7 @@ corresponding skill to apply them.
 | `phase-workflow` | build |
 | `provider-collaboration-protocol` | — |
 | `ralph-loop` | build |
+| `review-loop` | — |
 | `spec-workflow` | plan, build |
 | `stack-constraints` | build |
 | `team-lead-efficiency` | build (optional team mode) |

--- a/adapters/github-copilot/.github/instructions/review-loop.instructions.md
+++ b/adapters/github-copilot/.github/instructions/review-loop.instructions.md
@@ -1,0 +1,132 @@
+---
+applyTo: "**"
+---
+
+# Review Loop Protocol
+
+Agent-driven peer review loop for Build and Plan phases. The Build agent drives the loop; the reviewer is a separate, read-only LLM.
+
+## Loop Architecture
+
+The review loop is **agent-driven**: the Build agent calls `/review-submit`, which invokes `review-round-runner.sh` as a synchronous subprocess. The runner executes one round and returns. The agent reads the result and decides the next action. There is no long-running orchestrator.
+
+```
+Agent completes work → /review-submit → review-round-runner.sh (one round)
+                                              ↓
+                         EXIT 0 (PASS) → loop-summary.json → /phase-complete
+                         EXIT 1 (FAIL) → findings-round-N.json → agent fixes → /review-submit
+                         EXIT 2 (BREAKER) → breaker-tripped.json → agent stops → /review-decide
+```
+
+## File Contract
+
+All review-loop artifacts live under `.cct/review/` during the active loop.
+
+| File | Written By | Purpose |
+|------|-----------|---------|
+| `state.json` | `/review-submit` (init), runner (update) | Loop state: round, attempt, findings, breaker counters |
+| `findings-round-N.json` | Runner | Structured findings for round N |
+| `resolution-round-N.json` | Build agent | Builder's response to each finding |
+| `breaker-tripped.json` | Runner | Breaker context, awaiting `/review-decide` |
+| `decision.json` | `/review-decide` | Human's decision: approve, reject, or retry |
+| `loop-summary.json` | Runner (PASS) or agent (bypass) | Final record of all rounds |
+
+On loop completion, the completing actor copies `loop-summary.json` and writes a `build-review.md` artifact to `specs/<feature-id>/collaboration/`.
+
+## Finding Schema
+
+Each finding has a stable ID computed from `SHA-256(file + category + normalized_description)` truncated to 8 hex chars, prefixed with `f-`. Line numbers are excluded from the ID to remain stable across edits.
+
+```json
+{
+  "id": "f-a1b2c3d4",
+  "severity": "blocking|warning|note",
+  "category": "correctness|security|style|performance|design|testing|documentation",
+  "file": "path/relative/to/project",
+  "line_hint": "semantic anchor (display only)",
+  "description": "clear description",
+  "suggested_fix": "actionable fix",
+  "first_seen_round": 1,
+  "disposition": null
+}
+```
+
+### Severity Levels
+
+| Severity | Blocks PASS? | Builder must respond? |
+|----------|-------------|----------------------|
+| `blocking` | Yes | Yes — must set disposition |
+| `warning` | No | Optional |
+| `note` | No | No — informational |
+
+## Disposition Values
+
+The builder responds to each blocking finding with a disposition in `resolution-round-N.json`:
+
+| Disposition | Meaning | Required fields |
+|-------------|---------|----------------|
+| `fixed` | Builder addressed the finding | `commit_ref` (SHA of fix commit) |
+| `disputed` | Builder disagrees | `detail` (explanation) |
+| `deferred` | Acknowledged, fix later | `detail` (optional) |
+| `not-applicable` | Finding doesn't apply | `detail` (optional) |
+
+## Circuit Breakers
+
+All breakers escalate to human — there is no path to automatic acceptance of unresolved work.
+
+| Breaker | Default | Env Var | Behavior |
+|---------|---------|---------|----------|
+| Max rounds | 5 | `CCT_REVIEW_MAX_ROUNDS` | Escalate to `/review-decide` |
+| Wall-clock timeout | 900s | `CCT_REVIEW_TIMEOUT_SEC` | Escalate to `/review-decide` |
+| Stale findings | 2 consecutive | `CCT_REVIEW_STALE_THRESHOLD` | Escalate to `/review-decide` |
+| Provider unavailable | — | — | Escalate to `/review-decide` |
+
+A **stale finding** is one that appears in N consecutive rounds with disposition `fixed` each time (builder thinks they fixed it, reviewer disagrees). Stale findings remain blocking — they do not auto-downgrade.
+
+## Human Decision Channel
+
+When a breaker fires, the agent stops and the human runs `/review-decide`:
+
+| Decision | Effect |
+|----------|--------|
+| `approve` | Agent writes `loop-summary.json` with `bypass: true`. Proceeds to `/phase-complete`. |
+| `reject` | Agent logs rejection. No merge. |
+| `retry` | Reset breaker state. Round numbering continues monotonically (next round is N+1, not 1). |
+
+## Commit Lifecycle
+
+### Commit-Strategy Modes
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| `single` | `--review-commits single` | Amend same commit each round |
+| `per-round` | `--review-commits per-round` | New commit per fix round: `fix(review): round N — <summary>` |
+| `squash` | `--review-commits squash` (default) | Per-round during loop; `git reset --soft` to pre-review commit on PASS |
+
+### Rules
+
+1. The review system does NOT auto-commit. The Build agent commits following `phase-workflow.md` commit-gate rules.
+2. Before each `/review-submit`, the worktree must be clean (all fixes committed).
+3. Squash mode presents the final commit for user approval before creating it.
+4. If `git reset --soft` fails, fall back to a merge commit — never force-reset or lose work.
+
+## Plan-Phase Review
+
+**Product decision**: Plan review is advisory and single-round.
+
+- Run exactly one `/review-submit` round
+- A FAIL verdict is logged but does **not** gate Build entry
+- No fix loop, no circuit breakers, no commit strategies
+- Artifact written as `plan-consult.md` with `mode: consult`
+- Stop hook does not block plan-phase session stop based on review outcome
+
+This is deliberately narrower than Build-phase review. Plan artifacts are already approved by the human via the Plan Approval Gate before Build begins.
+
+## Read-Only Enforcement
+
+The reviewer runs in a snapshot copy of the working tree:
+- Working directory: `cp -R` to temp dir
+- No `.git` directory (reviewer cannot create commits)
+- `SSH_AUTH_SOCK` and `GPG_AGENT_INFO` unset
+- `CCT_READ_ONLY=true` set in environment
+- Post-review validation: runner compares real repo HEAD and status before/after. If changed, round is marked INVALID and findings are discarded.

--- a/scripts/review-round-runner.sh
+++ b/scripts/review-round-runner.sh
@@ -102,10 +102,14 @@ if [[ -n "$(git -C "$PROJECT_DIR" status --porcelain 2>/dev/null | grep -Ev '^[?
     exit 1
 fi
 
-# ── Circuit breaker: round limit ─────────────────────────────
+# ── Circuit breakers (build phase only) ──────────────────────
+# Plan-phase review is advisory and single-round — no breakers apply.
 
-if [[ "$NEXT_ROUND" -gt "$MAX_ROUNDS" ]]; then
-    cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
+if [[ "$PHASE" != "plan" ]]; then
+
+    # Round limit
+    if [[ "$NEXT_ROUND" -gt "$MAX_ROUNDS" ]]; then
+        cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
 {
   "breaker": "max_rounds",
   "rounds_completed": $CURRENT_ROUND,
@@ -114,17 +118,16 @@ if [[ "$NEXT_ROUND" -gt "$MAX_ROUNDS" ]]; then
   "action": "Run /review-decide approve|reject|retry"
 }
 BREAKER_EOF
-    echo "Circuit breaker: max rounds ($MAX_ROUNDS) reached after $CURRENT_ROUND rounds." >&2
-    exit 2
-fi
+        echo "Circuit breaker: max rounds ($MAX_ROUNDS) reached after $CURRENT_ROUND rounds." >&2
+        exit 2
+    fi
 
-# ── Circuit breaker: wall-clock timeout ──────────────────────
-
-NOW=$(date +%s)
-if [[ -n "$LOOP_START" ]]; then
-    ELAPSED=$((NOW - LOOP_START))
-    if [[ "$ELAPSED" -ge "$TIMEOUT_SEC" ]]; then
-        cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
+    # Wall-clock timeout
+    NOW=$(date +%s)
+    if [[ -n "$LOOP_START" ]]; then
+        ELAPSED=$((NOW - LOOP_START))
+        if [[ "$ELAPSED" -ge "$TIMEOUT_SEC" ]]; then
+            cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
 {
   "breaker": "timeout",
   "rounds_completed": $CURRENT_ROUND,
@@ -134,48 +137,43 @@ if [[ -n "$LOOP_START" ]]; then
   "action": "Run /review-decide approve|reject|retry"
 }
 BREAKER_EOF
-        echo "Circuit breaker: wall-clock timeout (${TIMEOUT_SEC}s) after ${ELAPSED}s." >&2
-        exit 2
+            echo "Circuit breaker: wall-clock timeout (${TIMEOUT_SEC}s) after ${ELAPSED}s." >&2
+            exit 2
+        fi
     fi
-fi
 
-# ── Circuit breaker: stale findings ──────────────────────────
-
-check_stale_findings() {
-    if [[ "$CURRENT_ROUND" -lt 2 || ! -f "$STATE_FILE" ]]; then return; fi
-
-    local stale_ids
-    stale_ids=$(jq -r --argjson threshold "$STALE_THRESHOLD" '
-        .findings // {} | to_entries[] |
-        select(.value.consecutive_fixed >= $threshold) |
-        .key
-    ' "$STATE_FILE" 2>/dev/null)
-
-    if [[ -n "$stale_ids" ]]; then
-        local stale_details
-        stale_details=$(jq --argjson threshold "$STALE_THRESHOLD" '
-            [.findings // {} | to_entries[] |
-             select(.value.consecutive_fixed >= $threshold) |
-             {id: .key, description: .value.description, rounds_seen: .value.rounds_seen,
-              consecutive_fixed: .value.consecutive_fixed}]
+    # Stale findings
+    if [[ "$CURRENT_ROUND" -ge 2 && -f "$STATE_FILE" ]]; then
+        STALE_IDS=$(jq -r --argjson threshold "$STALE_THRESHOLD" '
+            .findings // {} | to_entries[] |
+            select(.value.consecutive_fixed >= $threshold) |
+            .key
         ' "$STATE_FILE" 2>/dev/null)
 
-        cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
+        if [[ -n "$STALE_IDS" ]]; then
+            STALE_DETAILS=$(jq --argjson threshold "$STALE_THRESHOLD" '
+                [.findings // {} | to_entries[] |
+                 select(.value.consecutive_fixed >= $threshold) |
+                 {id: .key, description: .value.description, rounds_seen: .value.rounds_seen,
+                  consecutive_fixed: .value.consecutive_fixed}]
+            ' "$STATE_FILE" 2>/dev/null)
+
+            cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
 {
   "breaker": "stale_findings",
   "rounds_completed": $CURRENT_ROUND,
   "stale_threshold": $STALE_THRESHOLD,
-  "stale_findings": $stale_details,
+  "stale_findings": $STALE_DETAILS,
   "attempt": $ATTEMPT,
   "action": "Run /review-decide approve|reject|retry"
 }
 BREAKER_EOF
-        echo "Circuit breaker: stale findings detected (threshold: $STALE_THRESHOLD consecutive rounds with 'fixed' disposition)." >&2
-        exit 2
+            echo "Circuit breaker: stale findings detected (threshold: $STALE_THRESHOLD consecutive rounds with 'fixed' disposition)." >&2
+            exit 2
+        fi
     fi
-}
 
-check_stale_findings
+fi  # end build-phase-only breakers
 
 # ── Load provider config ─────────────────────────────────────
 
@@ -243,6 +241,11 @@ if ! run_healthcheck "$HEALTHCHECK"; then
     fi
 
     if [[ "$FALLBACK_FOUND" != "true" ]]; then
+        if [[ "$PHASE" == "plan" ]]; then
+            # Plan phase: advisory — log failure and exit without breaker
+            echo "Error: All providers unavailable (plan review skipped)." >&2
+            exit 1
+        fi
         cat > "$REVIEW_DIR/breaker-tripped.json" << BREAKER_EOF
 {
   "breaker": "provider_unavailable",
@@ -327,7 +330,25 @@ else
 fi)
 
 ${PRIOR_CONTEXT}
-## Files to Review
+## Recent Commits
+
+$(git -C "$PROJECT_DIR" log --oneline -10 2>/dev/null || echo "(no git history)")
+
+## Changes to Review
+
+$(git -C "$PROJECT_DIR" diff HEAD~1 --stat 2>/dev/null || echo "(no diff available)")
+
+### Diff
+
+\`\`\`diff
+$(git -C "$PROJECT_DIR" diff HEAD~1 2>/dev/null | head -500 || echo "(no diff available)")
+\`\`\`
+
+$(if [[ $(git -C "$PROJECT_DIR" diff HEAD~1 2>/dev/null | wc -l) -gt 500 ]]; then
+    echo "*Diff truncated at 500 lines. Full diff available in the working tree.*"
+fi)
+
+## Spec Artifacts
 
 $(if [[ -d "$SANDBOX_DIR/specs/$FEATURE_ID" ]]; then
     find "$SANDBOX_DIR/specs/$FEATURE_ID" -name '*.md' -not -path '*/collaboration/*' | sort | while read -r f; do
@@ -673,5 +694,69 @@ ARTIFACT_EOF
     exit 0
 fi
 
-# FAIL or INVALID
+# ── Plan phase: write artifact on any verdict (advisory) ─────
+
+if [[ "$PHASE" == "plan" ]]; then
+    TODAY=$(date +%Y-%m-%d)
+    jq -n \
+        --arg feature_id "$FEATURE_ID" \
+        --arg date "$TODAY" \
+        --arg phase "$PHASE" \
+        --arg verdict "$VERDICT" \
+        --argjson rounds_completed "$NEXT_ROUND" \
+        --argjson attempt "$ATTEMPT" \
+        --arg subject_provider "$SUBJECT_PROVIDER" \
+        --arg peer_provider "$PEER_PROVIDER" \
+        --arg runner_fingerprint "$RUNNER_FINGERPRINT" \
+        --argjson bypass false \
+        --arg target_ref "$TARGET_REF" \
+        --argjson findings "$ACCUMULATED" \
+        '{feature_id: $feature_id, date: $date, phase: $phase, verdict: $verdict,
+          rounds_completed: $rounds_completed, attempt_count: $attempt,
+          subject_provider: $subject_provider, peer_provider: $peer_provider,
+          runner_fingerprint: $runner_fingerprint, bypass: $bypass,
+          target_ref: $target_ref, findings: $findings}' \
+        > "$REVIEW_DIR/loop-summary.json"
+
+    COLLAB_DIR="$PROJECT_DIR/specs/$FEATURE_ID/collaboration"
+    mkdir -p "$COLLAB_DIR"
+    cat > "$COLLAB_DIR/plan-consult.md" << ARTIFACT_EOF
+---
+feature_id: $FEATURE_ID
+date: $TODAY
+status: final
+phase: $PHASE
+mode: consult
+subject_provider: $SUBJECT_PROVIDER
+peer_provider: $PEER_PROVIDER
+peer_profile: $PEER_PROVIDER
+runner_fingerprint: $RUNNER_FINGERPRINT
+verdict: $VERDICT
+blocking_findings_open: $BLOCKING_COUNT
+target_ref: $TARGET_REF
+rounds_completed: $NEXT_ROUND
+attempt_count: $ATTEMPT
+bypass: false
+---
+
+# Peer Review: $FEATURE_ID — Plan Phase (Advisory)
+
+**Reviewer**: $PEER_PROVIDER
+**Scope**: $REVIEW_SCOPE
+**Verdict**: $VERDICT (advisory — does not gate Build)
+
+## Summary
+
+$(echo "$REVIEW_OUTPUT" | awk '/^### Summary/{found=1; next} /^### /{found=0} found{print}')
+
+## Findings
+
+$(echo "$FINDINGS_JSON" | jq -r '.[] | "- [\(.severity)] \(.id): \(.description) (\(.file))"')
+ARTIFACT_EOF
+
+    echo "Plan review complete ($VERDICT, advisory) — plan-consult.md written." >&2
+    exit 0
+fi
+
+# FAIL or INVALID (build phase)
 exit 1

--- a/shared/rules/on-demand/review-loop.md
+++ b/shared/rules/on-demand/review-loop.md
@@ -1,0 +1,128 @@
+# Review Loop Protocol
+
+Agent-driven peer review loop for Build and Plan phases. The Build agent drives the loop; the reviewer is a separate, read-only LLM.
+
+## Loop Architecture
+
+The review loop is **agent-driven**: the Build agent calls `/review-submit`, which invokes `review-round-runner.sh` as a synchronous subprocess. The runner executes one round and returns. The agent reads the result and decides the next action. There is no long-running orchestrator.
+
+```
+Agent completes work → /review-submit → review-round-runner.sh (one round)
+                                              ↓
+                         EXIT 0 (PASS) → loop-summary.json → /phase-complete
+                         EXIT 1 (FAIL) → findings-round-N.json → agent fixes → /review-submit
+                         EXIT 2 (BREAKER) → breaker-tripped.json → agent stops → /review-decide
+```
+
+## File Contract
+
+All review-loop artifacts live under `.cct/review/` during the active loop.
+
+| File | Written By | Purpose |
+|------|-----------|---------|
+| `state.json` | `/review-submit` (init), runner (update) | Loop state: round, attempt, findings, breaker counters |
+| `findings-round-N.json` | Runner | Structured findings for round N |
+| `resolution-round-N.json` | Build agent | Builder's response to each finding |
+| `breaker-tripped.json` | Runner | Breaker context, awaiting `/review-decide` |
+| `decision.json` | `/review-decide` | Human's decision: approve, reject, or retry |
+| `loop-summary.json` | Runner (PASS) or agent (bypass) | Final record of all rounds |
+
+On loop completion, the completing actor copies `loop-summary.json` and writes a `build-review.md` artifact to `specs/<feature-id>/collaboration/`.
+
+## Finding Schema
+
+Each finding has a stable ID computed from `SHA-256(file + category + normalized_description)` truncated to 8 hex chars, prefixed with `f-`. Line numbers are excluded from the ID to remain stable across edits.
+
+```json
+{
+  "id": "f-a1b2c3d4",
+  "severity": "blocking|warning|note",
+  "category": "correctness|security|style|performance|design|testing|documentation",
+  "file": "path/relative/to/project",
+  "line_hint": "semantic anchor (display only)",
+  "description": "clear description",
+  "suggested_fix": "actionable fix",
+  "first_seen_round": 1,
+  "disposition": null
+}
+```
+
+### Severity Levels
+
+| Severity | Blocks PASS? | Builder must respond? |
+|----------|-------------|----------------------|
+| `blocking` | Yes | Yes — must set disposition |
+| `warning` | No | Optional |
+| `note` | No | No — informational |
+
+## Disposition Values
+
+The builder responds to each blocking finding with a disposition in `resolution-round-N.json`:
+
+| Disposition | Meaning | Required fields |
+|-------------|---------|----------------|
+| `fixed` | Builder addressed the finding | `commit_ref` (SHA of fix commit) |
+| `disputed` | Builder disagrees | `detail` (explanation) |
+| `deferred` | Acknowledged, fix later | `detail` (optional) |
+| `not-applicable` | Finding doesn't apply | `detail` (optional) |
+
+## Circuit Breakers
+
+All breakers escalate to human — there is no path to automatic acceptance of unresolved work.
+
+| Breaker | Default | Env Var | Behavior |
+|---------|---------|---------|----------|
+| Max rounds | 5 | `CCT_REVIEW_MAX_ROUNDS` | Escalate to `/review-decide` |
+| Wall-clock timeout | 900s | `CCT_REVIEW_TIMEOUT_SEC` | Escalate to `/review-decide` |
+| Stale findings | 2 consecutive | `CCT_REVIEW_STALE_THRESHOLD` | Escalate to `/review-decide` |
+| Provider unavailable | — | — | Escalate to `/review-decide` |
+
+A **stale finding** is one that appears in N consecutive rounds with disposition `fixed` each time (builder thinks they fixed it, reviewer disagrees). Stale findings remain blocking — they do not auto-downgrade.
+
+## Human Decision Channel
+
+When a breaker fires, the agent stops and the human runs `/review-decide`:
+
+| Decision | Effect |
+|----------|--------|
+| `approve` | Agent writes `loop-summary.json` with `bypass: true`. Proceeds to `/phase-complete`. |
+| `reject` | Agent logs rejection. No merge. |
+| `retry` | Reset breaker state. Round numbering continues monotonically (next round is N+1, not 1). |
+
+## Commit Lifecycle
+
+### Commit-Strategy Modes
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| `single` | `--review-commits single` | Amend same commit each round |
+| `per-round` | `--review-commits per-round` | New commit per fix round: `fix(review): round N — <summary>` |
+| `squash` | `--review-commits squash` (default) | Per-round during loop; `git reset --soft` to pre-review commit on PASS |
+
+### Rules
+
+1. The review system does NOT auto-commit. The Build agent commits following `phase-workflow.md` commit-gate rules.
+2. Before each `/review-submit`, the worktree must be clean (all fixes committed).
+3. Squash mode presents the final commit for user approval before creating it.
+4. If `git reset --soft` fails, fall back to a merge commit — never force-reset or lose work.
+
+## Plan-Phase Review
+
+**Product decision**: Plan review is advisory and single-round.
+
+- Run exactly one `/review-submit` round
+- A FAIL verdict is logged but does **not** gate Build entry
+- No fix loop, no circuit breakers, no commit strategies
+- Artifact written as `plan-consult.md` with `mode: consult`
+- Stop hook does not block plan-phase session stop based on review outcome
+
+This is deliberately narrower than Build-phase review. Plan artifacts are already approved by the human via the Plan Approval Gate before Build begins.
+
+## Read-Only Enforcement
+
+The reviewer runs in a snapshot copy of the working tree:
+- Working directory: `cp -R` to temp dir
+- No `.git` directory (reviewer cannot create commits)
+- `SSH_AUTH_SOCK` and `GPG_AGENT_INFO` unset
+- `CCT_READ_ONLY=true` set in environment
+- Post-review validation: runner compares real repo HEAD and status before/after. If changed, round is marked INVALID and findings are discarded.

--- a/tests/test-counts.env
+++ b/tests/test-counts.env
@@ -1,7 +1,7 @@
 # Expected PASS totals for top-level test suites.
 # Keep this in sync when assertions are added or removed.
 
-TEST_GENERATE_EXPECTED_PASS=269
+TEST_GENERATE_EXPECTED_PASS=273
 TEST_HOOKS_EXPECTED_PASS=188
 TEST_SHARED_STRUCTURE_EXPECTED_PASS=659
 TEST_SYNC_EXPECTED_PASS=61

--- a/tests/test-generate.sh
+++ b/tests/test-generate.sh
@@ -334,7 +334,7 @@ assert "instructions dir exists" "[[ -d '$INSTRUCTIONS_DIR' ]]"
 
 # Verify all on-demand rules become instruction files
 ON_DEMAND_COUNT=$(ls "$INSTRUCTIONS_DIR"/*.instructions.md 2>/dev/null | wc -l | tr -d ' ')
-assert "exactly 13 instruction files ($ON_DEMAND_COUNT)" "[[ $ON_DEMAND_COUNT -eq 13 ]]"
+assert "exactly 13 instruction files ($ON_DEMAND_COUNT)" "[[ $ON_DEMAND_COUNT -eq 14 ]]"
 
 # Verify each on-demand rule has a corresponding instruction file
 for f in "$SHARED/on-demand"/*.md; do
@@ -387,7 +387,7 @@ GH_INSTALL_RC=$?
 assert "gh-copilot install exits 0" "[[ $GH_INSTALL_RC -eq 0 ]]"
 assert "installed copilot-instructions.md" "[[ -f '$GH_TMP/.github/copilot-instructions.md' ]]"
 INSTALLED_INSTR=$(ls "$GH_TMP/.github/instructions"/*.instructions.md 2>/dev/null | wc -l | tr -d ' ')
-assert "gh-copilot installed 13 instruction files ($INSTALLED_INSTR)" "[[ $INSTALLED_INSTR -eq 13 ]]"
+assert "gh-copilot installed 13 instruction files ($INSTALLED_INSTR)" "[[ $INSTALLED_INSTR -eq 14 ]]"
 rm -rf "$GH_TMP"
 
 # ── Section 17: Windsurf rules.md ─────────────────────────

--- a/tests/test-shared-structure.sh
+++ b/tests/test-shared-structure.sh
@@ -156,7 +156,7 @@ for f in "${ON_DEMAND_FILES[@]}"; do
 done
 
 ONDEMAND_COUNT=$(find "$SHARED_DIR/rules/on-demand" -name '*.md' | wc -l | tr -d ' ')
-assert_eq "exactly 13 on-demand rules" "13" "$ONDEMAND_COUNT"
+assert_eq "exactly 14 on-demand rules" "14" "$ONDEMAND_COUNT"
 
 # ══════════════════════════════════════════════════════════════
 # 3. shared/docs/ — tool-agnostic docs exist
@@ -801,8 +801,8 @@ grep -Eq "rules/always/[[:space:]]+4 global rules" "$REPO_DIR/README.md" || rc=1
 assert_ok "README lists 4 global always rules" "$rc"
 
 rc=0
-grep -Eq "rules/on-demand/[[:space:]]+13 rules loaded by phase agents" "$REPO_DIR/README.md" || rc=1
-assert_ok "README lists 13 on-demand rules" "$rc"
+grep -Eq "rules/on-demand/[[:space:]]+14 rules loaded by phase agents" "$REPO_DIR/README.md" || rc=1
+assert_ok "README lists 14 on-demand rules" "$rc"
 
 rc=0
 grep -Eq "templates/[[:space:]]+9 stacks" "$REPO_DIR/README.md" || rc=1


### PR DESCRIPTION
New commands:
- /review-submit: validates worktree, initializes state, invokes review-round-runner.sh, instructs agent on PASS/FAIL/BREAKER paths
- /review-decide: resolves circuit breakers (approve/reject/retry), writes decision.json, handles bypass and retry state reset

New rule:
- review-loop.md: documents full protocol — loop architecture, file contract, finding schema, dispositions, circuit breakers, commit strategies, plan-phase advisory decision, read-only enforcement

Runner improvements:
- Include git diff and commit log in review request so reviewer can identify the actual changes
- Skip circuit breakers for plan phase (advisory, no escalation)
- Write plan-consult.md and loop-summary on plan-phase FAIL (exit 0)
- Plan-phase provider unavailable exits 1, not breaker exit 2

Phase-complete rewrite:
- Check loop-summary.json instead of creating pending.json (no double review). Plan phase proceeds regardless of verdict.

Integration:
- On-demand rule count 13→14, instruction file count 13→14
- Generate expected pass 269→273, README updated

## Summary

Briefly describe what this pull request changes and why.

## Changes

- 

## Validation

- [ ] `bash tests/test-generate.sh`
- [ ] `bash tests/test-hooks.sh`
- [ ] `bash tests/test-peer-review.sh`
- [ ] `bash adapters/claude-code/setup.sh && bash tests/test-shared-structure.sh`

## Checklist

- [ ] Scope is focused and does not mix unrelated changes
- [ ] Documentation updated where needed
- [ ] Security-sensitive findings were handled privately per `SECURITY.md`
- [ ] No secrets or credentials were introduced
