### PR TITLE
Patch wiki schema v0.2 from dogfood findings

### DIFF
--- a/knowledge/wiki/decisions/infra-verification-as-gate.md
+++ b/knowledge/wiki/decisions/infra-verification-as-gate.md
@@ -3,11 +3,19 @@ page_type: decision
 slug: infra-verification-as-gate
 title: Treat Infra Verification as a Gate, Not a Guideline
 status: stable
-last_reviewed: 2026-05-03
+last_reviewed: 2026-05-04
 sources:
   - path: specs/infra-verification-gate/spec.md
     sha: 2753e34
   - path: shared/skills/infra-verification/SKILL.md
+    sha: d2b083d
+  - path: scripts/generate.sh
+    sha: 0434fbf
+  - path: adapters/codex/AGENTS.md
+    sha: 0434fbf
+  - path: adapters/cursor/.cursor/rules/infra-verification.mdc
+    sha: d2b083d
+  - path: adapters/github-copilot/.github/instructions/infra-verification.instructions.md
     sha: d2b083d
 ---
 

--- a/knowledge/wiki/log.md
+++ b/knowledge/wiki/log.md
@@ -3,7 +3,7 @@ page_type: log
 slug: log
 title: Wiki Edit Log
 status: stable
-last_reviewed: 2026-05-03
+last_reviewed: 2026-05-04
 ---
 
 # Wiki Edit Log
@@ -16,6 +16,7 @@ Append-only. One bullet per entry, newest at the top. Format:
 
 ## Entries
 
+- 2026-05-04 — patched schema v0.2: F1 (private-source workaround in `citation-rules`), F4 (atomic cluster-promotion mode in `promote-lesson-to-wiki`), F5 (optional `## Instances` H2 for `incident`), F6 (cross-repo `pr:` example), F7 (softened `open-question` resolution H2), F8 (note on ADR-vs-frontmatter convention for `decision`), F9 (curator distribution-claim discipline in `WIKI_MAINTAINER`); driven by v0.1 dogfood findings.
 - 2026-05-03 — created `doc-coverage-audit` (workflow): periodic 30-day reconciliation of shipped features against user-facing docs; dogfood promotion C4.
 - 2026-05-03 — created `respond-to-production-readiness-review` (playbook): bucket items by release target, refuse lump-sum framing; dogfood promotion C5.
 - 2026-05-03 — created `phase-scoped-build-prompts` (concept): scope each agent build invocation to one phase with read-first + plan-first discipline; dogfood promotion C6.

--- a/knowledge/wiki/schema/WIKI_MAINTAINER.md
+++ b/knowledge/wiki/schema/WIKI_MAINTAINER.md
@@ -71,6 +71,46 @@ For every promotion or update:
   in a separate change. Do not commit lint violations.
 - **Mix promotion and curation in one turn.** Promote *or* refactor;
   not both.
+- **Assert a distribution claim without verifying it.** See the
+  next section.
+
+## Distribution-claim discipline
+
+Several wiki page types (decisions, incidents, concepts about
+shared infrastructure) describe how a generated artifact is
+distributed across the project — for example, "this skill
+reaches every adapter via `scripts/generate.sh`" or "this rule
+is always-on for Claude Code." Such claims are easy to overstate
+and hard to retract once cited from other pages.
+
+**Before writing any claim about how a generated artifact is
+distributed, you must:**
+
+1. Read the generator source code (`scripts/generate.sh` or the
+   equivalent) and identify the exact mechanism that propagates
+   the artifact (e.g., `ALWAYS_SKILLS`, on-demand TOC, hardcoded
+   advisory).
+2. Verify the claim against **at least one generated-artifact
+   target** — grep for the artifact in the generated adapter
+   output (e.g., `adapters/codex/AGENTS.md`,
+   `adapters/cursor/.cursor/rules/*.mdc`). "It runs through the
+   generator" is not the same as "every adapter receives it."
+3. **Cite both:** the generator source (with commit SHA) **and**
+   at least one generated-artifact target (with commit SHA), in
+   the page's `sources:` frontmatter. If different adapters
+   receive the artifact through different mechanisms (always-on
+   vs. on-demand vs. not-at-all), enumerate each adapter
+   explicitly in prose — do not collapse them into "all adapters."
+4. If a verification step shows the claim is narrower than you
+   first thought, **rewrite the prose, not the verification.**
+   The empirical signal is correct; the prose is the thing to
+   change.
+
+This rule was added in v0.2 after a peer-review pair fired twice
+on the same page (`decisions/infra-verification-as-gate.md`),
+each time on a different distribution overstatement. The pattern
+generalises: when in doubt about distribution, grep the generator
+and at least one target before writing the prose.
 
 ## Escalation
 

--- a/knowledge/wiki/schema/citation-rules.md
+++ b/knowledge/wiki/schema/citation-rules.md
@@ -27,13 +27,15 @@ sources:
 
 ```yaml
 sources:
-  - issue: 12        # in this repo
-  - pr: 22
-  - issue: gosha70/rlmkit#37   # cross-repo
+  - issue: 12                  # issue in this repo
+  - pr: 22                     # PR in this repo
+  - issue: gosha70/rlmkit#37   # cross-repo issue
+  - pr: gosha70/rlmkit#30      # cross-repo PR
 ```
 
 Use the bare number for issues/PRs in `code-copilot-team`. Use
-`<owner>/<repo>#<n>` for cross-repo references.
+`<owner>/<repo>#<n>` for cross-repo references — same form for
+both `issue:` and `pr:`.
 
 ### 3. External URL
 
@@ -46,6 +48,46 @@ sources:
 - `url` is the canonical permalink.
 - `retrieved` is the date you read it (URLs rot; the date tells the
   next reader how stale the citation may be).
+
+## When the upstream source is private (gitignored or in a sister repo's `doc_internal/`)
+
+The richest sources for methodological lessons are sometimes
+working docs in a gitignored `doc_internal/` directory of this
+repo or of a sister repo (e.g., `rlmkit`). The three forms above
+do not handle these — `path: + sha:` will not resolve for another
+contributor, and there is no public URL.
+
+**The blessed workaround** (validated by the v0.1 dogfood):
+**cite the public artifact the private working doc informed —
+the PR, issue, or merged spec — and reference the private doc
+inline in prose by path with a one-line description.** A future
+reader can audit every claim by following the public artifact;
+the inline pointer tells them the private doc exists and where.
+
+```yaml
+sources:
+  - pr: gosha70/rlmkit#30
+  - pr: gosha70/rlmkit#31
+  - pr: gosha70/rlmkit#32
+  - pr: gosha70/rlmkit#33
+```
+
+Then in prose:
+
+> The driving spec was `rlmkit doc_internal/specs/prefill-decode-telemetry.md`,
+> which evolved across seven review rounds; the four PRs cited
+> above are the public artifacts that landed each round.
+
+**Constraints:**
+
+- The private doc must have informed at least one citable public
+  artifact. A private doc that has produced nothing public yet is
+  not a citable source — wait for the public artifact to land.
+- Do not invent a `private_path:` source kind in the frontmatter.
+  The frontmatter must remain machine-checkable; the private-doc
+  pointer lives in prose only.
+- The inline pointer must be specific (path inside the sister
+  repo, one-line description), not vague ("internal notes").
 
 ## Forbidden citations
 

--- a/knowledge/wiki/schema/page-types.md
+++ b/knowledge/wiki/schema/page-types.md
@@ -56,7 +56,8 @@ Required H2 sections:
 ### `incident` — `incidents/<slug>.md`
 A real failure (or near-miss) and what was learned from it. NOT a
 generic "things to avoid" page — every incident page describes a
-specific event.
+specific event, or a tightly-scoped cluster of events with one
+root cause.
 
 Required H2 sections:
 
@@ -64,6 +65,18 @@ Required H2 sections:
 - `## Why it happened` (root cause, not symptom)
 - `## What we changed`
 - `## How to recognize a recurrence`
+
+Optional H2 section:
+
+- `## Instances` — used when the page bundles **multiple
+  receipts of one root cause** (e.g., three drift instances
+  caught across three review rounds). Place between `## Why it
+  happened` and `## What we changed`. Each instance is a `###`
+  subsection with a short headline and a 2–4 line account
+  (what was observed, what the receipt looked like, how it was
+  resolved). Use this **instead of** rewriting the four required
+  H2s in the plural — the singular framing of the required H2s
+  is intentional and stays.
 
 ### `decision` — `decisions/<slug>.md`
 An architecture or process decision. Light-weight ADR.
@@ -74,6 +87,15 @@ Required H2 sections:
 - `## Context`
 - `## Alternatives considered`
 - `## Consequences`
+
+**Note on ADR conventions:** Classical ADR templates (Nygard,
+MADR) include `## Status` and `## Date` H2s in the body. This
+schema deliberately surfaces both in the YAML frontmatter
+instead — `status` and `last_reviewed` — because they are
+machine-checkable there and the linter enforces them. **Do not
+add `## Status` or `## Date` H2s to a wiki decision page.** If
+you are migrating an external ADR, drop those sections and let
+the frontmatter carry the metadata.
 
 ### `playbook` — `playbooks/<slug>.md`
 An operational recipe for a recurring situation. Like a workflow,
@@ -108,7 +130,13 @@ Required H2 sections:
 
 - `## Question`
 - `## Why it matters`
-- `## What would resolve it`
+- `## What an answer might look like` — what shape a resolution
+  would take, what evidence would close the question, or what
+  precondition must change before it can be answered.
+  "**No clear resolution path yet**" is an explicitly valid body
+  for this section — say so plainly when that is the truth, and
+  describe what you have ruled out. Do not invent a fake
+  resolution path just to fill the slot.
 
 ### `index` — `index.md` only
 The wiki entry point. No required structure beyond grouping links by

--- a/knowledge/wiki/workflows/promote-lesson-to-wiki.md
+++ b/knowledge/wiki/workflows/promote-lesson-to-wiki.md
@@ -3,7 +3,7 @@ page_type: workflow
 slug: promote-lesson-to-wiki
 title: Promote a Lesson to the Wiki
 status: stable
-last_reviewed: 2026-05-03
+last_reviewed: 2026-05-04
 sources:
   - issue: 12
   - path: claude_code/.claude/rules/copilot-conventions.md
@@ -28,6 +28,57 @@ In Claude Code, the `/promote-lesson <description>` slash command
 runs this workflow on your behalf. The procedure below is the
 canonical, adapter-agnostic version; the slash command is a
 convenience wrapper around it.
+
+## Two modes: single-page and atomic cluster
+
+Promotion runs in one of two modes. Pick **before** you start
+writing.
+
+- **Single-page mode** — one lesson, one page, no inbound or
+  outbound wiki links beyond the index entry. Use this when the
+  page genuinely stands alone. Walk steps 1–10 below in order.
+- **Atomic cluster mode** — two or more pages promoted in one
+  turn that reference each other. Use this when the lessons share
+  a root cause, a sequence, or a pattern that only makes sense as
+  a set. Linking pages one-at-a-time forces a topological order
+  and breaks the linter mid-batch on every forward reference.
+  Atomic cluster mode avoids that entirely.
+
+If you find yourself two pages into single-page mode and a third
+page wants to link to one not yet written — stop, restart in
+atomic cluster mode. Do not paper over with placeholder TBD links;
+the linter catches them and the review trail is worse than the
+restart.
+
+### Atomic cluster recipe
+
+Use this in place of steps 4–9 when promoting a cluster:
+
+1. **Slug table first.** Decide all page types, slugs, and
+   directories upfront. Write them in a markdown table in the
+   conversation or in `doc_internal/` so they are visible. Do not
+   start writing pages before the table is settled.
+2. **Write each page with `## Related` placeholders.** Use literal
+   `## Related — Links added in cross-link pass.` so the section
+   exists but the linker pass has nothing to break. Do **not**
+   write speculative markdown-link stubs that point at not-yet-
+   written files — those will trip the linter the moment they
+   target a missing path.
+3. **Single cross-link pass.** With every page in the cluster
+   written, fill in every `## Related` section against the slug
+   table. This is also when you wire each page to siblings the
+   index already names.
+4. **Update `index.md` and `log.md` once.** One bullet per page
+   in `index.md`; one entry per page in `log.md`, all dated the
+   same day.
+5. **Lint once.** `bash knowledge/wiki/scripts/lint-wiki.sh`. With
+   the cross-link pass complete and the index updated, the linter
+   should pass on the first run. If it doesn't, fix the violation
+   without splitting the cluster.
+
+The dogfood that produced v0.2 measured cluster mode at
+~24 min/page versus ~28 min/page for one-at-a-time, with zero
+forward-link breakage.
 
 ## Steps
 


### PR DESCRIPTION
Seven targeted patches driven by the v0.1 dogfood (10 promotions across
  two checkpoints, 19 pages total):

  - F1: bless private-source citation workaround in citation-rules.md (cite the public artifact the gitignored doc informed; reference the private doc inline by path with a one-line description).
  - F4: document atomic cluster-promotion mode in promote-lesson-to-wiki.md with a 5-step recipe; reframes existing steps as the single-page path.
  - F5: add `## Instances` as an optional H2 in the incident template for "multiple receipts of one root cause" content.
  - F6: add cross-repo `pr: <owner>/<repo>#<n>` to citation-rules examples; one-sentence note that issue/PR share the form.
  - F7: rename open-question `## What would resolve it` to `## What an answer might look like`; explicitly accept "no clear resolution path yet" as a valid body.
  - F8: note in page-types.md that wiki decisions surface status/date in YAML frontmatter, not `## Status`/`## Date` H2s; do not migrate ADR H2s.
  - F9: add curator distribution-claim discipline to WIKI_MAINTAINER.md (read the generator source, verify against >=1 generated target, cite both, enumerate per-adapter when mechanisms differ); brings the F9 motivating page (decisions/infra-verification-as-gate.md) into compliance by adding scripts/generate.sh + three per-adapter generated targets to its sources frontmatter.

  Lint: `linted 19 pages, 0 violations`.

## Summary

Briefly describe what this pull request changes and why.

## Changes

- 

## Validation

- [ ] `bash tests/test-generate.sh`
- [ ] `bash tests/test-hooks.sh`
- [ ] `bash tests/test-peer-review.sh`
- [ ] `bash tests/test-review-loop.sh`
- [ ] `bash adapters/claude-code/setup.sh && bash tests/test-shared-structure.sh`

## Checklist

- [ ] Scope is focused and does not mix unrelated changes
- [ ] Documentation updated where needed
- [ ] Security-sensitive findings were handled privately per `SECURITY.md`
- [ ] No secrets or credentials were introduced
