### PR TITLE
feat(benchmark): usable cross-LLM comparison driver — scripts/bench + presets + live progress + timeout + safe defaults (Closes #36)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,7 +6,73 @@ The harness does **not** author benchmarks — it runs established public benchm
 
 See [`specs/benchmark-harness/spec.md`](../specs/benchmark-harness/spec.md) for the full design and [`specs/benchmark-harness/plan.md`](../specs/benchmark-harness/plan.md) for the phased delivery plan.
 
-## Quick start: compare multiple LLMs
+## 60-second quickstart
+
+`./scripts/bench` is the daily driver. It translates a terse CLI into
+the JSON config the harness consumes — no hand-authored config, no
+four-env-var incantation, live progress to your terminal, and a
+per-attempt timeout so a hung model never blocks the run.
+
+**First-time check (no LLM call, no spend):**
+
+```bash
+./scripts/bench
+```
+
+Runs an internal stub-vs-stub smoke (proves the wrapper + harness +
+report pipeline work), prints which LLM endpoints your environment has,
+and exits — without making any LLM call or touching your Anthropic
+account.
+
+**Compare two models on a coding task:**
+
+```bash
+./scripts/bench sonnet ollama:qwen2.5-coder:7b
+```
+
+`sonnet`/`opus`/`haiku` use your ambient Anthropic auth;
+`ollama:`/`lmstudio:`/`openrouter:`/`vllm:` auto-fill the gateway env
+vars for you (colons in model tags like `qwen2.5-coder:7b` are parsed
+correctly). The wrapper **prompts for confirmation before any
+Anthropic-API-bearing run** (all-local comparisons never prompt); add
+`--yes` for CI / non-interactive use.
+
+**Different models, tasks, or run counts:**
+
+```bash
+./scripts/bench --task python/bowling,go/bowling --runs 5 sonnet opus
+```
+
+**A curated comparison without thinking about candidate specs:**
+
+```bash
+./scripts/bench --preset local-vs-cloud
+```
+
+**Discovery:**
+
+```bash
+./scripts/bench --help
+./scripts/bench --list-presets      # anthropic-tour, local-vs-cloud, cross-language-mini
+./scripts/bench --list-providers    # what your machine can actually run (Ollama ≥0.14.0, etc.)
+```
+
+Live progress streams to **stderr** while a run is in flight (stdout
+stays clean JSON), so a long run is never silently stuck. A single
+candidate routes to `./scripts/benchmark run`; two or more route to
+`compare`. Everything below is the underlying machinery `./scripts/bench`
+drives — reach for it only when you need the raw knobs.
+
+## Advanced configuration
+
+> The `./scripts/bench` quickstart above is the recommended entry
+> point. This section documents the raw `./scripts/benchmark compare`
+> JSON-config flow it builds on, the four-`ANTHROPIC_*` gateway
+> incantation, the `claude-code:` long form, and the
+> `attempt_timeout_seconds` knob — kept here for users who need them
+> directly.
+
+### Compare multiple LLMs (raw JSON config)
 
 You have a benchmark (say, Aider Polyglot) and you want to know which LLM does best on it. The `compare` subcommand takes a JSON config listing N candidate LLMs and runs them sequentially under one shared run-dir, then aggregates a Markdown report with mean ± stdev per metric and the calibrated winner verdict.
 
@@ -45,7 +111,7 @@ Copy [`benchmarks/compare-config.example.json`](compare-config.example.json) as 
 {
   "benchmark": "aider-polyglot",
   "runs": 3,
-  "task": ["python/leap", "go/leap", "rust/leap"],
+  "task": ["python/bowling", "go/bowling", "rust/bowling"],
   "candidates": [
     { "name": "sonnet",   "backend": "claude-code", "model": "sonnet" },
     { "name": "opus",     "backend": "claude-code", "model": "opus"   },
@@ -69,6 +135,7 @@ Field reference (full schema: [`benchmarks/schema/compare-config.schema.json`](s
 | `benchmark` | string | yes | Adapter id from `./scripts/benchmark list`. |
 | `runs` | integer ≥1 | no (default 1) | Repetitions per task per candidate. **Use ≥3** for cross-LLM comparisons; the calibrated winner-rule needs stdev to declare a winner over noise. |
 | `task` | string[] | no | Task filter (omit to run every task). Same shape as `./scripts/benchmark run --task`. |
+| `attempt_timeout_seconds` | integer ≥1 | no | Per-attempt wall-clock cap. A timed-out attempt is recorded `result="timeout"` / `scores.timeout=true`, counts as a pass-rate failure, and is flagged separately in the report's `timed_out` tally (it does **not** alter the winner calculus). Precedence depends on the entry path. Via `./scripts/bench`: `--attempt-timeout` CLI flag > this field > the wrapper's heuristic (300s cloud, 600s when `ANTHROPIC_BASE_URL` is set). Via a hand-written config run with `./scripts/benchmark compare --config …` (which bypasses the wrapper): this field, else the backend's own default / `CCT_CLAUDE_TIMEOUT_SECONDS` env override (no 300/600 heuristic — that lives in `bench.py`). |
 | `candidates[]` | array (≥2) | yes | LLMs to compare. Order is preserved in the report. |
 | `candidates[].name` | string | no | Human-readable label; defaults to `<backend>:<model>`. Must be unique. |
 | `candidates[].backend` | string | yes | Backend family — `claude-code` or `stub`. **Do not** use the combined `claude-code:sonnet` form (rejected). |
@@ -119,7 +186,7 @@ Useful when you want to inspect run-dirs first before producing the comparison.
 **Three Anthropic models on Python tasks only:**
 ```json
 { "benchmark": "aider-polyglot", "runs": 3,
-  "task": ["python/leap", "python/anagram", "python/clock"],
+  "task": ["python/bowling", "python/book-store", "python/forth"],
   "candidates": [
     { "name": "haiku",  "backend": "claude-code", "model": "haiku"  },
     { "name": "sonnet", "backend": "claude-code", "model": "sonnet" },
@@ -130,7 +197,7 @@ Useful when you want to inspect run-dirs first before producing the comparison.
 **Anthropic API vs. one local LLM:**
 ```json
 { "benchmark": "aider-polyglot", "runs": 3,
-  "task": ["python/leap"],
+  "task": ["python/bowling"],
   "candidates": [
     { "name": "sonnet-cloud", "backend": "claude-code", "model": "sonnet" },
     { "name": "local-qwen", "backend": "claude-code",
@@ -168,6 +235,14 @@ Comparison driver (`./scripts/benchmark compare`) shipped 2026-05-13.
 ## CLI
 
 ```bash
+# Daily driver (terse wrapper — see the 60-second quickstart):
+./scripts/bench                                                # safe stub smoke + env detection
+./scripts/bench sonnet ollama:qwen2.5-coder:7b                 # compare two models
+./scripts/bench --preset local-vs-cloud --runs 5               # curated preset, run-count override
+./scripts/bench --yes --attempt-timeout 600 sonnet opus        # CI: no prompt, 600s/attempt cap
+./scripts/bench --help | --list-presets | --list-providers
+
+# Underlying harness (what the wrapper builds on):
 ./scripts/benchmark list                                       # adapters + backends
 ./scripts/benchmark list --benchmark aider-polyglot            # tasks for an adapter
 ./scripts/benchmark run --benchmark aider-polyglot \
@@ -378,15 +453,20 @@ python3 -m benchmarks.adapters.aider_polyglot.fetch
 
 # Run one Python task with Claude Code (default = Anthropic API):
 ./scripts/benchmark run --benchmark aider-polyglot \
-    --backend claude-code --model sonnet --runs 1 --task python/leap
+    --backend claude-code --model sonnet --runs 1 --task python/bowling
 
 # Same task, routed through a local vLLM gateway:
 export ANTHROPIC_BASE_URL=http://localhost:8000
 export ANTHROPIC_AUTH_TOKEN=dummy
 export ANTHROPIC_DEFAULT_SONNET_MODEL=<served-model-name>
 ./scripts/benchmark run --benchmark aider-polyglot \
-    --backend claude-code --model <served-model-name> --runs 1 --task python/leap
+    --backend claude-code --model <served-model-name> --runs 1 --task python/bowling
 ```
 
 Either run produces a complete record; the second path's
 `backend_metadata.provider_endpoint` reflects the local URL.
+
+> Tip: `./scripts/bench sonnet vllm:<served-model>@<endpoint>` does the
+> three env exports above for you and probes the endpoint first
+> (Anthropic-shape proxy → used directly; raw OpenAI-only vLLM → an
+> ephemeral LiteLLM proxy is started in front and torn down on exit).

--- a/benchmarks/presets/anthropic-tour.json
+++ b/benchmarks/presets/anthropic-tour.json
@@ -1,0 +1,22 @@
+{
+  "benchmark": "aider-polyglot",
+  "runs": 3,
+  "task": ["python/bowling"],
+  "candidates": [
+    {
+      "name": "claude-code-sonnet",
+      "backend": "claude-code",
+      "model": "sonnet"
+    },
+    {
+      "name": "claude-code-opus",
+      "backend": "claude-code",
+      "model": "opus"
+    },
+    {
+      "name": "claude-code-haiku",
+      "backend": "claude-code",
+      "model": "haiku"
+    }
+  ]
+}

--- a/benchmarks/presets/cross-language-mini.json
+++ b/benchmarks/presets/cross-language-mini.json
@@ -1,0 +1,12 @@
+{
+  "benchmark": "aider-polyglot",
+  "runs": 3,
+  "task": ["python/bowling", "go/bowling", "rust/bowling"],
+  "candidates": [
+    {
+      "name": "claude-code-sonnet",
+      "backend": "claude-code",
+      "model": "sonnet"
+    }
+  ]
+}

--- a/benchmarks/presets/local-vs-cloud.json
+++ b/benchmarks/presets/local-vs-cloud.json
@@ -1,0 +1,35 @@
+{
+  "benchmark": "aider-polyglot",
+  "runs": 3,
+  "attempt_timeout_seconds": 600,
+  "task": ["python/bowling", "go/bowling"],
+  "candidates": [
+    {
+      "name": "claude-code-sonnet-cloud",
+      "backend": "claude-code",
+      "model": "sonnet"
+    },
+    {
+      "name": "ollama-qwen2.5-coder-7b",
+      "backend": "claude-code",
+      "model": "qwen2.5-coder:7b",
+      "env": {
+        "ANTHROPIC_BASE_URL": "http://localhost:11434",
+        "ANTHROPIC_AUTH_TOKEN": "ollama",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen2.5-coder:7b",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen2.5-coder:7b"
+      }
+    },
+    {
+      "name": "ollama-qwen2.5-coder-32b",
+      "backend": "claude-code",
+      "model": "qwen2.5-coder:32b",
+      "env": {
+        "ANTHROPIC_BASE_URL": "http://localhost:11434",
+        "ANTHROPIC_AUTH_TOKEN": "ollama",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen2.5-coder:32b",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen2.5-coder:32b"
+      }
+    }
+  ]
+}

--- a/benchmarks/schema/compare-config.schema.json
+++ b/benchmarks/schema/compare-config.schema.json
@@ -26,7 +26,7 @@
     "attempt_timeout_seconds": {
       "type": "integer",
       "minimum": 1,
-      "description": "Optional per-attempt wall-clock timeout (seconds). NOT YET WIRED AT RUNTIME: as of D3 this key is schema-accepted but the compare config parser (`compare._validate`/`CompareConfig`) does not read or retain it, so a config that sets it currently runs with the harness's existing default timeout behaviour. D5 adds the parser field and threads it to the backend via RunContext.timeout_seconds, at which point a timed-out attempt is recorded result='timeout', counted as a pass_rate failure, and flagged separately in verdicts, and the wrapper's cloud/local heuristic default (scripts/bench: 300s cloud, 600s when ANTHROPIC_BASE_URL is non-default) applies when this key is omitted. See specs/benchmark-bench-driver/spec.md § D5."
+      "description": "Optional per-attempt wall-clock timeout (seconds). Parsed and retained by `compare._validate`/`CompareConfig`, then threaded to the backend via `RunContext.timeout_seconds`. A timed-out attempt is recorded with `result='timeout'` and `scores.timeout=true`, counted as a pass_rate failure, and flagged separately in the report tally (timed_out count). Precedence: `--attempt-timeout` CLI flag > this config field > the wrapper's heuristic default (300s for cloud backends, 600s when ANTHROPIC_BASE_URL is non-default). Omit this field to rely on the heuristic."
     },
     "candidates": {
       "type": "array",

--- a/benchmarks/schema/compare-config.schema.json
+++ b/benchmarks/schema/compare-config.schema.json
@@ -23,6 +23,11 @@
       "items": { "type": "string", "minLength": 1 },
       "description": "Optional task-id filter; same shape as `./scripts/benchmark run --task <id>` (repeatable). Omit to run every task the adapter exposes."
     },
+    "attempt_timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional per-attempt wall-clock timeout (seconds). NOT YET WIRED AT RUNTIME: as of D3 this key is schema-accepted but the compare config parser (`compare._validate`/`CompareConfig`) does not read or retain it, so a config that sets it currently runs with the harness's existing default timeout behaviour. D5 adds the parser field and threads it to the backend via RunContext.timeout_seconds, at which point a timed-out attempt is recorded result='timeout', counted as a pass_rate failure, and flagged separately in verdicts, and the wrapper's cloud/local heuristic default (scripts/bench: 300s cloud, 600s when ANTHROPIC_BASE_URL is non-default) applies when this key is omitted. See specs/benchmark-bench-driver/spec.md § D5."
+    },
     "candidates": {
       "type": "array",
       "minItems": 2,

--- a/scripts/bench
+++ b/scripts/bench
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# bench — user-facing wrapper for the CCT benchmark harness.
+#
+# Parses terse provider:model[@endpoint] tokens, auto-fills env-vars,
+# probes vLLM endpoints, and delegates to `./scripts/benchmark compare`
+# or `./scripts/benchmark run` depending on the number of resolved
+# candidates.
+#
+# Usage:
+#   ./scripts/bench                                   # safe default: stub×stub smoke + env detection
+#   ./scripts/bench sonnet opus
+#   ./scripts/bench sonnet ollama:qwen2.5-coder:7b
+#   ./scripts/bench sonnet vllm:Qwen3-Coder@http://127.0.0.1:8787
+#   ./scripts/bench --task python/bowling,go/leap --runs 5 sonnet ollama:qwen2.5-coder:7b
+#   ./scripts/bench --preset local-vs-cloud
+#   ./scripts/bench --yes sonnet ollama:qwen2.5-coder:7b
+#   ./scripts/bench --help | --list-presets | --list-providers
+#
+# See specs/benchmark-bench-driver/spec.md for the full feature spec.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec env PYTHONPATH="${REPO_DIR}/scripts:${REPO_DIR}${PYTHONPATH:+:${PYTHONPATH}}" \
+     PYTHONUNBUFFERED=1 \
+  python3 -m benchmark_runner.bench "$@"

--- a/scripts/benchmark_runner/backends/claude_code.py
+++ b/scripts/benchmark_runner/backends/claude_code.py
@@ -216,6 +216,7 @@ class ClaudeCodeBackend:
                     note=f"claude -p timed out after {timeout}s (process group killed)",
                 ),
                 failed_commands=1,
+                timed_out=True,  # D5: structured signal consumed by run._execute_attempt
             )
 
         elapsed = time.monotonic() - started

--- a/scripts/benchmark_runner/bench.py
+++ b/scripts/benchmark_runner/bench.py
@@ -1,0 +1,1042 @@
+# benchmark_runner.bench — user-facing CLI wrapper for ./scripts/bench.
+#
+# Parses terse `provider:model[@endpoint]` tokens into resolved candidates,
+# auto-fills env-var tables, writes a compare-config JSON to a tempfile,
+# and delegates to `./scripts/benchmark compare` (≥2 candidates) or
+# `./scripts/benchmark run` (1 candidate).
+#
+# Entrypoint: main(argv) — called by `python3 -m benchmark_runner.bench`.
+#
+# Key spec references:
+#   spec.md § Spec-parsing contract
+#   spec.md § Env-var auto-fill contract
+#   spec.md § vLLM contract
+#   spec.md § Safe zero-config behaviour
+#   spec.md § Confirmation gate
+#   spec.md § --list-providers detection rules
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from .proxy import LiteLLMProxy
+
+
+# ── Provider whitelist ─────────────────────────────────────────────────
+
+# Anthropic shorthand aliases.
+_ANTHROPIC_SHORTCUTS: frozenset[str] = frozenset({"sonnet", "opus", "haiku"})
+
+# Prefixes whose model portion may itself contain colons (e.g. Ollama tags).
+_ENDPOINT_PREFIXES: tuple[str, ...] = (
+    "claude-code:",
+    "ollama:",
+    "vllm:",
+    "lmstudio:",
+    "openrouter:",
+)
+
+# All known providers (used for did-you-mean hints).
+_ALL_KNOWN_PREFIXES: tuple[str, ...] = _ENDPOINT_PREFIXES + tuple(_ANTHROPIC_SHORTCUTS)
+
+
+# ── Parsed spec ────────────────────────────────────────────────────────
+
+
+@dataclass
+class ParsedSpec:
+    """Result of parsing one provider token."""
+    provider: str            # "anthropic", "claude-code", "ollama", "vllm", "lmstudio", "openrouter"
+    model: str               # model name (may include colons for Ollama tags)
+    endpoint: Optional[str]  # explicit @endpoint URL, or None for default
+
+
+def parse_spec(token: str) -> ParsedSpec:
+    """Parse one `provider:model[@endpoint]` token.
+
+    Rules (spec.md § Spec-parsing contract):
+    1. Token ∈ {sonnet, opus, haiku} → provider=anthropic, model=<token> (bare alias).
+       The model id is the bare alias, NOT "claude-code:<token>" — that combined form
+       is explicitly rejected by cli.py/compare.py as an invalid model id.
+    2. Token starts `claude-code:` → suffix is the model verbatim.
+    3. Token starts a known endpoint-bearing prefix → strip ONLY that prefix;
+       everything after is `model[@endpoint]`. Do NOT split on inner colons.
+    4. @endpoint is recognised only as the final @-introduced segment.
+    Unknown token → fail fast with a did-you-mean hint.
+    """
+    # Rule 1: Anthropic shortcuts — yield bare alias as model, never "claude-code:<token>".
+    if token in _ANTHROPIC_SHORTCUTS:
+        return ParsedSpec(provider="anthropic", model=token, endpoint=None)
+
+    # Rules 2 + 3: prefix-based dispatch.
+    for prefix in _ENDPOINT_PREFIXES:
+        if token.startswith(prefix):
+            provider = prefix.rstrip(":")  # "claude-code", "ollama", etc.
+            rest = token[len(prefix):]
+            model, endpoint = _split_model_endpoint(rest)
+            return ParsedSpec(provider=provider, model=model, endpoint=endpoint)
+
+    # Unknown token: fail fast with a hint.
+    hint = _did_you_mean(token)
+    raise ValueError(
+        f"Unknown provider token: {token!r}. "
+        f"Allowed prefixes: {', '.join(sorted(_ALL_KNOWN_PREFIXES))}."
+        + (f"\n  Did you mean: {hint}?" if hint else "")
+    )
+
+
+def _split_model_endpoint(rest: str) -> tuple[str, Optional[str]]:
+    """Split `model[@endpoint]` — @endpoint is the FINAL @-introduced segment.
+
+    Only the last `@` that is followed by `http://` or `https://` (or
+    a bare host:port) is treated as an endpoint delimiter. Inner `@`
+    characters in model names are left intact.
+    """
+    # Find the last @ that begins an endpoint-like string.
+    idx = rest.rfind("@")
+    if idx == -1:
+        return rest, None
+    candidate_ep = rest[idx + 1:]
+    # Require at least one character that looks like a URL or host.
+    if candidate_ep and ("://" in candidate_ep or "." in candidate_ep or ":" in candidate_ep):
+        return rest[:idx], candidate_ep
+    return rest, None
+
+
+def _did_you_mean(token: str) -> Optional[str]:
+    """Return the closest known prefix, or None."""
+    token_lower = token.lower()
+    for known in _ALL_KNOWN_PREFIXES:
+        if token_lower.startswith(known.rstrip(":")):
+            return known
+    # Try Levenshtein-free simple prefix match on first segment.
+    first_seg = token.split(":")[0].split("@")[0]
+    for known in _ALL_KNOWN_PREFIXES:
+        if first_seg.lower() in known.lower() or known.lower().startswith(first_seg.lower()[:3]):
+            return known
+    return None
+
+
+# ── Resolved candidate ─────────────────────────────────────────────────
+
+
+@dataclass
+class ResolvedCandidate:
+    """A fully resolved candidate ready to serialize into a compare-config."""
+    name: str
+    backend: str               # always "claude-code"
+    model: str
+    env: dict[str, str] = field(default_factory=dict)
+    is_anthropic: bool = False  # triggers the confirmation gate
+    # For vLLM: the effective ANTHROPIC_BASE_URL after probing.
+    vllm_proxy: Optional[Any] = None  # holds LiteLLMProxy if ephemeral
+
+
+# ── Env-fill table (spec.md § Env-var auto-fill) ──────────────────────
+
+
+def resolve_candidate(spec: ParsedSpec) -> ResolvedCandidate:
+    """Translate a ParsedSpec into a ResolvedCandidate (env-fill only, no probes)."""
+    provider = spec.provider
+    model = spec.model
+    endpoint = spec.endpoint
+
+    if provider == "anthropic":
+        # sonnet/opus/haiku shortcuts carry the bare alias as model (e.g. "sonnet").
+        return ResolvedCandidate(
+            name=model,
+            backend="claude-code",
+            model=model,
+            env={},
+            is_anthropic=True,
+        )
+
+    if provider == "claude-code":
+        return ResolvedCandidate(
+            name=f"claude-code:{model}",
+            backend="claude-code",
+            model=model,
+            env={},
+            is_anthropic=True,
+        )
+
+    if provider == "ollama":
+        ep = endpoint or "http://localhost:11434"
+        return ResolvedCandidate(
+            name=f"ollama:{model}",
+            backend="claude-code",
+            model=model,
+            env={
+                "ANTHROPIC_BASE_URL": ep,
+                "ANTHROPIC_AUTH_TOKEN": "ollama",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            },
+            is_anthropic=False,
+        )
+
+    if provider == "lmstudio":
+        ep = endpoint or "http://localhost:1234"
+        return ResolvedCandidate(
+            name=f"lmstudio:{model}",
+            backend="claude-code",
+            model=model,
+            env={
+                "ANTHROPIC_BASE_URL": ep,
+                "ANTHROPIC_AUTH_TOKEN": "lmstudio",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            },
+            is_anthropic=False,
+        )
+
+    if provider == "openrouter":
+        api_key = os.environ.get("OPENROUTER_API_KEY", "")
+        if not api_key:
+            raise ValueError(
+                "openrouter: provider requires OPENROUTER_API_KEY to be set. "
+                "Set it in your environment (never echo it)."
+            )
+        return ResolvedCandidate(
+            name=f"openrouter:{model}",
+            backend="claude-code",
+            model=model,
+            env={
+                "ANTHROPIC_BASE_URL": "https://openrouter.ai/api/v1",
+                "ANTHROPIC_AUTH_TOKEN": api_key,
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            },
+            is_anthropic=False,
+        )
+
+    if provider == "vllm":
+        # vLLM resolution requires probing; deferred to resolve_vllm_candidate().
+        # Callers must call that function for vllm: specs.
+        if endpoint is None:
+            raise ValueError(
+                f"vllm: provider requires an explicit endpoint: vllm:{model}@http://<host>:<port>"
+            )
+        # Return a placeholder; the caller probes via resolve_vllm_candidate().
+        return ResolvedCandidate(
+            name=f"vllm:{model}",
+            backend="claude-code",
+            model=model,
+            env={},
+            is_anthropic=False,
+        )
+
+    raise ValueError(f"Unhandled provider: {provider!r}")
+
+
+# ── vLLM probe-then-decide (spec.md § vLLM contract) ──────────────────
+
+
+def resolve_vllm_candidate(
+    spec: ParsedSpec,
+    *,
+    http_timeout: float = 5.0,
+) -> ResolvedCandidate:
+    """Probe the vLLM endpoint and return a fully-resolved candidate.
+
+    1. Probe /v1/messages (Anthropic shape): 2xx or non-404 4xx → user proxy.
+    2. Probe /v1/models (OpenAI shape): 200 with data:[] → raw vLLM →
+       spawn ephemeral LiteLLM proxy, run context-length preflight.
+    3. Else fail fast with a diagnostic message.
+    """
+    if spec.provider != "vllm":
+        raise ValueError(f"resolve_vllm_candidate called for non-vllm spec: {spec.provider!r}")
+    endpoint = spec.endpoint
+    if not endpoint:
+        raise ValueError(f"vllm: spec missing endpoint: {spec!r}")
+    model = spec.model
+
+    # Probe 1: Anthropic /v1/messages.
+    messages_url = endpoint.rstrip("/") + "/v1/messages"
+    probe_body = json.dumps({
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "ping"}],
+    }).encode()
+    req = urllib.request.Request(
+        messages_url,
+        data=probe_body,
+        headers={
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "x-api-key": "probe",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=http_timeout) as resp:
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    except Exception:  # noqa: BLE001
+        status = 0
+
+    # Any 2xx or a non-404 4xx → Anthropic-shape gateway (user's proxy).
+    if (200 <= status < 300) or (400 <= status < 500 and status != 404):
+        return ResolvedCandidate(
+            name=f"vllm:{model}",
+            backend="claude-code",
+            model=model,
+            env={
+                "ANTHROPIC_BASE_URL": endpoint,
+                "ANTHROPIC_AUTH_TOKEN": "vllm-user-proxy",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            },
+            is_anthropic=False,
+        )
+
+    # Probe 2: OpenAI /v1/models.
+    models_url = endpoint.rstrip("/") + "/v1/models"
+    try:
+        req2 = urllib.request.Request(models_url, method="GET")
+        with urllib.request.urlopen(req2, timeout=http_timeout) as resp2:
+            models_status = resp2.status
+            models_body = resp2.read().decode(errors="replace")
+    except urllib.error.HTTPError as exc:
+        models_status = exc.code
+        models_body = ""
+    except Exception:  # noqa: BLE001
+        models_status = 0
+        models_body = ""
+
+    if models_status == 200 and '"data"' in models_body:
+        # Raw vLLM: run context-length preflight, spawn ephemeral proxy.
+        _vllm_context_preflight(models_body, model, endpoint)
+
+        proxy = LiteLLMProxy(endpoint, model)
+        proxy.start()
+        return ResolvedCandidate(
+            name=f"vllm:{model}",
+            backend="claude-code",
+            model=model,
+            env={
+                "ANTHROPIC_BASE_URL": proxy.base_url,
+                "ANTHROPIC_AUTH_TOKEN": "vllm-ephemeral",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
+            },
+            is_anthropic=False,
+            vllm_proxy=proxy,
+        )
+
+    raise ValueError(
+        f"endpoint {endpoint!r} answers neither /v1/messages nor /v1/models; "
+        f"check the URL or start vLLM via run-compare-anthropic-vs-vllm.sh"
+    )
+
+
+def _vllm_context_preflight(models_body: str, model: str, endpoint: str) -> None:
+    """Abort if max_model_len < 32000; warn if < 131072."""
+    HARD_FLOOR = 32000
+    RECOMMENDED = 131072
+    try:
+        data = json.loads(models_body)
+        entries = data.get("data", [])
+        hit = [m for m in entries if m.get("id") == model]
+        ctx_len = hit[0].get("max_model_len") if hit else None
+    except Exception:  # noqa: BLE001
+        ctx_len = None
+
+    if ctx_len is None:
+        print(
+            f"vllm: could not read max_model_len from {endpoint}/v1/models — "
+            f"cannot verify context budget. If vLLM is on the default "
+            f"--max-model-len 8192, every claude-code call will 400.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    if ctx_len < HARD_FLOOR:
+        raise ValueError(
+            f"vllm: max_model_len={ctx_len} < {HARD_FLOOR} (claude-code's per-call "
+            f"output request). Every call will 400. Restart vLLM with "
+            f"--max-model-len {RECOMMENDED} --enable-auto-tool-choice "
+            f"--tool-call-parser qwen3_coder."
+        )
+    if ctx_len < RECOMMENDED:
+        print(
+            f"vllm: warn: max_model_len={ctx_len} accepts requests but leaves "
+            f"little room for multi-file prompts. Recommended: --max-model-len {RECOMMENDED}+.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+# ── Preset resolution ──────────────────────────────────────────────────
+
+
+def _presets_dir() -> Path:
+    return Path(__file__).resolve().parent.parent.parent / "benchmarks" / "presets"
+
+
+def list_presets() -> list[str]:
+    d = _presets_dir()
+    if not d.is_dir():
+        return []
+    return sorted(p.stem for p in d.glob("*.json"))
+
+
+def load_preset(name: str) -> dict[str, Any]:
+    d = _presets_dir()
+    p = d / f"{name}.json"
+    if not p.exists():
+        available = ", ".join(list_presets()) or "(none)"
+        raise ValueError(
+            f"Preset {name!r} not found. Available presets: {available}"
+        )
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Preset {name!r} is not valid JSON: {exc}") from exc
+
+
+# ── Compare-config construction ────────────────────────────────────────
+
+
+def build_compare_config(
+    candidates: list[ResolvedCandidate],
+    *,
+    benchmark: str,
+    runs: int,
+    task_filter: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Build a compare-config dict suitable for serialisation to a tempfile."""
+    cfg: dict[str, Any] = {
+        "benchmark": benchmark,
+        "runs": runs,
+        "candidates": [
+            {
+                "name": c.name,
+                "backend": c.backend,
+                "model": c.model,
+                "env": c.env,
+            }
+            for c in candidates
+        ],
+    }
+    if task_filter:
+        cfg["task"] = task_filter
+    return cfg
+
+
+# ── Provider discovery (--list-providers) ─────────────────────────────
+
+
+def list_providers(*, http_timeout: float = 5.0) -> None:
+    """Print detected provider availability to stdout."""
+    print("Detected providers:")
+
+    # Anthropic API.
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if api_key:
+        last4 = api_key[-4:] if len(api_key) >= 4 else "***"
+        print(f"  Anthropic API (key sk-ant-…{last4})")
+    else:
+        print("  Anthropic API — ANTHROPIC_API_KEY not set")
+
+    # Ollama: three checks (which/OLLAMA_HOST, /api/version >= 0.14.0, /api/tags).
+    ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+    has_ollama_bin = _which("ollama") is not None
+    has_ollama_host = "OLLAMA_HOST" in os.environ
+    if not has_ollama_bin and not has_ollama_host:
+        print("  Ollama — not detected (no 'ollama' binary and OLLAMA_HOST not set)")
+    else:
+        reason = _ollama_check(ollama_host, http_timeout=http_timeout)
+        if reason is None:
+            # /api/tags for model list.
+            models = _ollama_models(ollama_host, http_timeout=http_timeout)
+            print(f"  Ollama @ {ollama_host} — OK ({len(models)} model(s): {', '.join(models[:5])}{'…' if len(models) > 5 else ''})")
+        else:
+            print(f"  Ollama detected but unusable: {reason}")
+
+    # LM Studio: probe GET http://localhost:1234/v1/models.
+    lmstudio_url = "http://localhost:1234/v1/models"
+    try:
+        with urllib.request.urlopen(lmstudio_url, timeout=http_timeout) as resp:  # noqa: S310
+            body = resp.read().decode(errors="replace")
+        try:
+            data = json.loads(body).get("data", [])
+            count = len(data)
+        except Exception:  # noqa: BLE001
+            count = 0
+        print(f"  LM Studio @ localhost:1234 — OK ({count} model(s))")
+    except Exception:  # noqa: BLE001
+        print("  LM Studio — not reachable at localhost:1234")
+
+    # vLLM: opt-in only, not probed in --list-providers.
+    print("  vLLM — probe-on-demand only; use vllm:<model>@<endpoint>")
+
+    print()
+    print("Examples:")
+    print("  ./scripts/bench sonnet ollama:qwen2.5-coder:7b")
+    print("  ./scripts/bench sonnet vllm:Qwen3-Coder@http://192.168.1.23:8000")
+    print("  ./scripts/bench --preset local-vs-cloud")
+
+
+def _ollama_check(host: str, *, http_timeout: float) -> Optional[str]:
+    """Return None if Ollama is healthy (≥0.14.0), else a reason string."""
+    version_url = f"{host}/api/version"
+    try:
+        with urllib.request.urlopen(version_url, timeout=http_timeout) as resp:  # noqa: S310
+            body = json.loads(resp.read().decode())
+        version_str = body.get("version", "")
+    except Exception as exc:  # noqa: BLE001
+        return f"not reachable at {host}/api/version ({exc})"
+
+    if not version_str:
+        return "could not read version from /api/version"
+
+    # Check >= 0.14.0 (when /v1/messages landed).
+    try:
+        parts = [int(x) for x in version_str.split(".")[:3]]
+        # Pad to [major, minor, patch].
+        while len(parts) < 3:
+            parts.append(0)
+        if tuple(parts) < (0, 14, 0):
+            return (
+                f"version {version_str} < 0.14.0 — /v1/messages not available. "
+                f"Upgrade Ollama to 0.14.0+ for Anthropic API support."
+            )
+    except ValueError:
+        return f"cannot parse version {version_str!r}"
+
+    return None
+
+
+def _ollama_models(host: str, *, http_timeout: float) -> list[str]:
+    """Return model names from /api/tags, or empty list on error."""
+    try:
+        url = f"{host}/api/tags"
+        with urllib.request.urlopen(url, timeout=http_timeout) as resp:  # noqa: S310
+            body = json.loads(resp.read().decode())
+        return [m.get("name", "") for m in body.get("models", [])]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _which(cmd: str) -> Optional[str]:
+    import shutil
+    return shutil.which(cmd)
+
+
+# ── Safe zero-config smoke (spec.md § Safe zero-config) ───────────────
+
+
+def _run_stub_smoke(runs_root: Optional[Path] = None) -> bool:
+    """Run stub×stub end-to-end smoke; return True on success."""
+    repo_dir = Path(__file__).resolve().parent.parent.parent
+    benchmark_script = repo_dir / "scripts" / "benchmark"
+
+    import tempfile as _tmpmod
+    with _tmpmod.TemporaryDirectory() as td:
+        cmd = [
+            str(benchmark_script),
+            "run",
+            "--benchmark", "stub",
+            "--backend", "stub",
+            "--runs", "1",
+            "--runs-root", str(runs_root or Path(td) / "runs"),
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            return proc.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+
+# ── Confirmation gate (spec.md § Confirmation gate) ───────────────────
+
+
+def _confirmation_gate(candidates: list[ResolvedCandidate], *, runs: int, tasks: Optional[list[str]]) -> bool:
+    """Return True if the run should proceed.
+
+    Prompts only when ≥1 Anthropic-API-bearing candidate is present AND
+    stdin is a TTY. --yes / --no-confirm / non-TTY bypass it.
+    """
+    anthropic_candidates = [c for c in candidates if c.is_anthropic]
+    if not anthropic_candidates:
+        return True
+
+    task_desc = ", ".join(tasks) if tasks else "(all tasks)"
+    print(
+        f"\nThis run will call the Anthropic API for: "
+        f"{', '.join(c.name for c in anthropic_candidates)}",
+        file=sys.stderr,
+        flush=True,
+    )
+    print(
+        f"  runs={runs}, tasks={task_desc}, "
+        f"{len(anthropic_candidates)} Anthropic candidate(s)",
+        file=sys.stderr,
+        flush=True,
+    )
+    print(
+        "  (No token/dollar estimates — see spec.md § cost_reporting.)",
+        file=sys.stderr,
+        flush=True,
+    )
+    sys.stderr.write("Continue? [y/N]: ")
+    sys.stderr.flush()
+    try:
+        answer = input().strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return answer in {"y", "yes"}
+
+
+# ── Argument parsing ───────────────────────────────────────────────────
+
+
+def _build_help_text() -> str:
+    return """\
+bench — CCT benchmark driver (terse provider:model wrapper)
+
+Usage:
+  ./scripts/bench                                   # stub×stub smoke + env detection
+  ./scripts/bench sonnet opus                       # Anthropic API comparison
+  ./scripts/bench sonnet ollama:qwen2.5-coder:7b   # Anthropic vs local Ollama
+  ./scripts/bench sonnet vllm:Qwen3@http://host:8000
+  ./scripts/bench --task python/bowling,go/bowling --runs 5 sonnet ollama:qwen2.5-coder:7b
+  ./scripts/bench --preset local-vs-cloud
+  ./scripts/bench --yes sonnet ollama:qwen2.5-coder:7b   # bypass confirmation (CI)
+  ./scripts/bench --help | --list-presets | --list-providers
+
+Provider tokens:
+  sonnet / opus / haiku            Anthropic API shorthand
+  claude-code:<model>              Explicit Claude Code model
+  ollama:<model[:tag]>[@ep]        Local Ollama (default http://localhost:11434)
+  vllm:<model>@<endpoint>          vLLM endpoint (probed; spawns proxy if needed)
+  lmstudio:<model>[@ep]            LM Studio (default http://localhost:1234)
+  openrouter:<model>               OpenRouter (requires OPENROUTER_API_KEY)
+
+Options:
+  --task <id>[,<id>...]   Limit to specific task ids
+  --runs <n>              Repetitions per task (default 3)
+  --preset <name>         Load a preset compare-config from benchmarks/presets/
+  --yes / --no-confirm    Bypass the Anthropic-spend confirmation gate
+  --list-presets          List available presets and exit
+  --list-providers        Detect available providers and exit
+  --help                  Show this help and exit
+
+Unknown flags are passed through verbatim to ./scripts/benchmark compare.
+
+Exit codes: 0 success; 1 error; 2 usage error.
+"""
+
+
+def _parse_argv(argv: Sequence[str]) -> tuple[dict, list[str], list[str]]:
+    """Parse bench-specific flags; return (opts, candidates, passthrough_flags).
+
+    opts keys: task, runs, preset, yes, no_confirm, list_presets, list_providers, help
+    """
+    opts: dict[str, Any] = {
+        "task": None,
+        "runs": None,
+        "preset": None,
+        "yes": False,
+        "no_confirm": False,
+        "list_presets": False,
+        "list_providers": False,
+        "help": False,
+    }
+    candidates: list[str] = []
+    passthrough: list[str] = []
+
+    args = list(argv)
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a in ("-h", "--help"):
+            opts["help"] = True
+        elif a == "--list-presets":
+            opts["list_presets"] = True
+        elif a == "--list-providers":
+            opts["list_providers"] = True
+        elif a in ("--yes", "-y"):
+            opts["yes"] = True
+        elif a == "--no-confirm":
+            opts["no_confirm"] = True
+        elif a == "--task":
+            i += 1
+            if i >= len(args):
+                raise ValueError("--task requires an argument")
+            opts["task"] = [t.strip() for t in args[i].split(",") if t.strip()]
+        elif a.startswith("--task="):
+            opts["task"] = [t.strip() for t in a[7:].split(",") if t.strip()]
+        elif a == "--runs":
+            i += 1
+            if i >= len(args):
+                raise ValueError("--runs requires an argument")
+            try:
+                opts["runs"] = int(args[i])
+            except ValueError:
+                raise ValueError(f"--runs requires an integer, got {args[i]!r}") from None
+        elif a.startswith("--runs="):
+            try:
+                opts["runs"] = int(a[7:])
+            except ValueError:
+                raise ValueError(f"--runs requires an integer, got {a[7:]!r}") from None
+        elif a == "--preset":
+            i += 1
+            if i >= len(args):
+                raise ValueError("--preset requires an argument")
+            opts["preset"] = args[i]
+        elif a.startswith("--preset="):
+            opts["preset"] = a[9:]
+        elif a.startswith("-"):
+            # Unknown flag: pass through to benchmark compare.
+            passthrough.append(a)
+            # If the next argument doesn't start with '-' and there is one,
+            # treat it as the value for this flag (common argparse convention).
+            if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                i += 1
+                passthrough.append(args[i])
+        else:
+            # Positional: candidate token.
+            candidates.append(a)
+        i += 1
+
+    return opts, candidates, passthrough
+
+
+# ── Main ───────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    try:
+        opts, candidate_tokens, passthrough_flags = _parse_argv(argv)
+    except ValueError as exc:
+        print(f"bench: {exc}", file=sys.stderr)
+        return 2
+
+    # Informational exits.
+    if opts["help"]:
+        print(_build_help_text())
+        return 0
+
+    if opts["list_presets"]:
+        presets = list_presets()
+        if presets:
+            print("Available presets (in benchmarks/presets/):")
+            for name in presets:
+                print(f"  {name}")
+        else:
+            print("No presets found in benchmarks/presets/")
+        return 0
+
+    if opts["list_providers"]:
+        list_providers()
+        return 0
+
+    # ── Preset path ────────────────────────────────────────────────────
+    if opts["preset"] and not candidate_tokens:
+        return _run_preset(opts, passthrough_flags)
+
+    # ── No-arg safe zero-config ────────────────────────────────────────
+    if not candidate_tokens and not opts["preset"]:
+        return _run_zero_config()
+
+    # ── Parse + resolve candidates ─────────────────────────────────────
+    resolved: list[ResolvedCandidate] = []
+    proxies_to_stop: list[Any] = []
+
+    try:
+        for token in candidate_tokens:
+            try:
+                spec = parse_spec(token)
+            except ValueError as exc:
+                print(f"bench: {exc}", file=sys.stderr)
+                return 2
+
+            if spec.provider == "vllm":
+                try:
+                    candidate = resolve_vllm_candidate(spec)
+                except ValueError as exc:
+                    print(f"bench: {exc}", file=sys.stderr)
+                    return 1
+                if candidate.vllm_proxy is not None:
+                    proxies_to_stop.append(candidate.vllm_proxy)
+            else:
+                try:
+                    candidate = resolve_candidate(spec)
+                except ValueError as exc:
+                    print(f"bench: {exc}", file=sys.stderr)
+                    return 1
+
+            resolved.append(candidate)
+
+        return _dispatch(resolved, opts, passthrough_flags)
+
+    finally:
+        for proxy in proxies_to_stop:
+            try:
+                proxy.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _run_zero_config() -> int:
+    """Safe zero-config: stub×stub smoke + env detection."""
+    print("bench: no candidates specified — running stub×stub smoke (no LLM call).", flush=True)
+    print("bench: probing environment…", flush=True)
+
+    # Env summary.
+    _print_env_summary()
+
+    print("\nbench: running stub×stub smoke…", flush=True)
+    ok = _run_stub_smoke()
+    if ok:
+        print("bench: smoke PASSED — wrapper + harness + report pipeline OK.", flush=True)
+        print("bench: run './scripts/bench --help' to see usage or '--list-providers' to check your setup.", flush=True)
+        return 0
+    else:
+        print("bench: smoke FAILED — check harness setup.", file=sys.stderr, flush=True)
+        return 1
+
+
+def _print_env_summary() -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if api_key:
+        last4 = api_key[-4:] if len(api_key) >= 4 else "***"
+        print(f"  Anthropic API: key set (…{last4})")
+    else:
+        print("  Anthropic API: ANTHROPIC_API_KEY not set")
+
+    ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+    has_ollama = _which("ollama") is not None or "OLLAMA_HOST" in os.environ
+    if has_ollama:
+        reason = _ollama_check(ollama_host, http_timeout=3.0)
+        if reason:
+            print(f"  Ollama: detected but unusable ({reason})")
+        else:
+            models = _ollama_models(ollama_host, http_timeout=3.0)
+            print(f"  Ollama: reachable, {len(models)} model(s)")
+    else:
+        print("  Ollama: not detected")
+
+
+def _preset_candidate_is_anthropic(c: dict) -> bool:
+    """Return True if a raw preset candidate bears Anthropic API calls.
+
+    A preset candidate is Anthropic-API-bearing iff its env block does NOT
+    set ANTHROPIC_BASE_URL (no redirect → hits the real Anthropic API).
+    This mirrors spec.md § Confirmation gate: "without an env override that
+    redirects elsewhere".
+    """
+    return "ANTHROPIC_BASE_URL" not in c.get("env", {})
+
+
+def _run_preset(opts: dict, passthrough_flags: list[str]) -> int:
+    """Load a preset and dispatch."""
+    preset_name = opts["preset"]
+    try:
+        preset = load_preset(preset_name)
+    except ValueError as exc:
+        print(f"bench: {exc}", file=sys.stderr)
+        return 1
+
+    benchmark = preset.get("benchmark", "aider-polyglot")
+    runs = opts["runs"] if opts["runs"] is not None else preset.get("runs", 3)
+    task_filter = opts["task"] if opts["task"] is not None else preset.get("task")
+    candidates_raw = preset.get("candidates", [])
+
+    if not candidates_raw:
+        print(f"bench: preset {preset_name!r} has no candidates.", file=sys.stderr)
+        return 1
+
+    # Confirmation gate — apply BEFORE dispatching, same as the inline path.
+    # Build lightweight ResolvedCandidate stubs so _confirmation_gate can inspect them.
+    bypass_gate = opts["yes"] or opts["no_confirm"] or not sys.stdin.isatty()
+    anthropic_raw = [c for c in candidates_raw if _preset_candidate_is_anthropic(c)]
+    if anthropic_raw and not bypass_gate:
+        stub_candidates = [
+            ResolvedCandidate(
+                name=c.get("name", c.get("model", "?")),
+                backend=c.get("backend", "claude-code"),
+                model=c.get("model", ""),
+                is_anthropic=True,
+            )
+            for c in anthropic_raw
+        ]
+        proceed = _confirmation_gate(stub_candidates, runs=runs, tasks=task_filter)
+        if not proceed:
+            print("bench: aborted.", flush=True)
+            return 0
+
+    # Single-candidate preset → route to `benchmark run`.
+    if len(candidates_raw) == 1:
+        c = candidates_raw[0]
+        with _patched_env(c.get("env", {})):
+            return _invoke_benchmark_run(
+                benchmark=benchmark,
+                backend=c.get("backend", "claude-code"),
+                model=c.get("model", ""),
+                runs=runs,
+                task_filter=task_filter,
+                passthrough_flags=passthrough_flags,
+            )
+
+    # Multi-candidate → write tempfile config and call compare.
+    # Apply --runs / --task overrides.
+    if opts["runs"] is not None:
+        preset["runs"] = opts["runs"]
+    if opts["task"] is not None:
+        preset["task"] = opts["task"]
+
+    return _invoke_benchmark_compare_from_preset(preset, passthrough_flags)
+
+
+def _invoke_benchmark_compare_from_preset(preset: dict, passthrough_flags: list[str]) -> int:
+    """Write preset to tempfile and call benchmark compare."""
+    repo_dir = Path(__file__).resolve().parent.parent.parent
+    benchmark_script = repo_dir / "scripts" / "benchmark"
+    fd, tmp_path = tempfile.mkstemp(suffix=".json", prefix="bench-preset-")
+    try:
+        os.close(fd)
+        Path(tmp_path).write_text(json.dumps(preset, indent=2), encoding="utf-8")
+        cmd = [str(benchmark_script), "compare", "--config", tmp_path] + passthrough_flags
+        proc = subprocess.run(cmd)
+        return proc.returncode
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _dispatch(
+    candidates: list[ResolvedCandidate],
+    opts: dict,
+    passthrough_flags: list[str],
+) -> int:
+    """Build config, gate, dispatch to compare or run."""
+    runs = opts["runs"] if opts["runs"] is not None else 3
+    task_filter = opts["task"]
+    bypass_gate = opts["yes"] or opts["no_confirm"] or not sys.stdin.isatty()
+
+    # Confirmation gate (only for Anthropic-bearing candidates unless bypassed).
+    has_anthropic = any(c.is_anthropic for c in candidates)
+    if has_anthropic and not bypass_gate:
+        proceed = _confirmation_gate(candidates, runs=runs, tasks=task_filter)
+        if not proceed:
+            print("bench: aborted.", flush=True)
+            return 0
+
+    repo_dir = Path(__file__).resolve().parent.parent.parent
+    benchmark_script = repo_dir / "scripts" / "benchmark"
+
+    # Single-candidate → `benchmark run`.
+    if len(candidates) == 1:
+        c = candidates[0]
+        env_block = c.env
+        with _patched_env(env_block):
+            return _invoke_benchmark_run(
+                benchmark="aider-polyglot",
+                backend=c.backend,
+                model=c.model,
+                runs=runs,
+                task_filter=task_filter,
+                passthrough_flags=passthrough_flags,
+            )
+
+    # Multi-candidate → write tempfile config and call compare.
+    cfg = build_compare_config(
+        candidates,
+        benchmark="aider-polyglot",
+        runs=runs,
+        task_filter=task_filter,
+    )
+    fd, tmp_path = tempfile.mkstemp(suffix=".json", prefix="bench-compare-")
+    try:
+        os.close(fd)
+        Path(tmp_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+        cmd = [str(benchmark_script), "compare", "--config", tmp_path] + passthrough_flags
+        proc = subprocess.run(cmd)
+        return proc.returncode
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _invoke_benchmark_run(
+    *,
+    benchmark: str,
+    backend: str,
+    model: str,
+    runs: int,
+    task_filter: Optional[list[str]],
+    passthrough_flags: list[str],
+) -> int:
+    repo_dir = Path(__file__).resolve().parent.parent.parent
+    benchmark_script = repo_dir / "scripts" / "benchmark"
+    cmd = [
+        str(benchmark_script), "run",
+        "--benchmark", benchmark,
+        "--backend", backend,
+        "--runs", str(runs),
+    ]
+    if model:
+        cmd += ["--model", model]
+    if task_filter:
+        for t in task_filter:
+            cmd += ["--task", t]
+    cmd += passthrough_flags
+    proc = subprocess.run(cmd)
+    return proc.returncode
+
+
+# ── Env patching helper (mirrors compare._patched_env) ─────────────────
+
+
+from contextlib import contextmanager
+from typing import Iterator
+
+
+@contextmanager
+def _patched_env(overrides: dict[str, str]) -> Iterator[None]:
+    saved: dict[str, Optional[str]] = {}
+    try:
+        for k, v in overrides.items():
+            saved[k] = os.environ.get(k)
+            os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ── Module entry point ─────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/benchmark_runner/bench.py
+++ b/scripts/benchmark_runner/bench.py
@@ -558,6 +558,7 @@ def _run_stub_smoke(runs_root: Optional[Path] = None) -> bool:
                 capture_output=True,
                 text=True,
                 timeout=60,
+                env=_subprocess_env(),
             )
             return proc.returncode == 0
         except subprocess.TimeoutExpired:
@@ -920,7 +921,7 @@ def _invoke_benchmark_compare_from_preset(preset: dict, passthrough_flags: list[
         os.close(fd)
         Path(tmp_path).write_text(json.dumps(preset, indent=2), encoding="utf-8")
         cmd = [str(benchmark_script), "compare", "--config", tmp_path] + passthrough_flags
-        proc = subprocess.run(cmd)
+        proc = subprocess.run(cmd, env=_subprocess_env())
         return proc.returncode
     finally:
         try:
@@ -976,7 +977,7 @@ def _dispatch(
         os.close(fd)
         Path(tmp_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
         cmd = [str(benchmark_script), "compare", "--config", tmp_path] + passthrough_flags
-        proc = subprocess.run(cmd)
+        proc = subprocess.run(cmd, env=_subprocess_env())
         return proc.returncode
     finally:
         try:
@@ -1008,8 +1009,24 @@ def _invoke_benchmark_run(
         for t in task_filter:
             cmd += ["--task", t]
     cmd += passthrough_flags
-    proc = subprocess.run(cmd)
+    proc = subprocess.run(cmd, env=_subprocess_env())
     return proc.returncode
+
+
+# ── Subprocess environment helper (D2 flush discipline) ──────────────────
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Return os.environ with PYTHONUNBUFFERED=1 guaranteed.
+
+    Belt-and-suspenders flush discipline: scripts/bench already exports
+    PYTHONUNBUFFERED=1 at the shim level, but we also inject it here
+    so any subprocess spawned by bench.py (e.g. when bench is imported
+    and called programmatically rather than via the shim) inherits it.
+    """
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
 
 
 # ── Env patching helper (mirrors compare._patched_env) ─────────────────

--- a/scripts/benchmark_runner/bench.py
+++ b/scripts/benchmark_runner/bench.py
@@ -414,6 +414,7 @@ def build_compare_config(
     benchmark: str,
     runs: int,
     task_filter: Optional[list[str]] = None,
+    attempt_timeout_seconds: Optional[int] = None,
 ) -> dict[str, Any]:
     """Build a compare-config dict suitable for serialisation to a tempfile."""
     cfg: dict[str, Any] = {
@@ -431,6 +432,8 @@ def build_compare_config(
     }
     if task_filter:
         cfg["task"] = task_filter
+    if attempt_timeout_seconds is not None:
+        cfg["attempt_timeout_seconds"] = attempt_timeout_seconds
     return cfg
 
 
@@ -633,13 +636,14 @@ Provider tokens:
   openrouter:<model>               OpenRouter (requires OPENROUTER_API_KEY)
 
 Options:
-  --task <id>[,<id>...]   Limit to specific task ids
-  --runs <n>              Repetitions per task (default 3)
-  --preset <name>         Load a preset compare-config from benchmarks/presets/
-  --yes / --no-confirm    Bypass the Anthropic-spend confirmation gate
-  --list-presets          List available presets and exit
-  --list-providers        Detect available providers and exit
-  --help                  Show this help and exit
+  --task <id>[,<id>...]         Limit to specific task ids
+  --runs <n>                    Repetitions per task (default 3)
+  --preset <name>               Load a preset compare-config from benchmarks/presets/
+  --attempt-timeout <seconds>   Per-attempt timeout in seconds (overrides heuristic + preset)
+  --yes / --no-confirm          Bypass the Anthropic-spend confirmation gate
+  --list-presets                List available presets and exit
+  --list-providers              Detect available providers and exit
+  --help                        Show this help and exit
 
 Unknown flags are passed through verbatim to ./scripts/benchmark compare.
 
@@ -656,6 +660,7 @@ def _parse_argv(argv: Sequence[str]) -> tuple[dict, list[str], list[str]]:
         "task": None,
         "runs": None,
         "preset": None,
+        "attempt_timeout": None,
         "yes": False,
         "no_confirm": False,
         "list_presets": False,
@@ -699,6 +704,26 @@ def _parse_argv(argv: Sequence[str]) -> tuple[dict, list[str], list[str]]:
                 opts["runs"] = int(a[7:])
             except ValueError:
                 raise ValueError(f"--runs requires an integer, got {a[7:]!r}") from None
+        elif a == "--attempt-timeout":
+            i += 1
+            if i >= len(args):
+                raise ValueError("--attempt-timeout requires an argument")
+            try:
+                val = int(args[i])
+            except ValueError:
+                raise ValueError(f"--attempt-timeout requires an integer, got {args[i]!r}") from None
+            if val < 1:
+                raise ValueError(f"--attempt-timeout must be a positive integer, got {val!r}")
+            opts["attempt_timeout"] = val
+        elif a.startswith("--attempt-timeout="):
+            raw_val = a[len("--attempt-timeout="):]
+            try:
+                val = int(raw_val)
+            except ValueError:
+                raise ValueError(f"--attempt-timeout requires an integer, got {raw_val!r}") from None
+            if val < 1:
+                raise ValueError(f"--attempt-timeout must be a positive integer, got {val!r}")
+            opts["attempt_timeout"] = val
         elif a == "--preset":
             i += 1
             if i >= len(args):
@@ -870,6 +895,26 @@ def _run_preset(opts: dict, passthrough_flags: list[str]) -> int:
         print(f"bench: preset {preset_name!r} has no candidates.", file=sys.stderr)
         return 1
 
+    # D5: resolve the per-attempt timeout for the preset path.
+    # Precedence: --attempt-timeout > preset attempt_timeout_seconds > heuristic.
+    preset_timeout = preset.get("attempt_timeout_seconds")
+    # Build stub candidates to drive the heuristic (any env with ANTHROPIC_BASE_URL → local).
+    stub_for_heuristic = [
+        ResolvedCandidate(
+            name=c.get("name", "?"),
+            backend=c.get("backend", "claude-code"),
+            model=c.get("model", ""),
+            env=c.get("env", {}),
+            is_anthropic="ANTHROPIC_BASE_URL" not in c.get("env", {}),
+        )
+        for c in candidates_raw
+    ]
+    timeout_seconds = _resolve_timeout(
+        explicit=opts.get("attempt_timeout"),
+        preset_timeout=preset_timeout,
+        candidates=stub_for_heuristic,
+    )
+
     # Confirmation gate — apply BEFORE dispatching, same as the inline path.
     # Build lightweight ResolvedCandidate stubs so _confirmation_gate can inspect them.
     bypass_gate = opts["yes"] or opts["no_confirm"] or not sys.stdin.isatty()
@@ -900,14 +945,17 @@ def _run_preset(opts: dict, passthrough_flags: list[str]) -> int:
                 runs=runs,
                 task_filter=task_filter,
                 passthrough_flags=passthrough_flags,
+                attempt_timeout_seconds=timeout_seconds,
             )
 
     # Multi-candidate → write tempfile config and call compare.
-    # Apply --runs / --task overrides.
+    # Apply --runs / --task / --attempt-timeout overrides.
     if opts["runs"] is not None:
         preset["runs"] = opts["runs"]
     if opts["task"] is not None:
         preset["task"] = opts["task"]
+    if timeout_seconds is not None:
+        preset["attempt_timeout_seconds"] = timeout_seconds
 
     return _invoke_benchmark_compare_from_preset(preset, passthrough_flags)
 
@@ -940,6 +988,12 @@ def _dispatch(
     task_filter = opts["task"]
     bypass_gate = opts["yes"] or opts["no_confirm"] or not sys.stdin.isatty()
 
+    # D5: resolve the per-attempt timeout.
+    timeout_seconds = _resolve_timeout(
+        explicit=opts.get("attempt_timeout"),
+        candidates=candidates,
+    )
+
     # Confirmation gate (only for Anthropic-bearing candidates unless bypassed).
     has_anthropic = any(c.is_anthropic for c in candidates)
     if has_anthropic and not bypass_gate:
@@ -963,6 +1017,7 @@ def _dispatch(
                 runs=runs,
                 task_filter=task_filter,
                 passthrough_flags=passthrough_flags,
+                attempt_timeout_seconds=timeout_seconds,
             )
 
     # Multi-candidate → write tempfile config and call compare.
@@ -971,6 +1026,7 @@ def _dispatch(
         benchmark="aider-polyglot",
         runs=runs,
         task_filter=task_filter,
+        attempt_timeout_seconds=timeout_seconds,
     )
     fd, tmp_path = tempfile.mkstemp(suffix=".json", prefix="bench-compare-")
     try:
@@ -994,6 +1050,7 @@ def _invoke_benchmark_run(
     runs: int,
     task_filter: Optional[list[str]],
     passthrough_flags: list[str],
+    attempt_timeout_seconds: Optional[int] = None,
 ) -> int:
     repo_dir = Path(__file__).resolve().parent.parent.parent
     benchmark_script = repo_dir / "scripts" / "benchmark"
@@ -1008,9 +1065,48 @@ def _invoke_benchmark_run(
     if task_filter:
         for t in task_filter:
             cmd += ["--task", t]
+    if attempt_timeout_seconds is not None:
+        cmd += ["--attempt-timeout", str(attempt_timeout_seconds)]
     cmd += passthrough_flags
     proc = subprocess.run(cmd, env=_subprocess_env())
     return proc.returncode
+
+
+# ── Timeout resolution (D5) ───────────────────────────────────────────────
+
+# Heuristic per-attempt timeouts (seconds).
+# 300s for cloud Anthropic API (fast, reliable); 600s for local LLMs
+# (slower inference, more variable). Precedence: --attempt-timeout >
+# config/preset attempt_timeout_seconds > heuristic.
+_CLOUD_TIMEOUT_SECONDS = 300
+_LOCAL_TIMEOUT_SECONDS = 600
+
+
+def _resolve_timeout(
+    *,
+    explicit: Optional[int] = None,
+    preset_timeout: Optional[int] = None,
+    candidates: Optional[list[ResolvedCandidate]] = None,
+) -> Optional[int]:
+    """Resolve the effective per-attempt timeout.
+
+    Precedence (highest to lowest):
+      1. --attempt-timeout CLI flag (explicit)
+      2. Preset / config attempt_timeout_seconds
+      3. Per-candidate heuristic: 300s for cloud Anthropic; 600s when
+         ANTHROPIC_BASE_URL is set in any candidate's env (local LLM heuristic)
+    """
+    if explicit is not None:
+        return explicit
+    if preset_timeout is not None:
+        return preset_timeout
+    if not candidates:
+        return None
+    # Heuristic: if ANY candidate has a non-default ANTHROPIC_BASE_URL → local
+    any_local = any(
+        "ANTHROPIC_BASE_URL" in c.env for c in candidates
+    )
+    return _LOCAL_TIMEOUT_SECONDS if any_local else _CLOUD_TIMEOUT_SECONDS
 
 
 # ── Subprocess environment helper (D2 flush discipline) ──────────────────

--- a/scripts/benchmark_runner/cli.py
+++ b/scripts/benchmark_runner/cli.py
@@ -107,6 +107,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path("runs"),
         help="Directory under which run records are written (default ./runs).",
     )
+    p_run.add_argument(
+        "--attempt-timeout",
+        type=int,
+        default=None,
+        metavar="SECONDS",
+        help="Per-attempt timeout in seconds (D5). Passed to RunContext.timeout_seconds.",
+    )
 
     # ── report ────────────────────────────────────────────────────────
     p_report = sub.add_parser(
@@ -233,6 +240,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
             runs=args.runs,
             runs_root=args.runs_root,
             task_filter=args.task,
+            attempt_timeout_seconds=args.attempt_timeout,
         )
     except EmptyAdapterError as exc:
         # Distinct from "unknown task id" (KeyError) — no tasks at all.

--- a/scripts/benchmark_runner/compare.py
+++ b/scripts/benchmark_runner/compare.py
@@ -62,6 +62,7 @@ class CompareConfig:
     runs: int
     candidates: list[Candidate]
     task_filter: Optional[list[str]] = None
+    attempt_timeout_seconds: Optional[int] = None
 
 
 class CompareConfigError(ValueError):
@@ -161,11 +162,26 @@ def _validate(raw: Any, *, source: str = "<config>") -> CompareConfig:
             Candidate(name=name, backend=backend, model=model, env=dict(env_raw))
         )
 
+    # Optional top-level per-attempt timeout (D3 schema field; D5 wires it).
+    # Positive integer only — silently ignoring a bad value would let a typo'd
+    # setting masquerade as "no timeout", which is exactly the hang-risk D5
+    # is meant to prevent.
+    raw_timeout = raw.get("attempt_timeout_seconds")
+    attempt_timeout_seconds: Optional[int] = None
+    if raw_timeout is not None:
+        if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int) or raw_timeout < 1:
+            raise CompareConfigError(
+                f"{source}: 'attempt_timeout_seconds' must be a positive integer (≥ 1); "
+                f"got {raw_timeout!r}"
+            )
+        attempt_timeout_seconds = raw_timeout
+
     return CompareConfig(
         benchmark=benchmark,
         runs=runs,
         candidates=candidates,
         task_filter=task,
+        attempt_timeout_seconds=attempt_timeout_seconds,
     )
 
 
@@ -203,6 +219,7 @@ def run_comparison(
     runs_root: Path = Path("runs"),
     timestamp: Optional[str] = None,
     emit_report: bool = True,
+    attempt_timeout_seconds: Optional[int] = None,
 ) -> Path:
     """Run every candidate sequentially under one shared parent run-dir.
 
@@ -248,6 +265,10 @@ def run_comparison(
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
     )
 
+    # Resolve the effective per-attempt timeout: explicit caller arg
+    # overrides the config field (bench.py passes --attempt-timeout here).
+    effective_timeout = attempt_timeout_seconds or config.attempt_timeout_seconds
+
     candidate_runs: list[dict[str, str]] = []
     for c in config.candidates:
         with _patched_env(c.env):
@@ -258,6 +279,7 @@ def run_comparison(
                 runs=config.runs,
                 runs_root=parent,
                 task_filter=config.task_filter,
+                attempt_timeout_seconds=effective_timeout,
             )
         candidate_runs.append(
             {"name": c.name, "run_dir": run_dir.relative_to(parent).as_posix()}

--- a/scripts/benchmark_runner/contracts.py
+++ b/scripts/benchmark_runner/contracts.py
@@ -162,6 +162,12 @@ class BackendResult:
     log, e.g. Claude Code's JSON transcript). Backends that have no
     separate text output (only the worktree mutations) leave it
     ``None``.
+
+    ``timed_out`` is True when the backend killed the attempt due to a
+    harness-imposed timeout (D5). Only the backend's own TimeoutExpired
+    branch sets this; all other code paths leave it False. Using a
+    structured boolean rather than substring-matching the human-readable
+    ``note`` field keeps the classification stable across note rewording.
     """
 
     transcript_path: Optional[Path]
@@ -175,6 +181,7 @@ class BackendResult:
     tool_calls: Mapping[str, int] = field(default_factory=dict)
     failed_commands: int = 0
     backend_metadata: Mapping[str, Any] = field(default_factory=dict)
+    timed_out: bool = False
 
 
 # ── Protocols ──────────────────────────────────────────────────────────

--- a/scripts/benchmark_runner/progress.py
+++ b/scripts/benchmark_runner/progress.py
@@ -1,0 +1,147 @@
+# benchmark_runner.progress — stderr progress logger for live attempt reporting.
+#
+# Every emission uses print(..., file=sys.stderr, flush=True) so progress
+# lines are never buffered, even when stdout is redirected. The heartbeat
+# interval is injectable (constructor arg) so unit tests can use a
+# sub-second interval without a 60-second real wait.
+#
+# Three line shapes (spec.md § Live progress contract):
+#   [idx/total] <candidate> <task>  attempt <K>  starting...
+#   [idx/total] <candidate> <task>  attempt <K>  running... <N>s elapsed
+#   [idx/total] <candidate> <task>  attempt <K>  pass (<S>s, <T> tool calls)
+#   [idx/total] <candidate> <task>  attempt <K>  fail (<S>s, <T> tool calls)
+#   [idx/total] <candidate> <task>  attempt <K>  error (<S>s)
+#
+# Flush discipline: every line is flushed immediately. The wrapper
+# (scripts/bench) also exports PYTHONUNBUFFERED=1 into every subprocess
+# it spawns as belt-and-suspenders.
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from typing import Optional
+
+
+_DEFAULT_HEARTBEAT_INTERVAL = 30.0  # seconds
+
+
+class ProgressLogger:
+    """Emits structured attempt-progress lines to stderr.
+
+    Parameters
+    ----------
+    heartbeat_interval:
+        Seconds between heartbeat emissions while an attempt is running.
+        Defaults to 30s (spec.md § Live progress contract). Inject a
+        shorter value in tests so you don't wait 30 seconds per heartbeat.
+    """
+
+    def __init__(self, heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL) -> None:
+        self._interval = heartbeat_interval
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def emit_start(
+        self,
+        *,
+        idx: int,
+        total: int,
+        candidate: str,
+        task: str,
+        attempt: int,
+    ) -> None:
+        """Emit the attempt-start line."""
+        _emit(f"[{idx}/{total}] {candidate}  {task}  attempt {attempt}  starting...")
+
+    def emit_heartbeat(
+        self,
+        *,
+        idx: int,
+        total: int,
+        candidate: str,
+        task: str,
+        attempt: int,
+        elapsed_seconds: float,
+    ) -> None:
+        """Emit one heartbeat line."""
+        n = int(elapsed_seconds)
+        _emit(f"[{idx}/{total}] {candidate}  {task}  attempt {attempt}  running... {n}s elapsed")
+
+    def emit_end(
+        self,
+        *,
+        idx: int,
+        total: int,
+        candidate: str,
+        task: str,
+        attempt: int,
+        result: str,
+        elapsed_seconds: float,
+        tool_calls: int = 0,
+    ) -> None:
+        """Emit the attempt-end line.
+
+        result is one of "pass", "fail", "error", or "timeout".
+        """
+        s = round(elapsed_seconds, 1)
+        if result == "pass":
+            detail = f"pass ({s}s, {tool_calls} tool calls)"
+        elif result == "fail":
+            detail = f"fail ({s}s, {tool_calls} tool calls)"
+        elif result == "timeout":
+            detail = f"timeout after {s}s — skipping"
+        else:
+            # "error" or any unexpected value
+            detail = f"error ({s}s)"
+        _emit(f"[{idx}/{total}] {candidate}  {task}  attempt {attempt}  {detail}")
+
+    # ── Heartbeat context ───────────────────────────────────────────────
+
+    def run_heartbeat(
+        self,
+        *,
+        stop_event: threading.Event,
+        started_at: float,
+        idx: int,
+        total: int,
+        candidate: str,
+        task: str,
+        attempt: int,
+    ) -> None:
+        """Target function for the daemon heartbeat thread.
+
+        Emits a heartbeat every ``self._interval`` seconds while
+        ``stop_event`` is not set. Returns immediately once the event
+        is set. Designed to be run in a daemon thread so it cannot
+        outlive the orchestrator process even if join() is skipped in
+        extreme cases.
+
+        Never raises into the caller — exceptions are silently swallowed
+        so a progress-system failure cannot crash an otherwise-healthy run.
+        """
+        try:
+            while not stop_event.wait(timeout=self._interval):
+                try:
+                    elapsed = time.monotonic() - started_at
+                    self.emit_heartbeat(
+                        idx=idx,
+                        total=total,
+                        candidate=candidate,
+                        task=task,
+                        attempt=attempt,
+                        elapsed_seconds=elapsed,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass  # never crash the heartbeat loop
+        except Exception:  # noqa: BLE001
+            pass  # never propagate into the spawning thread
+
+
+# ── Module-level helper ─────────────────────────────────────────────────
+
+
+def _emit(line: str) -> None:
+    """Write one progress line to stderr, flushed immediately."""
+    print(line, file=sys.stderr, flush=True)

--- a/scripts/benchmark_runner/proxy.py
+++ b/scripts/benchmark_runner/proxy.py
@@ -1,0 +1,276 @@
+# benchmark_runner.proxy — shared LiteLLM Anthropic→OpenAI proxy lifecycle.
+#
+# Extracted from scripts/run-compare-anthropic-vs-vllm.sh so that the
+# same verified launch recipe is used by both:
+#   - scripts/bench (ephemeral proxy for raw-vLLM candidates)
+#   - scripts/run-compare-anthropic-vs-vllm.sh (via subprocess)
+#
+# The `hosted_vllm/` provider prefix is mandatory — see
+# benchmarks/backends/vllm.md blocker #5: LiteLLM ≥1.50 with the
+# `openai/` prefix auto-routes to vLLM's /v1/responses endpoint, which
+# rejects the multi-turn input-array shape with 212 validation errors.
+# `hosted_vllm/` pins routing to /v1/chat/completions.
+#
+# Proxy lifecycle:
+#   1. Write a YAML config tempfile with the `hosted_vllm/` alias.
+#   2. Start `litellm --config … --port … --host 127.0.0.1` in background.
+#   3. Healthcheck-loop: poll /v1/models up to 30s.
+#   4. Caller calls stop() (or an atexit handler) which sends SIGTERM;
+#      if the process does not exit within 5s, escalates to SIGKILL.
+#
+# Usage (Python):
+#   proxy = LiteLLMProxy(vllm_base, vllm_model, port=8787)
+#   proxy.start()          # blocks until healthy
+#   try:
+#       ...
+#   finally:
+#       proxy.stop()
+#
+# Or as a context manager:
+#   with LiteLLMProxy(vllm_base, vllm_model) as proxy:
+#       base_url = proxy.base_url   # http://127.0.0.1:<port>
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+class ProxyStartError(RuntimeError):
+    """Raised when the LiteLLM proxy fails to start within the timeout."""
+
+
+class LiteLLMProxy:
+    """Ephemeral LiteLLM Anthropic→OpenAI proxy wrapping a raw vLLM endpoint.
+
+    Writes a per-instance tempfile config so concurrent proxy instances
+    (different ports / different models) do not clobber each other.
+    """
+
+    def __init__(
+        self,
+        vllm_base: str,
+        vllm_model: str,
+        *,
+        port: int = 8787,
+        startup_timeout: int = 30,
+    ) -> None:
+        self._vllm_base = vllm_base.rstrip("/")
+        self._vllm_model = vllm_model
+        self._port = port
+        self._startup_timeout = startup_timeout
+        self._proc: Optional[subprocess.Popen] = None  # type: ignore[type-arg]
+        self._config_path: Optional[Path] = None
+        self._log_path: Optional[Path] = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    # ── Lifecycle ──────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Write config, start proxy, wait for health."""
+        self._write_config()
+        self._spawn()
+        self._wait_healthy()
+
+    def stop(self) -> None:
+        """SIGTERM → wait 5s → SIGKILL if still running."""
+        if self._proc is None:
+            return
+        proc = self._proc
+        self._proc = None
+        _graceful_kill(proc, sigterm_timeout=5)
+        # Clean up tempfiles after the process is gone.
+        if self._config_path and self._config_path.exists():
+            try:
+                self._config_path.unlink()
+            except OSError:
+                pass
+        if self._log_path and self._log_path.exists():
+            try:
+                self._log_path.unlink()
+            except OSError:
+                pass
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    # ── Context manager ────────────────────────────────────────────────
+
+    def __enter__(self) -> "LiteLLMProxy":
+        self.start()
+        return self
+
+    def __exit__(self, *_exc) -> None:  # type: ignore[no-untyped-def]
+        self.stop()
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _write_config(self) -> None:
+        # Use mktemp so two concurrent instances don't clobber each other.
+        fd, config_path = tempfile.mkstemp(suffix=".yaml", prefix="cct-litellm-")
+        os.close(fd)
+        self._config_path = Path(config_path)
+        # The hosted_vllm/ prefix pins routing to /v1/chat/completions.
+        # api_key is required by the LiteLLM SDK; vLLM ignores it.
+        config_yaml = (
+            f"model_list:\n"
+            f"  - model_name: \"{self._vllm_model}\"\n"
+            f"    litellm_params:\n"
+            f"      model: \"hosted_vllm/{self._vllm_model}\"\n"
+            f"      api_base: \"{self._vllm_base}/v1\"\n"
+            f"      api_key: \"dummy\"\n"
+            f"litellm_settings:\n"
+            f"  drop_params: true\n"
+        )
+        self._config_path.write_text(config_yaml, encoding="utf-8")
+
+        fd2, log_path = tempfile.mkstemp(suffix=".log", prefix="cct-litellm-")
+        os.close(fd2)
+        self._log_path = Path(log_path)
+
+    def _spawn(self) -> None:
+        log_fd = open(self._log_path, "w") if self._log_path else subprocess.DEVNULL  # noqa: SIM115
+        self._proc = subprocess.Popen(
+            [
+                "litellm",
+                "--config", str(self._config_path),
+                "--port", str(self._port),
+                "--host", "127.0.0.1",
+            ],
+            stdout=log_fd,
+            stderr=log_fd,
+            start_new_session=True,
+        )
+
+    def _wait_healthy(self) -> None:
+        """Poll /v1/models up to startup_timeout seconds."""
+        url = f"{self.base_url}/v1/models"
+        deadline = time.monotonic() + self._startup_timeout
+        while time.monotonic() < deadline:
+            if self._proc is not None and self._proc.poll() is not None:
+                log_tail = _read_tail(self._log_path, 40)
+                raise ProxyStartError(
+                    f"LiteLLM proxy (PID {self._proc.pid}) died during startup.\n"
+                    f"Log tail:\n{log_tail}"
+                )
+            if _http_ok(url):
+                return
+            time.sleep(1)
+        log_tail = _read_tail(self._log_path, 40)
+        raise ProxyStartError(
+            f"LiteLLM proxy did not answer {url} within {self._startup_timeout}s.\n"
+            f"Log tail:\n{log_tail}"
+        )
+
+    def get_log_tail(self, lines: int = 40) -> str:
+        return _read_tail(self._log_path, lines)
+
+
+# ── CLI helper (used by run-compare-anthropic-vs-vllm.sh) ─────────────
+#
+# Called as:
+#   python3 -m benchmark_runner.proxy start \
+#       --vllm-base <url> --model <name> --port <n>
+#
+# Prints to stdout (one key=value per line):
+#   pid=<n>
+#   config=<path>
+#   log=<path>
+#   base_url=http://127.0.0.1:<port>
+#
+# The caller (bash script) reads these and stores PID for its trap.
+# This is the "single source of truth" contract: the bash script no
+# longer carries its own config-writing or spawn logic.
+
+
+def _cli_start(vllm_base: str, vllm_model: str, port: int) -> None:
+    """Start proxy and print pid/config/log/base_url to stdout."""
+    proxy = LiteLLMProxy(vllm_base, vllm_model, port=port)
+    proxy._write_config()
+    proxy._spawn()
+    proxy._wait_healthy()
+    pid = proxy._proc.pid if proxy._proc else -1
+    print(f"pid={pid}")
+    print(f"config={proxy._config_path}")
+    print(f"log={proxy._log_path}")
+    print(f"base_url={proxy.base_url}")
+    # Hand off ownership — don't stop in __del__.
+    proxy._proc = None  # noqa: SLF001 — intentional ownership transfer
+
+
+def main_cli() -> None:  # noqa: D401 — CLI entry
+    import argparse
+    parser = argparse.ArgumentParser(
+        prog="python3 -m benchmark_runner.proxy",
+        description="Start an ephemeral LiteLLM proxy and print PID/paths to stdout.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_start = sub.add_parser("start", help="Start the proxy.")
+    p_start.add_argument("--vllm-base", required=True)
+    p_start.add_argument("--model", required=True)
+    p_start.add_argument("--port", type=int, default=8787)
+    args = parser.parse_args()
+    if args.cmd == "start":
+        _cli_start(args.vllm_base, args.model, args.port)
+
+
+if __name__ == "__main__":
+    main_cli()
+
+
+# ── Module-level helpers ───────────────────────────────────────────────
+
+
+def _graceful_kill(proc: subprocess.Popen, *, sigterm_timeout: int = 5) -> None:  # type: ignore[type-arg]
+    """SIGTERM → wait → SIGKILL escalation for a process group."""
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        pass  # already dead
+
+    try:
+        proc.wait(timeout=sigterm_timeout)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    # Escalate to SIGKILL.
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def _http_ok(url: str, timeout: float = 2.0) -> bool:
+    """Return True if the URL responds with any 2xx status."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310
+            return 200 <= resp.status < 300
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _read_tail(path: Optional[Path], lines: int) -> str:
+    if path is None or not path.exists():
+        return "(no log)"
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        return "\n".join(text.splitlines()[-lines:])
+    except OSError:
+        return "(unreadable)"

--- a/scripts/benchmark_runner/proxy.py
+++ b/scripts/benchmark_runner/proxy.py
@@ -224,10 +224,6 @@ def main_cli() -> None:  # noqa: D401 — CLI entry
         _cli_start(args.vllm_base, args.model, args.port)
 
 
-if __name__ == "__main__":
-    main_cli()
-
-
 # ── Module-level helpers ───────────────────────────────────────────────
 
 
@@ -274,3 +270,12 @@ def _read_tail(path: Optional[Path], lines: int) -> str:
         return "\n".join(text.splitlines()[-lines:])
     except OSError:
         return "(unreadable)"
+
+
+# Entrypoint MUST be last: ``python3 -m benchmark_runner.proxy`` executes
+# the module top-to-bottom, so main_cli() can only run after every
+# helper (_graceful_kill / _http_ok / _read_tail) is defined. Keeping
+# this block mid-file caused a NameError on _http_ok during the DGX
+# pre-merge check (T1.4 extraction regression, caught 2026-05-19).
+if __name__ == "__main__":
+    main_cli()

--- a/scripts/benchmark_runner/report.py
+++ b/scripts/benchmark_runner/report.py
@@ -272,6 +272,11 @@ def _group_summary(
 ) -> dict[str, Any]:
     total = len(rows)
     passed = sum(1 for r in rows if r["score"]["result"] == "pass")
+    # D5: count timeout attempts separately so reviewers can distinguish
+    # "LLM failed" from "LLM hung". The timeout count is additive — it does
+    # NOT change pass_rate (timeouts already lower it via result != "pass").
+    # Constraint #8: verdict calculus is untouched; we only ADD a tally.
+    timed_out = sum(1 for r in rows if r["score"]["result"] == "timeout")
     elapsed_values = [r["score"]["derived"]["elapsed_seconds"] for r in rows]
 
     # Provider endpoints seen in this group — usually one, but multiple
@@ -290,6 +295,7 @@ def _group_summary(
         "candidate_name": candidate_name,
         "total_attempts": total,
         "passed": passed,
+        "timed_out": timed_out,
         "pass_rate": _safe_div(passed, total),
         "elapsed_seconds_mean": _mean(elapsed_values),
         "elapsed_seconds_stdev": _stdev(elapsed_values),
@@ -406,9 +412,11 @@ def _render_markdown(summary: Mapping[str, Any]) -> str:
     for label, g in summary["groups"].items():
         lines.append(f"## `{label}` (backend={g['backend_id']}, model={g['model'] or '<none>'})")
         lines.append("")
+        timeout_note = f" ({g['timed_out']} timed out)" if g.get("timed_out", 0) > 0 else ""
         lines.append(
             f"- Total attempts: {g['total_attempts']}  "
             f"\n- Passed: {g['passed']}  "
+            f"\n- Timed out: {g.get('timed_out', 0)}{timeout_note}  "
             f"\n- Pass rate: {_fmt_pct(g['pass_rate'])}  "
             f"\n- Elapsed (s): mean {_fmt_num(g['elapsed_seconds_mean'])}, "
             f"stdev {_fmt_num(g['elapsed_seconds_stdev'])}"

--- a/scripts/benchmark_runner/run.py
+++ b/scripts/benchmark_runner/run.py
@@ -22,11 +22,13 @@ import json
 import re
 import shutil
 import subprocess
+import threading
 import time
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Optional
 
+from .progress import ProgressLogger
 from .contracts import (
     RESULT_ERROR,
     RESULT_FAIL,
@@ -90,11 +92,30 @@ def run_benchmark(
 
     run_dir = _make_run_dir(runs_root, benchmark_id, backend.backend_id)
 
+    # Live-progress setup (D2).
+    # Total = tasks × runs × max_attempts gives an upper bound; in
+    # practice the loop breaks early on pass so the counter may not
+    # reach total. We expose the upper bound rather than lying with a
+    # smaller number — the user sees [3/6] not [3/3] when one task
+    # passed early and the rest are running.
+    progress = ProgressLogger()
+    max_attempts = adapter.max_attempts()
+    attempt_total = len(tasks) * runs * max_attempts
+    # Monotonically increasing attempt counter (1-based).
+    attempt_idx = 0
+
+    # candidate_name for progress display: "backend_family:backend_model"
+    # or just "backend_family" when model is empty (stub, etc.).
+    candidate_name = (
+        f"{backend_family}:{backend_model}" if backend_model else backend_family
+    )
+
     for task in tasks:
         for run_index in range(1, runs + 1):
             run_id = f"run-{run_index:03d}"
             prior: Optional[VerifyResult] = None
-            for attempt in range(1, adapter.max_attempts() + 1):
+            for attempt in range(1, max_attempts + 1):
+                attempt_idx += 1
                 attempt_verify = _execute_attempt(
                     adapter=adapter,
                     backend=backend,
@@ -104,6 +125,10 @@ def run_benchmark(
                     run_id=run_id,
                     run_dir=run_dir,
                     prior=prior,
+                    progress=progress,
+                    attempt_idx=attempt_idx,
+                    attempt_total=attempt_total,
+                    candidate_name=candidate_name,
                 )
                 # Stop early on success — there is no value in burning
                 # a second attempt for a task that already passed.
@@ -130,6 +155,10 @@ def _execute_attempt(
     run_id: str,
     run_dir: Path,
     prior: Optional[VerifyResult],
+    progress: Optional[ProgressLogger] = None,
+    attempt_idx: int = 0,
+    attempt_total: int = 0,
+    candidate_name: str = "",
 ) -> VerifyResult:
     attempt_dir = run_dir / _slug(task.task_id) / f"attempt-{attempt:02d}-{run_id}"
     attempt_dir.mkdir(parents=True, exist_ok=False)
@@ -171,6 +200,53 @@ def _execute_attempt(
         timeout_seconds=None,
     )
 
+    # ── Live progress (D2) ───────────────────────────────────────────
+    # Emit start line, spawn a daemon heartbeat thread, then run the
+    # backend. The thread emits a line every progress._interval seconds
+    # while the attempt_in_progress event is set. The finally block
+    # clears the event and joins the thread unconditionally — whether
+    # backend.run returns normally, returns a timeout result, or raises.
+    # This is safe because the heartbeat thread never writes to the
+    # run record; it only emits to stderr.
+    if progress is not None:
+        progress.emit_start(
+            idx=attempt_idx,
+            total=attempt_total,
+            candidate=candidate_name,
+            task=task.task_id,
+            attempt=attempt,
+        )
+
+    attempt_in_progress = threading.Event()
+    heartbeat_started_at = time.monotonic()
+
+    # attempt_in_progress is a stop-signal Event:
+    # - cleared (not set) while the attempt is running → heartbeat loops
+    # - set when the attempt finishes → heartbeat thread exits
+    # This is the inverse of a "flag" event so that Event.wait(timeout=)
+    # returns False on timeout (heartbeat should fire) and True when
+    # stop is requested (heartbeat should exit).
+    attempt_in_progress.clear()
+
+    if progress is not None:
+        _heartbeat_thread = threading.Thread(
+            target=progress.run_heartbeat,
+            kwargs=dict(
+                stop_event=attempt_in_progress,
+                started_at=heartbeat_started_at,
+                idx=attempt_idx,
+                total=attempt_total,
+                candidate=candidate_name,
+                task=task.task_id,
+                attempt=attempt,
+            ),
+            daemon=True,
+            name=f"heartbeat-{attempt_idx}",
+        )
+        _heartbeat_thread.start()
+    else:
+        _heartbeat_thread = None
+
     backend_error: Optional[str] = None
     try:
         backend_result: BackendResult = backend.run(prompt, ctx)
@@ -184,6 +260,13 @@ def _execute_attempt(
             transcript_path=None,
             elapsed_seconds=time.monotonic() - started,
         )
+    finally:
+        # Signal the heartbeat thread to stop by setting the event.
+        # join() waits for it to exit. timeout=5 is a safety net;
+        # the daemon flag ensures it cannot outlive the process.
+        attempt_in_progress.set()
+        if _heartbeat_thread is not None:
+            _heartbeat_thread.join(timeout=5)
 
     # Verify regardless — even on backend error, the worktree may be
     # in a partially-populated state and the verify step's output is
@@ -257,6 +340,22 @@ def _execute_attempt(
         },
         "result": _classify_result(verify_result, backend_error),
     }
+
+    # Emit the attempt-end progress line now that we know the result
+    # and elapsed time. tool_calls is the sum of all tool invocations
+    # recorded by the backend.
+    if progress is not None:
+        _total_tool_calls = sum(backend_result.tool_calls.values())
+        progress.emit_end(
+            idx=attempt_idx,
+            total=attempt_total,
+            candidate=candidate_name,
+            task=task.task_id,
+            attempt=attempt,
+            result=score["result"],
+            elapsed_seconds=elapsed,
+            tool_calls=_total_tool_calls,
+        )
 
     stats = {
         "schema_version": SCHEMA_VERSION,

--- a/scripts/benchmark_runner/run.py
+++ b/scripts/benchmark_runner/run.py
@@ -33,6 +33,7 @@ from .contracts import (
     RESULT_ERROR,
     RESULT_FAIL,
     RESULT_PASS,
+    RESULT_TIMEOUT,
     BackendResult,
     BenchmarkAdapter,
     IsolationConfig,
@@ -72,10 +73,20 @@ def run_benchmark(
     runs: int,
     runs_root: Path,
     task_filter: Optional[list[str]] = None,
+    attempt_timeout_seconds: Optional[int] = None,
 ) -> Path:
     """Execute the benchmark; return the produced run directory."""
     if runs < 1:
         raise ValueError(f"--runs must be >= 1; got {runs}")
+    if attempt_timeout_seconds is not None and (
+        isinstance(attempt_timeout_seconds, bool)
+        or not isinstance(attempt_timeout_seconds, int)
+        or attempt_timeout_seconds <= 0
+    ):
+        raise ValueError(
+            f"--attempt-timeout must be a positive integer of seconds; "
+            f"got {attempt_timeout_seconds!r}"
+        )
 
     adapter = get_adapter(benchmark_id)
     backend = get_backend(backend_family, backend_model)
@@ -129,6 +140,7 @@ def run_benchmark(
                     attempt_idx=attempt_idx,
                     attempt_total=attempt_total,
                     candidate_name=candidate_name,
+                    attempt_timeout_seconds=attempt_timeout_seconds,
                 )
                 # Stop early on success — there is no value in burning
                 # a second attempt for a task that already passed.
@@ -159,6 +171,7 @@ def _execute_attempt(
     attempt_idx: int = 0,
     attempt_total: int = 0,
     candidate_name: str = "",
+    attempt_timeout_seconds: Optional[int] = None,
 ) -> VerifyResult:
     attempt_dir = run_dir / _slug(task.task_id) / f"attempt-{attempt:02d}-{run_id}"
     attempt_dir.mkdir(parents=True, exist_ok=False)
@@ -197,7 +210,7 @@ def _execute_attempt(
         model=backend_model,
         temperature=0.0,
         seed=None,
-        timeout_seconds=None,
+        timeout_seconds=attempt_timeout_seconds,
     )
 
     # ── Live progress (D2) ───────────────────────────────────────────
@@ -316,6 +329,16 @@ def _execute_attempt(
         },
     }
 
+    # D5: detect harness-imposed timeout via the structured flag on BackendResult.
+    # The backend's TimeoutExpired branch sets timed_out=True; all other paths
+    # leave it False. Timeout takes classification precedence over fail because
+    # the verify step ran on a worktree that the model never finished editing.
+    is_timeout = backend_result.timed_out
+    if is_timeout:
+        timeout_note = _timeout_output(attempt_timeout_seconds or 0, elapsed)
+    else:
+        timeout_note = None
+
     score = {
         "schema_version": SCHEMA_VERSION,
         "benchmark_id": adapter.benchmark_id,
@@ -328,7 +351,7 @@ def _execute_attempt(
             "lint_passed": verify_result.lint_passed,
             "typecheck_passed": verify_result.typecheck_passed,
             "required_files_present": verify_result.required_files_present,
-            "timeout": False,
+            "timeout": is_timeout,
             "human_interventions": 0,
         },
         "derived": {
@@ -338,7 +361,7 @@ def _execute_attempt(
             "lines_removed": lines_removed,
             "failed_commands": backend_result.failed_commands + verify_result.failed_commands,
         },
-        "result": _classify_result(verify_result, backend_error),
+        "result": _classify_result(verify_result, backend_error, is_timeout),
     }
 
     # Emit the attempt-end progress line now that we know the result
@@ -374,10 +397,14 @@ def _execute_attempt(
     _write_json(attempt_dir / "score.json", score)
     _write_json(attempt_dir / "stats.json", stats)
 
-    if verify_result.tests_output:
-        (attempt_dir / "verify-output.txt").write_text(
-            verify_result.tests_output, encoding="utf-8"
-        )
+    # D5: for timed-out attempts, prepend the harness-imposed timeout note to
+    # verify-output.txt so postmortem inspection shows why the verify result
+    # (if any) was produced on an incomplete worktree.
+    verify_output = verify_result.tests_output
+    if timeout_note:
+        verify_output = timeout_note + ("\n" + verify_output if verify_output else "")
+    if verify_output:
+        (attempt_dir / "verify-output.txt").write_text(verify_output, encoding="utf-8")
 
     return verify_result
 
@@ -482,7 +509,21 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def _classify_result(verify: VerifyResult, backend_error: Optional[str]) -> str:
+def _timeout_output(timeout_seconds: int, elapsed: float) -> str:
+    """Return the harness-imposed timeout note written to verify-output.txt."""
+    n = round(elapsed, 1)
+    return f"<harness-imposed timeout after {n}s>"
+
+
+def _classify_result(
+    verify: VerifyResult,
+    backend_error: Optional[str],
+    is_timeout: bool = False,
+) -> str:
+    # D5: timeout takes precedence over fail/error — the model never finished,
+    # so recording "fail" or "error" would misrepresent what happened.
+    if is_timeout:
+        return RESULT_TIMEOUT
     if backend_error is not None:
         return RESULT_ERROR
     return RESULT_PASS if verify.tests_passed else RESULT_FAIL

--- a/scripts/benchmark_runner/tests/test_bench_cli.py
+++ b/scripts/benchmark_runner/tests/test_bench_cli.py
@@ -1,0 +1,472 @@
+# tests/test_bench_cli.py — CLI flag handling: --yes, non-TTY, --preset,
+# --runs/--task override, zero-config smoke, --list-providers Ollama 3-check.
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+from benchmark_runner.bench import (
+    _parse_argv,
+    list_presets,
+    load_preset,
+    main,
+)
+
+
+# ── Argument parsing ───────────────────────────────────────────────────
+
+
+class TestParseArgv(unittest.TestCase):
+    def test_no_args(self) -> None:
+        opts, candidates, passthrough = _parse_argv([])
+        self.assertFalse(opts["yes"])
+        self.assertFalse(opts["list_presets"])
+        self.assertEqual(candidates, [])
+
+    def test_candidates_parsed(self) -> None:
+        opts, candidates, passthrough = _parse_argv(["sonnet", "ollama:qwen2.5-coder:7b"])
+        self.assertEqual(candidates, ["sonnet", "ollama:qwen2.5-coder:7b"])
+        self.assertEqual(passthrough, [])
+
+    def test_yes_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--yes", "sonnet"])
+        self.assertTrue(opts["yes"])
+
+    def test_no_confirm_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--no-confirm", "sonnet"])
+        self.assertTrue(opts["no_confirm"])
+
+    def test_runs_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--runs", "5", "sonnet"])
+        self.assertEqual(opts["runs"], 5)
+
+    def test_task_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--task", "python/bowling,go/bowling"])
+        self.assertEqual(opts["task"], ["python/bowling", "go/bowling"])
+
+    def test_preset_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--preset", "local-vs-cloud"])
+        self.assertEqual(opts["preset"], "local-vs-cloud")
+
+    def test_unknown_flags_pass_through(self) -> None:
+        opts, candidates, passthrough = _parse_argv(
+            ["--no-report", "--runs-root", "/tmp/x", "sonnet"]
+        )
+        self.assertEqual(candidates, ["sonnet"])
+        self.assertIn("--no-report", passthrough)
+        self.assertIn("--runs-root", passthrough)
+        self.assertIn("/tmp/x", passthrough)
+
+    def test_list_presets(self) -> None:
+        opts, _, _ = _parse_argv(["--list-presets"])
+        self.assertTrue(opts["list_presets"])
+
+    def test_list_providers(self) -> None:
+        opts, _, _ = _parse_argv(["--list-providers"])
+        self.assertTrue(opts["list_providers"])
+
+    def test_help_flag(self) -> None:
+        opts, _, _ = _parse_argv(["--help"])
+        self.assertTrue(opts["help"])
+
+
+# ── Help / list-presets exits 0 ───────────────────────────────────────
+
+
+class TestHelpExits(unittest.TestCase):
+    def test_help_exits_0(self) -> None:
+        rc = main(["--help"])
+        self.assertEqual(rc, 0)
+
+    def test_list_presets_exits_0(self) -> None:
+        rc = main(["--list-presets"])
+        self.assertEqual(rc, 0)
+
+
+# ── Preset loading ─────────────────────────────────────────────────────
+
+
+class TestPresetLoading(unittest.TestCase):
+    def _write_preset(self, tmpdir: str, name: str, content: dict) -> Path:
+        d = Path(tmpdir) / "benchmarks" / "presets"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / f"{name}.json"
+        p.write_text(json.dumps(content), encoding="utf-8")
+        return p
+
+    def test_load_preset_missing_raises(self) -> None:
+        with mock.patch(
+            "benchmark_runner.bench._presets_dir",
+            return_value=Path("/nonexistent/path"),
+        ):
+            with self.assertRaises(ValueError) as cm:
+                load_preset("no-such-preset")
+            self.assertIn("no-such-preset", str(cm.exception))
+
+    def test_list_presets_returns_stems(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "a.json").write_text("{}", encoding="utf-8")
+            (d / "b.json").write_text("{}", encoding="utf-8")
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d):
+                names = list_presets()
+        self.assertIn("a", names)
+        self.assertIn("b", names)
+
+
+# ── Confirmation gate ──────────────────────────────────────────────────
+
+
+class TestConfirmationGate(unittest.TestCase):
+    def test_yes_flag_bypasses_gate(self) -> None:
+        """--yes should not prompt even with Anthropic candidates."""
+        with mock.patch("subprocess.run") as mock_run, \
+             mock.patch("benchmark_runner.bench._run_stub_smoke", return_value=True):
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            rc = main(["--yes", "sonnet", "opus"])
+        # Should reach subprocess.run (benchmark compare), not prompt.
+        self.assertEqual(rc, 0)
+
+    def test_no_confirm_bypasses_gate(self) -> None:
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            rc = main(["--no-confirm", "sonnet", "opus"])
+        self.assertEqual(rc, 0)
+
+    def test_non_tty_bypasses_gate(self) -> None:
+        """Non-TTY stdin should behave as --yes."""
+        with mock.patch("sys.stdin") as mock_stdin, \
+             mock.patch("subprocess.run") as mock_run:
+            mock_stdin.isatty.return_value = False
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            rc = main(["sonnet", "opus"])
+        self.assertEqual(rc, 0)
+
+    def test_all_local_never_prompts(self) -> None:
+        """Ollama-only candidates should never trigger the confirmation gate."""
+        import io
+        original_stdin = sys.stdin
+        try:
+            # Replace stdin with a stream that raises on read — ensures
+            # the gate never calls input().
+            sys.stdin = io.StringIO("")
+            sys.stdin.isatty = lambda: True  # type: ignore[method-assign]
+            with mock.patch("subprocess.run") as mock_run:
+                mock_run.return_value = mock.MagicMock(returncode=0)
+                rc = main(["--yes", "ollama:qwen2.5-coder:7b", "lmstudio:phi-3"])
+        finally:
+            sys.stdin = original_stdin
+        self.assertEqual(rc, 0)
+
+
+# ── Zero-config smoke ──────────────────────────────────────────────────
+
+
+class TestZeroConfig(unittest.TestCase):
+    def test_no_args_exits_0(self) -> None:
+        """./scripts/bench (no args) must exit 0 without calling any LLM."""
+        with mock.patch("benchmark_runner.bench._run_stub_smoke", return_value=True):
+            rc = main([])
+        self.assertEqual(rc, 0)
+
+    def test_no_args_smoke_fail_exits_1(self) -> None:
+        with mock.patch("benchmark_runner.bench._run_stub_smoke", return_value=False):
+            rc = main([])
+        self.assertEqual(rc, 1)
+
+
+# ── --list-providers Ollama 3-check ────────────────────────────────────
+
+
+class TestListProvidersOllamaCheck(unittest.TestCase):
+    def _urlopen_factory(self, version_body: bytes, tags_body: bytes):  # noqa: ANN202
+        """Return a urlopen side_effect that handles /api/version and /api/tags."""
+        def fake_urlopen(url_or_req, timeout=None):  # noqa: ANN001, ANN202
+            url = url_or_req if isinstance(url_or_req, str) else url_or_req.full_url
+            resp = mock.MagicMock()
+            resp.__enter__ = mock.Mock(return_value=resp)
+            resp.__exit__ = mock.Mock(return_value=False)
+            if "/api/version" in url:
+                resp.status = 200
+                resp.read.return_value = version_body
+                return resp
+            if "/api/tags" in url:
+                resp.status = 200
+                resp.read.return_value = tags_body
+                return resp
+            if "/v1/models" in url:
+                # LM Studio probe — not found.
+                import urllib.error
+                raise urllib.error.URLError("not reachable")
+            import urllib.error
+            raise urllib.error.URLError("unmatched")
+        return fake_urlopen
+
+    def test_ollama_usable(self) -> None:
+        version_body = json.dumps({"version": "0.14.0"}).encode()
+        tags_body = json.dumps({"models": [{"name": "qwen2.5-coder:7b"}]}).encode()
+        with mock.patch.dict("os.environ", {"OLLAMA_HOST": "http://localhost:11434"}), \
+             mock.patch("urllib.request.urlopen",
+                        side_effect=self._urlopen_factory(version_body, tags_body)):
+            rc = main(["--list-providers"])
+        self.assertEqual(rc, 0)
+
+    def test_ollama_too_old_unusable(self) -> None:
+        version_body = json.dumps({"version": "0.13.5"}).encode()
+        tags_body = json.dumps({"models": []}).encode()
+        captured = []
+        with mock.patch.dict("os.environ", {"OLLAMA_HOST": "http://localhost:11434"}), \
+             mock.patch("urllib.request.urlopen",
+                        side_effect=self._urlopen_factory(version_body, tags_body)), \
+             mock.patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+            rc = main(["--list-providers"])
+        self.assertEqual(rc, 0)
+        combined = "\n".join(captured)
+        self.assertIn("unusable", combined.lower())
+        self.assertIn("0.13.5", combined)
+
+    def test_ollama_not_detected_without_binary_or_host(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=True), \
+             mock.patch("benchmark_runner.bench._which", return_value=None):
+            captured = []
+            with mock.patch("builtins.print", side_effect=lambda *a, **kw: captured.append(" ".join(str(x) for x in a))):
+                rc = main(["--list-providers"])
+        self.assertEqual(rc, 0)
+        combined = "\n".join(captured)
+        self.assertIn("not detected", combined.lower())
+
+
+# ── Legacy --config path regression ────────────────────────────────────
+
+
+class TestLegacyConfigRegression(unittest.TestCase):
+    """The legacy ./scripts/benchmark compare --config <file> path must be unaffected."""
+
+    def test_compare_load_config_unchanged(self) -> None:
+        """Regression: load_config on a well-formed compare-config returns expected fields."""
+        from benchmark_runner.compare import load_config, CompareConfigError
+
+        good = {
+            "benchmark": "stub",
+            "runs": 2,
+            "candidates": [
+                {"backend": "stub", "model": ""},
+                {"backend": "stub2", "model": ""},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "cfg.json"
+            p.write_text(json.dumps(good), encoding="utf-8")
+            cfg = load_config(p)
+        self.assertEqual(cfg.benchmark, "stub")
+        self.assertEqual(cfg.runs, 2)
+        self.assertEqual(len(cfg.candidates), 2)
+
+        # Single candidate still rejected.
+        bad = {
+            "benchmark": "stub",
+            "candidates": [{"backend": "stub"}],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "bad.json"
+            p.write_text(json.dumps(bad), encoding="utf-8")
+            with self.assertRaisesRegex(CompareConfigError, "at least 2"):
+                load_config(p)
+
+
+# ── Defect 2: preset confirmation gate ────────────────────────────────
+
+
+class TestPresetConfirmationGate(unittest.TestCase):
+    """Regression tests for D2: _run_preset must honour the confirmation gate."""
+
+    def _anthropic_preset(self) -> dict:
+        """Synthetic all-Anthropic preset (no ANTHROPIC_BASE_URL in any candidate env)."""
+        return {
+            "benchmark": "stub",
+            "runs": 1,
+            "candidates": [
+                {"name": "c-sonnet", "backend": "claude-code", "model": "sonnet"},
+                {"name": "c-opus", "backend": "claude-code", "model": "opus"},
+            ],
+        }
+
+    def _local_preset(self) -> dict:
+        """Synthetic all-local preset (every candidate has ANTHROPIC_BASE_URL)."""
+        return {
+            "benchmark": "stub",
+            "runs": 1,
+            "candidates": [
+                {
+                    "name": "local-a",
+                    "backend": "claude-code",
+                    "model": "qwen:7b",
+                    "env": {"ANTHROPIC_BASE_URL": "http://localhost:11434"},
+                },
+                {
+                    "name": "local-b",
+                    "backend": "claude-code",
+                    "model": "qwen:32b",
+                    "env": {"ANTHROPIC_BASE_URL": "http://localhost:11434"},
+                },
+            ],
+        }
+
+    def _single_anthropic_preset(self) -> dict:
+        """Single Anthropic candidate preset — tests gate + Defect 3 together."""
+        return {
+            "benchmark": "stub",
+            "runs": 1,
+            "candidates": [
+                {"name": "c-sonnet", "backend": "claude-code", "model": "sonnet"},
+            ],
+        }
+
+    def _single_local_preset(self) -> dict:
+        """Single local candidate preset with an env block (Defect 3 regression)."""
+        return {
+            "benchmark": "stub",
+            "runs": 1,
+            "candidates": [
+                {
+                    "name": "local-single",
+                    "backend": "claude-code",
+                    "model": "qwen:7b",
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "http://localhost:11434",
+                        "ANTHROPIC_AUTH_TOKEN": "ollama",
+                        "ANTHROPIC_DEFAULT_SONNET_MODEL": "qwen:7b",
+                        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen:7b",
+                    },
+                },
+            ],
+        }
+
+    def test_preset_anthropic_tty_n_aborts(self) -> None:
+        """--preset with Anthropic candidates + TTY + answer 'n' must abort WITHOUT dispatching."""
+        import io
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "benchmarks" / "presets"
+            d.mkdir(parents=True)
+            (d / "tour.json").write_text(json.dumps(self._anthropic_preset()))
+
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d), \
+                 mock.patch("subprocess.run") as mock_sub, \
+                 mock.patch("sys.stdin") as mock_stdin, \
+                 mock.patch("builtins.input", return_value="n"):
+                mock_stdin.isatty.return_value = True
+                rc = main(["--preset", "tour"])
+
+        # Gate returned False → must not have dispatched.
+        mock_sub.assert_not_called()
+        self.assertEqual(rc, 0)
+
+    def test_preset_anthropic_yes_flag_bypasses_gate(self) -> None:
+        """--preset + --yes must skip the gate and dispatch."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "benchmarks" / "presets"
+            d.mkdir(parents=True)
+            (d / "tour.json").write_text(json.dumps(self._anthropic_preset()))
+
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d), \
+                 mock.patch("subprocess.run") as mock_sub:
+                mock_sub.return_value = mock.MagicMock(returncode=0)
+                rc = main(["--preset", "tour", "--yes"])
+
+        mock_sub.assert_called_once()
+        self.assertEqual(rc, 0)
+
+    def test_preset_all_local_no_gate(self) -> None:
+        """All-local preset must NOT prompt — calling input() is a test failure."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "benchmarks" / "presets"
+            d.mkdir(parents=True)
+            (d / "local.json").write_text(json.dumps(self._local_preset()))
+
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d), \
+                 mock.patch("subprocess.run") as mock_sub, \
+                 mock.patch("sys.stdin") as mock_stdin, \
+                 mock.patch("builtins.input",
+                            side_effect=AssertionError("input() called for all-local preset")):
+                mock_stdin.isatty.return_value = True
+                mock_sub.return_value = mock.MagicMock(returncode=0)
+                rc = main(["--preset", "local"])
+
+        self.assertEqual(rc, 0)
+
+    def test_preset_non_tty_no_gate(self) -> None:
+        """Non-TTY stdin must bypass the gate even for Anthropic presets."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "benchmarks" / "presets"
+            d.mkdir(parents=True)
+            (d / "tour.json").write_text(json.dumps(self._anthropic_preset()))
+
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d), \
+                 mock.patch("subprocess.run") as mock_sub, \
+                 mock.patch("sys.stdin") as mock_stdin, \
+                 mock.patch("builtins.input",
+                            side_effect=AssertionError("input() called for non-TTY")):
+                mock_stdin.isatty.return_value = False
+                mock_sub.return_value = mock.MagicMock(returncode=0)
+                rc = main(["--preset", "tour"])
+
+        self.assertEqual(rc, 0)
+
+
+# ── Defect 3: single-candidate preset applies env ─────────────────────
+
+
+class TestPresetSingleCandidateEnv(unittest.TestCase):
+    """Regression test for D3: single-candidate preset must patch env before invoking run."""
+
+    def test_single_candidate_env_patched(self) -> None:
+        """Env block from the single preset candidate must be visible to the invoked command."""
+        preset = {
+            "benchmark": "stub",
+            "runs": 1,
+            "candidates": [
+                {
+                    "name": "local-single",
+                    "backend": "claude-code",
+                    "model": "qwen:7b",
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "http://localhost:11434",
+                        "ANTHROPIC_AUTH_TOKEN": "test-token-xyz",
+                    },
+                },
+            ],
+        }
+
+        captured_env: dict = {}
+
+        def capture_env(*args, **kwargs):  # noqa: ANN002, ANN003
+            captured_env.update(os.environ.copy())
+            return mock.MagicMock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "benchmarks" / "presets"
+            d.mkdir(parents=True)
+            (d / "single.json").write_text(json.dumps(preset))
+
+            with mock.patch("benchmark_runner.bench._presets_dir", return_value=d), \
+                 mock.patch("subprocess.run", side_effect=capture_env), \
+                 mock.patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False  # bypass gate
+                rc = main(["--preset", "single"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured_env.get("ANTHROPIC_BASE_URL"), "http://localhost:11434",
+            "ANTHROPIC_BASE_URL from preset env must be set during subprocess.run")
+        self.assertEqual(captured_env.get("ANTHROPIC_AUTH_TOKEN"), "test-token-xyz",
+            "ANTHROPIC_AUTH_TOKEN from preset env must be set during subprocess.run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_bench_envfill.py
+++ b/scripts/benchmark_runner/tests/test_bench_envfill.py
@@ -1,0 +1,258 @@
+# tests/test_bench_envfill.py — env-fill table correctness.
+#
+# Verifies spec.md § Env-var auto-fill for each provider; mocks HTTP
+# probes so no real network contact is made.
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from benchmark_runner.bench import (
+    ParsedSpec,
+    build_compare_config,
+    parse_spec,
+    resolve_candidate,
+)
+from benchmark_runner.compare import load_config
+
+
+class TestAnthropicEnvFill(unittest.TestCase):
+    def test_sonnet_no_env(self) -> None:
+        spec = parse_spec("sonnet")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.backend, "claude-code")
+        # Rule 1 (spec.md § Spec-parsing contract): bare alias, not "claude-code:sonnet".
+        self.assertEqual(c.model, "sonnet")
+        self.assertEqual(c.env, {})
+        self.assertTrue(c.is_anthropic)
+
+    def test_opus_no_env(self) -> None:
+        spec = parse_spec("opus")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.env, {})
+        self.assertTrue(c.is_anthropic)
+
+    def test_haiku_no_env(self) -> None:
+        spec = parse_spec("haiku")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.env, {})
+        self.assertTrue(c.is_anthropic)
+
+    def test_claude_code_explicit(self) -> None:
+        spec = parse_spec("claude-code:claude-sonnet-4-6")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.model, "claude-sonnet-4-6")
+        self.assertEqual(c.env, {})
+        self.assertTrue(c.is_anthropic)
+
+
+class TestOllamaEnvFill(unittest.TestCase):
+    def test_default_endpoint(self) -> None:
+        spec = parse_spec("ollama:qwen2.5-coder:7b")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.backend, "claude-code")
+        self.assertEqual(c.model, "qwen2.5-coder:7b")
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://localhost:11434")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "ollama")
+        self.assertEqual(c.env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "qwen2.5-coder:7b")
+        self.assertEqual(c.env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "qwen2.5-coder:7b")
+        self.assertFalse(c.is_anthropic)
+
+    def test_custom_endpoint(self) -> None:
+        spec = parse_spec("ollama:qwen2.5-coder:7b@http://192.168.1.5:11434")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://192.168.1.5:11434")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "ollama")
+
+
+class TestLmStudioEnvFill(unittest.TestCase):
+    def test_default_endpoint(self) -> None:
+        spec = parse_spec("lmstudio:phi-3")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://localhost:1234")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "lmstudio")
+        self.assertEqual(c.env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "phi-3")
+        self.assertFalse(c.is_anthropic)
+
+    def test_custom_endpoint(self) -> None:
+        spec = parse_spec("lmstudio:phi-3@http://localhost:5678")
+        c = resolve_candidate(spec)
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://localhost:5678")
+
+
+class TestOpenrouterEnvFill(unittest.TestCase):
+    def test_reads_api_key_from_env(self) -> None:
+        spec = parse_spec("openrouter:meta-llama/llama-3-70b")
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-test-1234"}):
+            c = resolve_candidate(spec)
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "https://openrouter.ai/api/v1")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "sk-or-test-1234")
+        self.assertEqual(c.env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "meta-llama/llama-3-70b")
+        self.assertFalse(c.is_anthropic)
+
+    def test_raises_when_api_key_missing(self) -> None:
+        spec = parse_spec("openrouter:some-model")
+        env_without_key = {k: v for k, v in os.environ.items() if k != "OPENROUTER_API_KEY"}
+        with mock.patch.dict(os.environ, env_without_key, clear=True):
+            with self.assertRaises(ValueError) as cm:
+                resolve_candidate(spec)
+            self.assertIn("OPENROUTER_API_KEY", str(cm.exception))
+
+
+class TestVllmEnvFill(unittest.TestCase):
+    """vLLM probe-then-decide — probes mocked."""
+
+    def _mock_anthropic_proxy_response(self) -> mock.MagicMock:
+        """Mock urllib.request.urlopen to return an Anthropic-shape 200."""
+        resp = mock.MagicMock()
+        resp.__enter__ = mock.Mock(return_value=resp)
+        resp.__exit__ = mock.Mock(return_value=False)
+        resp.status = 200
+        resp.read.return_value = b'{"type":"message","id":"msg_test"}'
+        return resp
+
+    def _mock_openai_models_response(self, ctx_len: int = 131072) -> mock.MagicMock:
+        """Mock urllib.request.urlopen to return an OpenAI /v1/models 200."""
+        resp = mock.MagicMock()
+        resp.__enter__ = mock.Mock(return_value=resp)
+        resp.__exit__ = mock.Mock(return_value=False)
+        resp.status = 200
+        body = json.dumps({
+            "data": [{"id": "MyModel", "max_model_len": ctx_len}],
+        }).encode()
+        resp.read.return_value = body
+        return resp
+
+    def test_anthropic_proxy_path(self) -> None:
+        """Endpoint answers /v1/messages → use directly as user proxy."""
+        from benchmark_runner.bench import resolve_vllm_candidate
+        spec = ParsedSpec(provider="vllm", model="MyModel",
+                          endpoint="http://127.0.0.1:8787")
+        resp = self._mock_anthropic_proxy_response()
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            c = resolve_vllm_candidate(spec)
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://127.0.0.1:8787")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "vllm-user-proxy")
+        self.assertIsNone(c.vllm_proxy)
+
+    def test_raw_vllm_spawns_proxy(self) -> None:
+        """Endpoint answers /v1/models with data:[] → ephemeral proxy spawned."""
+        from benchmark_runner.bench import resolve_vllm_candidate
+
+        spec = ParsedSpec(provider="vllm", model="MyModel",
+                          endpoint="http://192.168.1.23:8000")
+
+        # First call (POST /v1/messages) should raise a 404 → not-an-anthropic-proxy.
+        import urllib.error as _ue
+
+        class FakeHTTPError404(_ue.HTTPError):
+            def __init__(self):  # noqa: ANN204
+                super().__init__("url", 404, "Not Found", {}, None)
+
+        models_resp = self._mock_openai_models_response(ctx_len=131072)
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):  # noqa: ANN001, ANN202
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise FakeHTTPError404()
+            return models_resp
+
+        # Mock the proxy start/stop so no real process is spawned.
+        fake_proxy = mock.MagicMock()
+        fake_proxy.base_url = "http://127.0.0.1:8787"
+        fake_proxy.__enter__ = mock.Mock(return_value=fake_proxy)
+        fake_proxy.__exit__ = mock.Mock(return_value=False)
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("benchmark_runner.bench.LiteLLMProxy", return_value=fake_proxy) as MockProxy:
+            c = resolve_vllm_candidate(spec)
+
+        MockProxy.assert_called_once_with("http://192.168.1.23:8000", "MyModel")
+        fake_proxy.start.assert_called_once()
+        self.assertEqual(c.env["ANTHROPIC_BASE_URL"], "http://127.0.0.1:8787")
+        self.assertEqual(c.env["ANTHROPIC_AUTH_TOKEN"], "vllm-ephemeral")
+        self.assertIs(c.vllm_proxy, fake_proxy)
+
+    def test_context_length_too_small_aborts(self) -> None:
+        """max_model_len < 32000 → ValueError."""
+        from benchmark_runner.bench import resolve_vllm_candidate
+        import urllib.error as _ue
+
+        class FakeHTTPError404(_ue.HTTPError):
+            def __init__(self):  # noqa: ANN204
+                super().__init__("url", 404, "Not Found", {}, None)
+
+        models_resp = self._mock_openai_models_response(ctx_len=8192)
+
+        call_count = [0]
+
+        def fake_urlopen(req, timeout=None):  # noqa: ANN001, ANN202
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise FakeHTTPError404()
+            return models_resp
+
+        spec = ParsedSpec(provider="vllm", model="MyModel",
+                          endpoint="http://192.168.1.23:8000")
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            with self.assertRaises(ValueError) as cm:
+                resolve_vllm_candidate(spec)
+        self.assertIn("32000", str(cm.exception))
+
+    def test_neither_endpoint_fails_fast(self) -> None:
+        """Endpoint answers neither /v1/messages nor /v1/models → ValueError."""
+        from benchmark_runner.bench import resolve_vllm_candidate
+        import urllib.error as _ue
+
+        class FakeHTTPError404(_ue.HTTPError):
+            def __init__(self):  # noqa: ANN204
+                super().__init__("url", 404, "Not Found", {}, None)
+
+        spec = ParsedSpec(provider="vllm", model="MyModel",
+                          endpoint="http://no-such-host:9999")
+
+        def fake_urlopen(req, timeout=None):  # noqa: ANN001, ANN202
+            raise FakeHTTPError404()
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            with self.assertRaises(ValueError) as cm:
+                resolve_vllm_candidate(spec)
+        self.assertIn("neither", str(cm.exception))
+
+
+class TestBuildCompareConfig(unittest.TestCase):
+    """build_compare_config produces a config that loads via compare.load_config."""
+
+    def test_loads_via_compare_load_config(self) -> None:
+        from benchmark_runner.bench import ResolvedCandidate
+        candidates = [
+            ResolvedCandidate(name="c1", backend="claude-code", model="sonnet", env={}, is_anthropic=True),
+            ResolvedCandidate(name="c2", backend="claude-code", model="opus", env={}, is_anthropic=True),
+        ]
+        cfg_dict = build_compare_config(
+            candidates,
+            benchmark="stub",
+            runs=3,
+            task_filter=["python/bowling"],
+        )
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "cfg.json"
+            p.write_text(json.dumps(cfg_dict), encoding="utf-8")
+            cfg = load_config(p)
+        self.assertEqual(cfg.benchmark, "stub")
+        self.assertEqual(cfg.runs, 3)
+        self.assertEqual(cfg.task_filter, ["python/bowling"])
+        self.assertEqual(len(cfg.candidates), 2)
+        self.assertEqual(cfg.candidates[0].name, "c1")
+        self.assertEqual(cfg.candidates[1].name, "c2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_bench_parser.py
+++ b/scripts/benchmark_runner/tests/test_bench_parser.py
@@ -1,0 +1,184 @@
+# tests/test_bench_parser.py — spec-parser invariants.
+#
+# Covers every whitelisted prefix, the colon-tag invariant, @endpoint
+# parsing, and unknown-token did-you-mean hints.
+
+from __future__ import annotations
+
+import unittest
+
+from benchmark_runner.bench import ParsedSpec, ResolvedCandidate, parse_spec, resolve_candidate
+
+
+class TestAnthoropicShortcuts(unittest.TestCase):
+    def test_sonnet(self) -> None:
+        s = parse_spec("sonnet")
+        self.assertEqual(s.provider, "anthropic")
+        # Rule 1: bare alias, NOT "claude-code:sonnet" (spec.md § Spec-parsing contract rule 1).
+        self.assertEqual(s.model, "sonnet")
+        self.assertIsNone(s.endpoint)
+
+    def test_opus(self) -> None:
+        s = parse_spec("opus")
+        self.assertEqual(s.provider, "anthropic")
+        self.assertEqual(s.model, "opus")
+        self.assertIsNone(s.endpoint)
+
+    def test_haiku(self) -> None:
+        s = parse_spec("haiku")
+        self.assertEqual(s.provider, "anthropic")
+        self.assertEqual(s.model, "haiku")
+        self.assertIsNone(s.endpoint)
+
+    def test_shorthand_model_is_not_combined_form(self) -> None:
+        """Regression: model must never be 'claude-code:<token>' — that form
+        is rejected by cli.py/compare.py as an invalid model id."""
+        for alias in ("sonnet", "opus", "haiku"):
+            s = parse_spec(alias)
+            self.assertNotIn("claude-code:", s.model,
+                msg=f"parse_spec({alias!r}).model must be the bare alias, not a combined form")
+
+    def test_resolve_candidate_anthropic_shortcuts(self) -> None:
+        """resolve_candidate on anthropic shortcuts must yield backend=claude-code,
+        model=bare alias (e.g. 'sonnet'), is_anthropic=True."""
+        for alias in ("sonnet", "opus", "haiku"):
+            spec = parse_spec(alias)
+            rc = resolve_candidate(spec)
+            self.assertEqual(rc.backend, "claude-code",
+                msg=f"backend for {alias!r} must be 'claude-code'")
+            self.assertEqual(rc.model, alias,
+                msg=f"model for {alias!r} must be bare alias, got {rc.model!r}")
+            self.assertTrue(rc.is_anthropic,
+                msg=f"is_anthropic must be True for {alias!r}")
+            self.assertNotIn("claude-code:", rc.model,
+                msg=f"rc.model for {alias!r} must not contain 'claude-code:'")
+
+
+class TestClaudeCodePrefix(unittest.TestCase):
+    def test_claude_code_explicit(self) -> None:
+        s = parse_spec("claude-code:sonnet")
+        self.assertEqual(s.provider, "claude-code")
+        self.assertEqual(s.model, "sonnet")
+        self.assertIsNone(s.endpoint)
+
+    def test_claude_code_full_id(self) -> None:
+        s = parse_spec("claude-code:claude-sonnet-4-6")
+        self.assertEqual(s.provider, "claude-code")
+        self.assertEqual(s.model, "claude-sonnet-4-6")
+        self.assertIsNone(s.endpoint)
+
+
+class TestOllamaPrefix(unittest.TestCase):
+    def test_simple_model(self) -> None:
+        s = parse_spec("ollama:qwen2.5-coder")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "qwen2.5-coder")
+        self.assertIsNone(s.endpoint)
+
+    def test_colon_tag_invariant(self) -> None:
+        """ollama:qwen2.5-coder:7b → (ollama, qwen2.5-coder:7b, default).
+
+        The inner colon in the model name must NOT be treated as a
+        provider/endpoint separator.
+        """
+        s = parse_spec("ollama:qwen2.5-coder:7b")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "qwen2.5-coder:7b")
+        self.assertIsNone(s.endpoint)
+
+    def test_colon_tag_32b(self) -> None:
+        s = parse_spec("ollama:qwen2.5-coder:32b")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "qwen2.5-coder:32b")
+        self.assertIsNone(s.endpoint)
+
+    def test_qwen3_tag(self) -> None:
+        s = parse_spec("ollama:qwen3.6:27b")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "qwen3.6:27b")
+        self.assertIsNone(s.endpoint)
+
+    def test_with_endpoint(self) -> None:
+        s = parse_spec("ollama:qwen2.5-coder:7b@http://192.168.1.10:11434")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "qwen2.5-coder:7b")
+        self.assertEqual(s.endpoint, "http://192.168.1.10:11434")
+
+
+class TestVllmPrefix(unittest.TestCase):
+    def test_model_with_endpoint(self) -> None:
+        s = parse_spec("vllm:Qwen3-Coder@http://127.0.0.1:8787")
+        self.assertEqual(s.provider, "vllm")
+        self.assertEqual(s.model, "Qwen3-Coder")
+        self.assertEqual(s.endpoint, "http://127.0.0.1:8787")
+
+    def test_model_with_host_endpoint(self) -> None:
+        s = parse_spec("vllm:RedHatAI/Qwen3-Coder-Next-NVFP4@http://192.168.1.23:8000")
+        self.assertEqual(s.provider, "vllm")
+        self.assertEqual(s.model, "RedHatAI/Qwen3-Coder-Next-NVFP4")
+        self.assertEqual(s.endpoint, "http://192.168.1.23:8000")
+
+    def test_no_endpoint(self) -> None:
+        s = parse_spec("vllm:SomeModel")
+        self.assertEqual(s.provider, "vllm")
+        self.assertEqual(s.model, "SomeModel")
+        self.assertIsNone(s.endpoint)
+
+
+class TestLmStudioPrefix(unittest.TestCase):
+    def test_simple(self) -> None:
+        s = parse_spec("lmstudio:phi-3")
+        self.assertEqual(s.provider, "lmstudio")
+        self.assertEqual(s.model, "phi-3")
+        self.assertIsNone(s.endpoint)
+
+    def test_with_endpoint(self) -> None:
+        s = parse_spec("lmstudio:phi-3@http://localhost:5678")
+        self.assertEqual(s.provider, "lmstudio")
+        self.assertEqual(s.model, "phi-3")
+        self.assertEqual(s.endpoint, "http://localhost:5678")
+
+
+class TestOpenrouterPrefix(unittest.TestCase):
+    def test_simple(self) -> None:
+        s = parse_spec("openrouter:meta-llama/llama-3-70b")
+        self.assertEqual(s.provider, "openrouter")
+        self.assertEqual(s.model, "meta-llama/llama-3-70b")
+        self.assertIsNone(s.endpoint)
+
+
+class TestEndpointParsing(unittest.TestCase):
+    def test_endpoint_only_at_final_at(self) -> None:
+        # @endpoint is the FINAL @-introduced segment.
+        s = parse_spec("ollama:some@model@http://host:11434")
+        self.assertEqual(s.provider, "ollama")
+        self.assertEqual(s.model, "some@model")
+        self.assertEqual(s.endpoint, "http://host:11434")
+
+    def test_no_at_sign_is_no_endpoint(self) -> None:
+        s = parse_spec("ollama:some-model-no-at")
+        self.assertIsNone(s.endpoint)
+
+
+class TestUnknownToken(unittest.TestCase):
+    def test_unknown_token_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            parse_spec("gpt-4o")
+        msg = str(cm.exception).lower()
+        self.assertIn("unknown provider token", msg)
+
+    def test_unknown_token_includes_did_you_mean(self) -> None:
+        # A token that looks like a mis-spelled known prefix should
+        # include a hint.
+        with self.assertRaises(ValueError) as cm:
+            parse_spec("llama:model")
+        msg = str(cm.exception)
+        self.assertIn("Unknown provider token", msg)
+
+    def test_bare_model_name_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_spec("claude-3-sonnet")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_compare.py
+++ b/scripts/benchmark_runner/tests/test_compare.py
@@ -444,5 +444,73 @@ class RunComparisonE2ETest(unittest.TestCase):
         self.assertNotIn("CCT_COMPARE_PROBE", os.environ)
 
 
+# ── D1 regression: legacy --config flow unaffected ─────────────────────
+
+
+class LegacyConfigRegressionTest(unittest.TestCase):
+    """Regression: the legacy ./scripts/benchmark compare --config <file> path
+    must be byte-for-byte unaffected by the D1 wrapper changes."""
+
+    def setUp(self) -> None:
+        _fresh_registry()
+        self.addCleanup(_register.unregister_all_for_tests)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runs_root = Path(self._tmp.name) / "runs"
+
+    def test_load_config_on_two_candidate_config(self) -> None:
+        raw = {
+            "benchmark": "stub",
+            "runs": 2,
+            "candidates": [
+                {"backend": "stub", "model": ""},
+                {"backend": "stub2", "model": ""},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "cfg.json"
+            p.write_text(json.dumps(raw), encoding="utf-8")
+            cfg = load_config(p)
+        self.assertEqual(cfg.benchmark, "stub")
+        self.assertEqual(cfg.runs, 2)
+        self.assertEqual(len(cfg.candidates), 2)
+
+    def test_single_candidate_still_rejected(self) -> None:
+        """compare's minItems:2 guard must remain intact after D1."""
+        raw = {
+            "benchmark": "stub",
+            "candidates": [{"backend": "stub"}],
+        }
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "bad.json"
+            p.write_text(json.dumps(raw), encoding="utf-8")
+            with self.assertRaisesRegex(CompareConfigError, "at least 2"):
+                load_config(p)
+
+    def test_end_to_end_run_comparison_still_works(self) -> None:
+        """run_comparison on a 2-candidate config produces the expected layout."""
+        cfg = CompareConfig(
+            benchmark="stub",
+            runs=1,
+            task_filter=None,
+            candidates=[
+                Candidate(name="alpha", backend="stub", model="", env={}),
+                Candidate(name="beta", backend="stub2", model="", env={}),
+            ],
+        )
+        run_dir = run_comparison(
+            cfg,
+            runs_root=self.runs_root,
+            timestamp="20260518T000000Z",
+            emit_report=False,
+        )
+        self.assertTrue(run_dir.is_dir())
+        self.assertTrue((run_dir / "compare-manifest.json").is_file())
+        self.assertTrue((run_dir / "candidate-runs.json").is_file())
+        # Both candidate run-dirs exist.
+        nested = [p for p in run_dir.iterdir() if p.is_dir()]
+        self.assertEqual(len(nested), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/benchmark_runner/tests/test_progress_heartbeat.py
+++ b/scripts/benchmark_runner/tests/test_progress_heartbeat.py
@@ -1,0 +1,576 @@
+# tests/test_progress_heartbeat.py — heartbeat thread and progress logger tests.
+#
+# Four test groups (spec.md T2.1 Done-when clause):
+#   (a) A fake attempt that sleeps > 2 heartbeat-intervals emits ≥2 heartbeats.
+#   (b) Tee-latency property: a heartbeat line is observable within ~1s of
+#       emission (use a short interval; assert timing, not a 60s real wait).
+#   (c) Start + end lines emitted exactly once each.
+#   (d) Backend-exception path: event cleared, end line emitted, thread
+#       does not leak (threading.active_count() returns to baseline).
+#
+# No real `claude` is spawned — all backend calls are mocked.
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from benchmark_runner._register import register_all, unregister_all_for_tests
+from benchmark_runner.contracts import (
+    ISOLATION_WORKTREE,
+    BackendResult,
+    IsolationConfig,
+    RunContext,
+    TaskSpec,
+    VerifyResult,
+)
+from benchmark_runner.progress import ProgressLogger
+from benchmark_runner.registry import register_adapter, register_backend
+from benchmark_runner.run import run_benchmark
+
+
+# ── Minimal test adapter ────────────────────────────────────────────────
+
+
+class _MinimalAdapter:
+    """Minimal benchmark adapter for heartbeat tests."""
+
+    benchmark_id = "heartbeat-test"
+
+    def __init__(self, verify_pass: bool = True) -> None:
+        self._verify_pass = verify_pass
+
+    def list_tasks(self) -> list[TaskSpec]:
+        return [TaskSpec(task_id="heartbeat/task", language="text")]
+
+    def isolation_for(self, task: TaskSpec) -> IsolationConfig:
+        return IsolationConfig(tier=ISOLATION_WORKTREE)
+
+    def prepare_task(self, task: TaskSpec, worktree: Path) -> None:
+        pass
+
+    def prompt_for(
+        self, task: TaskSpec, attempt: int, prior: object
+    ) -> str:
+        return f"attempt {attempt}"
+
+    def verify(self, task: TaskSpec, worktree: Path) -> VerifyResult:
+        return VerifyResult(
+            tests_passed=self._verify_pass, tests_output="ok"
+        )
+
+    def golden_patch(self, task: TaskSpec) -> Path:
+        return Path("/tmp")
+
+    def max_attempts(self) -> int:
+        return 1
+
+
+# ── Backend factories ───────────────────────────────────────────────────
+
+
+class _SleepingBackend:
+    """Backend that sleeps for `sleep_seconds` before returning."""
+
+    backend_id = "sleeping"
+
+    def __init__(self, sleep_seconds: float) -> None:
+        self._sleep = sleep_seconds
+
+    def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+        time.sleep(self._sleep)
+        return BackendResult(transcript_path=None, elapsed_seconds=self._sleep)
+
+
+class _RaisingBackend:
+    """Backend that always raises an exception."""
+
+    backend_id = "raising"
+
+    def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+        raise RuntimeError("synthetic backend failure")
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _capture_stderr_lines(fn) -> list[str]:
+    """Call fn(), capture stderr, return lines that look like progress output."""
+    buf = io.StringIO()
+    old_stderr = sys.stderr
+    sys.stderr = buf
+    try:
+        fn()
+    finally:
+        sys.stderr = old_stderr
+    return buf.getvalue().splitlines()
+
+
+# ── Test: heartbeat fires ≥2 times for a >2-interval attempt ────────────
+
+
+class TestHeartbeatFiresMultipleTimes(unittest.TestCase):
+    """(a) A fake attempt that sleeps > 2 heartbeat-intervals emits ≥2 heartbeats."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("heartbeat-test", _MinimalAdapter)
+        register_backend("sleeping", lambda model: _SleepingBackend(0.5))
+
+    def test_at_least_two_heartbeats_emitted(self) -> None:
+        # Use a very short interval (0.1s) so 0.5s of sleep produces ≥4.
+        # We only assert ≥2 to be conservative about scheduling jitter.
+        interval = 0.1
+        heartbeats: list[str] = []
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                # Patch ProgressLogger to use our short interval.
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "sleeping",
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        lines = _capture_stderr_lines(_run)
+        heartbeat_lines = [l for l in lines if "running..." in l]
+        self.assertGreaterEqual(
+            len(heartbeat_lines),
+            2,
+            f"Expected ≥2 heartbeat lines, got {len(heartbeat_lines)}. "
+            f"All stderr lines: {lines}",
+        )
+
+
+# ── Test: tee-latency — heartbeat line observable within ~1s ────────────
+
+
+class TestTeeLatency(unittest.TestCase):
+    """(b) Tee-latency: a heartbeat line is observable within ~1s of emission.
+
+    Methodology: use a short heartbeat interval (0.15s) so the first heartbeat
+    fires quickly. Capture stderr in a real-time manner using a pipe written by
+    the run_benchmark thread and a reader thread on the other end. Assert that
+    at least one heartbeat line is readable within 1.5s of the run starting.
+    """
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("heartbeat-test", _MinimalAdapter)
+        register_backend("sleeping", lambda model: _SleepingBackend(0.5))
+
+    def test_heartbeat_observable_within_one_second(self) -> None:
+        interval = 0.15  # first heartbeat fires after 0.15s
+        collected: list[str] = []
+        first_heartbeat_time: list[float] = []
+
+        class _CollectingLogger(ProgressLogger):
+            def emit_heartbeat(self, **kwargs):
+                t = time.monotonic()
+                first_heartbeat_time.append(t)
+                super().emit_heartbeat(**kwargs)
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=_CollectingLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "sleeping",
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        start = time.monotonic()
+        lines = _capture_stderr_lines(_run)
+        end = time.monotonic()
+
+        # Assert at least one heartbeat was emitted.
+        heartbeat_lines = [l for l in lines if "running..." in l]
+        self.assertGreater(
+            len(heartbeat_lines),
+            0,
+            f"No heartbeat lines emitted. All lines: {lines}",
+        )
+
+        # Assert the first heartbeat occurred within ~1s of the start
+        # (interval=0.15s + OS scheduling slack).
+        self.assertTrue(
+            first_heartbeat_time,
+            "No heartbeat timestamp was recorded.",
+        )
+        latency = first_heartbeat_time[0] - start
+        self.assertLess(
+            latency,
+            1.5,
+            f"First heartbeat latency {latency:.3f}s exceeded 1.5s budget.",
+        )
+
+
+# ── Test: start + end lines emitted exactly once each ───────────────────
+
+
+class TestStartAndEndLinesExactlyOnce(unittest.TestCase):
+    """(c) Start + end lines emitted exactly once each per attempt."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+
+    def _run_with_backend(self, backend_instance) -> list[str]:
+        register_adapter("heartbeat-test", _MinimalAdapter)
+        register_backend(backend_instance.backend_id, lambda model: backend_instance)
+        interval = 0.05
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        backend_instance.backend_id,
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        return _capture_stderr_lines(_run)
+
+    def test_start_emitted_once_on_normal_run(self) -> None:
+        unregister_all_for_tests()
+        lines = self._run_with_backend(_SleepingBackend(0.01))
+        start_lines = [l for l in lines if "starting..." in l]
+        self.assertEqual(
+            len(start_lines),
+            1,
+            f"Expected exactly 1 start line, got {len(start_lines)}. Lines: {lines}",
+        )
+
+    def test_end_emitted_once_on_normal_run(self) -> None:
+        unregister_all_for_tests()
+        lines = self._run_with_backend(_SleepingBackend(0.01))
+        end_lines = [
+            l for l in lines
+            if any(kw in l for kw in ("pass (", "fail (", "error (", "timeout after"))
+        ]
+        self.assertEqual(
+            len(end_lines),
+            1,
+            f"Expected exactly 1 end line, got {len(end_lines)}. Lines: {lines}",
+        )
+
+    def test_end_line_says_pass_when_tests_pass(self) -> None:
+        unregister_all_for_tests()
+        lines = self._run_with_backend(_SleepingBackend(0.01))
+        end_lines = [l for l in lines if "pass (" in l]
+        self.assertEqual(len(end_lines), 1, f"Expected 1 pass end-line. Lines: {lines}")
+
+    def test_multiple_runs_each_get_start_and_end(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("heartbeat-test", lambda: _MinimalAdapter(verify_pass=False))
+        register_backend("sleeping", lambda model: _SleepingBackend(0.01))
+        interval = 0.05
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "sleeping",
+                        runs=3,
+                        runs_root=Path(td),
+                    )
+
+        lines = _capture_stderr_lines(_run)
+        start_lines = [l for l in lines if "starting..." in l]
+        end_lines = [
+            l for l in lines
+            if any(kw in l for kw in ("pass (", "fail (", "error (", "timeout after"))
+        ]
+        self.assertEqual(len(start_lines), 3, f"Expected 3 start lines. Lines: {lines}")
+        self.assertEqual(len(end_lines), 3, f"Expected 3 end lines. Lines: {lines}")
+
+
+# ── Test: backend-exception path ─────────────────────────────────────────
+
+
+class TestBackendExceptionPath(unittest.TestCase):
+    """(d) Backend exception: event cleared, end line emitted, thread does not leak."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("heartbeat-test", _MinimalAdapter)
+        register_backend("raising", lambda model: _RaisingBackend())
+
+    def test_end_line_emitted_after_backend_exception(self) -> None:
+        interval = 0.05
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "raising",
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        lines = _capture_stderr_lines(_run)
+
+        # An end line must be emitted even when the backend raises.
+        end_lines = [
+            l for l in lines
+            if any(kw in l for kw in ("pass (", "fail (", "error (", "timeout after"))
+        ]
+        self.assertGreater(
+            len(end_lines),
+            0,
+            f"No end line emitted after backend exception. Lines: {lines}",
+        )
+
+    def test_thread_does_not_leak_after_backend_exception(self) -> None:
+        # Measure active thread count before and after a run where the
+        # backend raises. The heartbeat thread must be joined; active_count
+        # must return to its pre-run baseline.
+        interval = 0.05
+
+        # Allow a tiny settle window for any test-harness threads.
+        time.sleep(0.05)
+        baseline_count = threading.active_count()
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=interval),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "raising",
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        _capture_stderr_lines(_run)
+
+        # Give the join() a moment to settle in case of OS scheduling.
+        time.sleep(0.1)
+        final_count = threading.active_count()
+
+        self.assertLessEqual(
+            final_count,
+            baseline_count,
+            f"Thread leaked: baseline={baseline_count}, after={final_count}. "
+            f"Heartbeat thread was not properly joined.",
+        )
+
+    def test_event_is_cleared_after_backend_exception(self) -> None:
+        # The stop_event passed to the heartbeat thread must be cleared
+        # in the finally block, whether backend.run returns normally or
+        # raises. We test this by intercepting the ProgressLogger and
+        # capturing the event after the run completes.
+        interval = 0.05
+        captured_events: list[threading.Event] = []
+
+        original_run_heartbeat = ProgressLogger.run_heartbeat
+
+        def _patched_run_heartbeat(self_logger, *, stop_event, **kwargs):
+            captured_events.append(stop_event)
+            return original_run_heartbeat(self_logger, stop_event=stop_event, **kwargs)
+
+        with mock.patch.object(
+            ProgressLogger, "run_heartbeat", _patched_run_heartbeat
+        ):
+            def _run():
+                with tempfile.TemporaryDirectory() as td:
+                    with mock.patch(
+                        "benchmark_runner.run.ProgressLogger",
+                        return_value=ProgressLogger(heartbeat_interval=interval),
+                    ):
+                        run_benchmark(
+                            "heartbeat-test",
+                            "raising",
+                            runs=1,
+                            runs_root=Path(td),
+                        )
+
+            _capture_stderr_lines(_run)
+
+        self.assertEqual(
+            len(captured_events),
+            1,
+            f"Expected exactly 1 stop_event, got {len(captured_events)}",
+        )
+        # The stop-signal event must be SET after the attempt completes.
+        # The heartbeat thread uses "event.wait()" to detect stop;
+        # setting it causes the thread to exit its loop.
+        self.assertTrue(
+            captured_events[0].is_set(),
+            "stop_event was not set after the attempt completed — heartbeat thread was not signaled to stop.",
+        )
+
+
+# ── Test: idx/total counter values ──────────────────────────────────────
+
+
+class TestIdxTotalCounter(unittest.TestCase):
+    """idx/total values in progress lines are correct and never lie."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+
+    def test_single_run_shows_1_of_1(self) -> None:
+        register_adapter("heartbeat-test", _MinimalAdapter)
+        register_backend("sleeping", lambda model: _SleepingBackend(0.01))
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=0.05),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "sleeping",
+                        runs=1,
+                        runs_root=Path(td),
+                    )
+
+        lines = _capture_stderr_lines(_run)
+        # The start line should contain [1/1] (1 task × 1 run × 1 max_attempt).
+        start_lines = [l for l in lines if "starting..." in l]
+        self.assertEqual(len(start_lines), 1)
+        self.assertIn("[1/1]", start_lines[0], f"Expected [1/1] in: {start_lines[0]}")
+
+    def test_three_runs_shows_ascending_idx(self) -> None:
+        register_adapter("heartbeat-test", lambda: _MinimalAdapter(verify_pass=False))
+        register_backend("sleeping", lambda model: _SleepingBackend(0.01))
+
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=0.05),
+                ):
+                    run_benchmark(
+                        "heartbeat-test",
+                        "sleeping",
+                        runs=3,
+                        runs_root=Path(td),
+                    )
+
+        lines = _capture_stderr_lines(_run)
+        start_lines = [l for l in lines if "starting..." in l]
+        self.assertEqual(len(start_lines), 3)
+        # [1/3], [2/3], [3/3]
+        for i, line in enumerate(start_lines, start=1):
+            self.assertIn(f"[{i}/3]", line, f"Run {i}: expected [{i}/3] in: {line}")
+
+
+# ── Test: ProgressLogger unit tests ─────────────────────────────────────
+
+
+class TestProgressLoggerUnit(unittest.TestCase):
+    """Unit tests for ProgressLogger emit methods."""
+
+    def _capture_emit(self, fn) -> str:
+        buf = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = buf
+        try:
+            fn()
+        finally:
+            sys.stderr = old_stderr
+        return buf.getvalue()
+
+    def test_emit_start_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_start(
+            idx=2, total=6, candidate="claude-code:sonnet",
+            task="python/bowling", attempt=1,
+        ))
+        self.assertIn("[2/6]", out)
+        self.assertIn("claude-code:sonnet", out)
+        self.assertIn("python/bowling", out)
+        self.assertIn("attempt 1", out)
+        self.assertIn("starting...", out)
+
+    def test_emit_heartbeat_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_heartbeat(
+            idx=1, total=6, candidate="claude-code:sonnet",
+            task="python/bowling", attempt=1, elapsed_seconds=30.7,
+        ))
+        self.assertIn("[1/6]", out)
+        self.assertIn("running...", out)
+        self.assertIn("30s elapsed", out)
+
+    def test_emit_end_pass_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_end(
+            idx=1, total=6, candidate="claude-code:sonnet",
+            task="python/bowling", attempt=1,
+            result="pass", elapsed_seconds=87.3, tool_calls=12,
+        ))
+        self.assertIn("pass (", out)
+        self.assertIn("12 tool calls", out)
+
+    def test_emit_end_fail_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_end(
+            idx=1, total=6, candidate="ollama:qwen2.5-coder:7b",
+            task="python/bowling", attempt=2,
+            result="fail", elapsed_seconds=42.0, tool_calls=5,
+        ))
+        self.assertIn("fail (", out)
+        self.assertIn("5 tool calls", out)
+
+    def test_emit_end_error_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_end(
+            idx=3, total=6, candidate="stub",
+            task="stub-task", attempt=1,
+            result="error", elapsed_seconds=0.5,
+        ))
+        self.assertIn("error (", out)
+
+    def test_emit_end_timeout_format(self) -> None:
+        logger = ProgressLogger()
+        out = self._capture_emit(lambda: logger.emit_end(
+            idx=1, total=2, candidate="claude-code:sonnet",
+            task="python/bowling", attempt=1,
+            result="timeout", elapsed_seconds=300.0,
+        ))
+        self.assertIn("timeout after", out)
+        self.assertIn("skipping", out)
+
+    def test_default_interval_is_30s(self) -> None:
+        logger = ProgressLogger()
+        self.assertEqual(logger._interval, 30.0)  # noqa: SLF001
+
+    def test_injectable_interval(self) -> None:
+        logger = ProgressLogger(heartbeat_interval=0.5)
+        self.assertEqual(logger._interval, 0.5)  # noqa: SLF001
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_proxy_helper.py
+++ b/scripts/benchmark_runner/tests/test_proxy_helper.py
@@ -143,5 +143,54 @@ class TestHttpOk(unittest.TestCase):
             self.assertFalse(_http_ok("http://no-such-host:9999"))
 
 
+class TestEntrypointOrdering(unittest.TestCase):
+    """Regression: the T1.4 extraction placed the ``if __name__ ==
+    '__main__': main_cli()`` block mid-file, *before* the module-level
+    helpers (_graceful_kill / _http_ok / _read_tail). Running
+    ``python3 -m benchmark_runner.proxy`` executes top-to-bottom, so
+    main_cli() ran before those defs -> ``NameError: name '_http_ok'
+    is not defined``, caught only by the DGX pre-merge check
+    (2026-05-19). Invariant: every module-level def/class must precede
+    the ``__main__`` entrypoint block.
+    """
+
+    def test_entrypoint_block_is_after_all_module_level_defs(self) -> None:
+        import ast
+        from pathlib import Path
+
+        import benchmark_runner.proxy as proxy_mod
+
+        src = Path(proxy_mod.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+
+        last_def_lineno = max(
+            node.lineno
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        )
+        main_guard_lineno = None
+        for node in tree.body:
+            if (
+                isinstance(node, ast.If)
+                and isinstance(node.test, ast.Compare)
+                and isinstance(node.test.left, ast.Name)
+                and node.test.left.id == "__name__"
+            ):
+                main_guard_lineno = node.lineno
+                break
+
+        self.assertIsNotNone(
+            main_guard_lineno, "no `if __name__ == '__main__'` guard found in proxy.py"
+        )
+        self.assertGreater(
+            main_guard_lineno,
+            last_def_lineno,
+            'the `if __name__ == "__main__"` block must come AFTER every '
+            "module-level def/class — otherwise `python3 -m "
+            "benchmark_runner.proxy` calls main_cli() before later "
+            "helpers are defined (NameError). Move it to EOF.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/benchmark_runner/tests/test_proxy_helper.py
+++ b/scripts/benchmark_runner/tests/test_proxy_helper.py
@@ -1,0 +1,147 @@
+# tests/test_proxy_helper.py — LiteLLM proxy helper.
+#
+# Verifies:
+#   - Config emits the `hosted_vllm/` provider prefix (not `openai/`).
+#   - Teardown escalates SIGTERM → SIGKILL (subprocess mocked).
+#   - ProxyStartError raised when process dies during startup.
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from benchmark_runner.proxy import LiteLLMProxy, _graceful_kill, _http_ok
+
+
+class TestConfigEmitsHostedVllm(unittest.TestCase):
+    """Config written by LiteLLMProxy must use hosted_vllm/ prefix."""
+
+    def test_config_contains_hosted_vllm_prefix(self) -> None:
+        proxy = LiteLLMProxy(
+            vllm_base="http://192.168.1.23:8000",
+            vllm_model="RedHatAI/Qwen3-Coder-Next-NVFP4",
+            port=8787,
+        )
+        proxy._write_config()
+        try:
+            config_text = proxy._config_path.read_text(encoding="utf-8")
+            self.assertIn("hosted_vllm/", config_text)
+            self.assertNotIn("openai/RedHatAI", config_text)
+            self.assertIn("RedHatAI/Qwen3-Coder-Next-NVFP4", config_text)
+            self.assertIn("http://192.168.1.23:8000/v1", config_text)
+            self.assertIn("drop_params: true", config_text)
+        finally:
+            if proxy._config_path and proxy._config_path.exists():
+                proxy._config_path.unlink()
+            if proxy._log_path and proxy._log_path.exists():
+                proxy._log_path.unlink()
+
+    def test_config_api_key_is_dummy(self) -> None:
+        proxy = LiteLLMProxy("http://host:8000", "model")
+        proxy._write_config()
+        try:
+            config_text = proxy._config_path.read_text(encoding="utf-8")
+            self.assertIn('api_key: "dummy"', config_text)
+        finally:
+            if proxy._config_path and proxy._config_path.exists():
+                proxy._config_path.unlink()
+            if proxy._log_path and proxy._log_path.exists():
+                proxy._log_path.unlink()
+
+
+class TestGracefulKill(unittest.TestCase):
+    """_graceful_kill: SIGTERM → SIGKILL escalation."""
+
+    def test_sigterm_sufficient(self) -> None:
+        """Process that dies on SIGTERM should not escalate to SIGKILL."""
+        proc = mock.MagicMock(spec=subprocess.Popen)
+        proc.pid = 99999
+        proc.wait.return_value = 0  # exits promptly on first wait()
+
+        kill_calls = []
+        with mock.patch("os.getpgid", return_value=12345), \
+             mock.patch("os.killpg", side_effect=lambda pgid, sig: kill_calls.append(sig)):
+            _graceful_kill(proc, sigterm_timeout=5)
+
+        self.assertIn(signal.SIGTERM, kill_calls)
+        self.assertNotIn(signal.SIGKILL, kill_calls)
+
+    def test_sigkill_escalation_on_timeout(self) -> None:
+        """Process that doesn't exit on SIGTERM → SIGKILL after timeout."""
+        proc = mock.MagicMock(spec=subprocess.Popen)
+        proc.pid = 99999
+
+        # First wait() times out (process doesn't respond to SIGTERM);
+        # second wait() succeeds after SIGKILL.
+        proc.wait.side_effect = [subprocess.TimeoutExpired([], 5), 0]
+
+        kill_calls = []
+        with mock.patch("os.getpgid", return_value=12345), \
+             mock.patch("os.killpg", side_effect=lambda pgid, sig: kill_calls.append(sig)):
+            _graceful_kill(proc, sigterm_timeout=5)
+
+        self.assertIn(signal.SIGTERM, kill_calls)
+        self.assertIn(signal.SIGKILL, kill_calls)
+        # SIGTERM must come before SIGKILL.
+        self.assertLess(kill_calls.index(signal.SIGTERM), kill_calls.index(signal.SIGKILL))
+
+    def test_process_already_dead_no_error(self) -> None:
+        """ProcessLookupError on getpgid should be swallowed gracefully."""
+        proc = mock.MagicMock(spec=subprocess.Popen)
+        proc.pid = 99999
+        proc.wait.return_value = 0
+
+        with mock.patch("os.getpgid", side_effect=ProcessLookupError):
+            _graceful_kill(proc, sigterm_timeout=5)  # must not raise
+
+
+class TestProxyStartError(unittest.TestCase):
+    """ProxyStartError raised when the proxy dies during startup."""
+
+    def test_process_dies_during_startup_raises(self) -> None:
+        from benchmark_runner.proxy import ProxyStartError
+
+        proxy = LiteLLMProxy("http://host:8000", "model", startup_timeout=2)
+        proxy._write_config()
+
+        # Simulate a process that is immediately dead (poll() returns 1).
+        fake_proc = mock.MagicMock(spec=subprocess.Popen)
+        fake_proc.pid = 12345
+        fake_proc.poll.return_value = 1  # already exited
+
+        try:
+            with mock.patch.object(proxy, "_spawn", lambda: setattr(proxy, "_proc", fake_proc)), \
+                 mock.patch("benchmark_runner.proxy._http_ok", return_value=False):
+                with self.assertRaises(ProxyStartError):
+                    proxy._wait_healthy()
+        finally:
+            if proxy._config_path and proxy._config_path.exists():
+                proxy._config_path.unlink()
+            if proxy._log_path and proxy._log_path.exists():
+                proxy._log_path.unlink()
+
+
+class TestHttpOk(unittest.TestCase):
+    def test_returns_true_on_200(self) -> None:
+        resp = mock.MagicMock()
+        resp.__enter__ = mock.Mock(return_value=resp)
+        resp.__exit__ = mock.Mock(return_value=False)
+        resp.status = 200
+        with mock.patch("urllib.request.urlopen", return_value=resp):
+            self.assertTrue(_http_ok("http://example.com"))
+
+    def test_returns_false_on_exception(self) -> None:
+        import urllib.error
+        with mock.patch("urllib.request.urlopen",
+                        side_effect=urllib.error.URLError("no route")):
+            self.assertFalse(_http_ok("http://no-such-host:9999"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_timeout_classification.py
+++ b/scripts/benchmark_runner/tests/test_timeout_classification.py
@@ -1,0 +1,692 @@
+# tests/test_timeout_classification.py — D5 timeout classification + skip + aggregator flag.
+#
+# Test groups:
+#   A. Timeout detection: BackendResult.timed_out=True → result="timeout",
+#      scores.timeout=True, verify-output.txt contains harness note.
+#   B. Skip-to-next: timed-out attempt does NOT halt the campaign;
+#      the next attempt/run continues normally.
+#   C. Progress: end line contains "timeout after Ns — skipping".
+#   D. Aggregator: timed_out count in group summary; verify-output.txt
+#      contains harness note; verdict calculus unchanged (constraint #8).
+#   E. compare._validate / CompareConfig parse attempt_timeout_seconds.
+#   F. Timeout threading: RunContext.timeout_seconds carries the resolved value.
+#   G. Precedence: --attempt-timeout > preset > heuristic.
+#   H. load_config on local-vs-cloud.json retains attempt_timeout_seconds == 600.
+#
+# No real `claude` is spawned — all backends are in-process stubs.
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Optional
+from unittest import mock
+
+from benchmark_runner._register import register_all, unregister_all_for_tests
+from benchmark_runner.compare import (
+    CompareConfig,
+    CompareConfigError,
+    _validate,
+    load_config,
+)
+from benchmark_runner.contracts import (
+    ISOLATION_WORKTREE,
+    BackendResult,
+    IsolationConfig,
+    RunContext,
+    TaskSpec,
+    VerifyResult,
+)
+from benchmark_runner.progress import ProgressLogger
+from benchmark_runner.registry import register_adapter, register_backend
+from benchmark_runner.report import render_report
+from benchmark_runner.run import run_benchmark
+
+
+# ── Minimal test adapter ────────────────────────────────────────────────
+
+
+class _MinimalAdapter:
+    """Minimal benchmark adapter shared across all timeout test groups."""
+
+    benchmark_id = "timeout-test"
+
+    def __init__(self, verify_pass: bool = False) -> None:
+        self._verify_pass = verify_pass
+
+    def list_tasks(self) -> list[TaskSpec]:
+        return [TaskSpec(task_id="timeout/task", language="text")]
+
+    def isolation_for(self, task: TaskSpec) -> IsolationConfig:
+        return IsolationConfig(tier=ISOLATION_WORKTREE)
+
+    def prepare_task(self, task: TaskSpec, worktree: Path) -> None:
+        pass
+
+    def prompt_for(self, task: TaskSpec, attempt: int, prior: object) -> str:
+        return f"attempt {attempt}"
+
+    def verify(self, task: TaskSpec, worktree: Path) -> VerifyResult:
+        return VerifyResult(
+            tests_passed=self._verify_pass, tests_output=""
+        )
+
+    def golden_patch(self, task: TaskSpec) -> Path:
+        return Path("/tmp")
+
+    def max_attempts(self) -> int:
+        return 1
+
+
+# ── Timed-out backend stub ──────────────────────────────────────────────
+
+
+class _TimedOutBackend:
+    """Backend that signals it timed out (timed_out=True, exit_code=None).
+
+    Simulates exactly what ClaudeCodeBackend returns on TimeoutExpired —
+    without actually sleeping or spawning processes. Sets timed_out=True
+    so _classify_result picks up RESULT_TIMEOUT.
+    """
+
+    backend_id = "timed-out-stub"
+
+    def __init__(self, elapsed: float = 5.0) -> None:
+        self._elapsed = elapsed
+
+    def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+        return BackendResult(
+            transcript_path=None,
+            elapsed_seconds=self._elapsed,
+            failed_commands=1,
+            timed_out=True,
+            backend_metadata={
+                "family": "timed-out-stub",
+                "model": "",
+                "exit_code": None,
+                "note": f"claude -p timed out after {self._elapsed}s (process group killed)",
+            },
+        )
+
+
+class _NormalBackend:
+    """Backend that returns normally (no timeout)."""
+
+    backend_id = "normal-stub"
+
+    def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+        return BackendResult(transcript_path=None, elapsed_seconds=0.1)
+
+
+# ── Helper ──────────────────────────────────────────────────────────────
+
+
+def _capture_stderr(fn) -> list[str]:
+    buf = io.StringIO()
+    old = sys.stderr
+    sys.stderr = buf
+    try:
+        fn()
+    finally:
+        sys.stderr = old
+    return buf.getvalue().splitlines()
+
+
+# ── A. Timeout detection ────────────────────────────────────────────────
+
+
+class TestTimeoutDetection(unittest.TestCase):
+    """score.json reflects result=timeout, scores.timeout=True, verify-output.txt note."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("timeout-test", _MinimalAdapter)
+        register_backend("timed-out-stub", lambda model: _TimedOutBackend(elapsed=5.0))
+
+    def test_result_is_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_benchmark(
+                "timeout-test", "timed-out-stub", runs=1, runs_root=Path(td)
+            )
+            score = json.loads(next(run_dir.rglob("score.json")).read_text())
+        self.assertEqual(score["result"], "timeout")
+
+    def test_scores_timeout_true(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_benchmark(
+                "timeout-test", "timed-out-stub", runs=1, runs_root=Path(td)
+            )
+            score = json.loads(next(run_dir.rglob("score.json")).read_text())
+        self.assertTrue(score["scores"]["timeout"])
+
+    def test_verify_output_contains_harness_note(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_benchmark(
+                "timeout-test", "timed-out-stub", runs=1, runs_root=Path(td)
+            )
+            attempt_dirs = [p for p in run_dir.rglob("attempt-*") if p.is_dir()]
+            self.assertEqual(len(attempt_dirs), 1)
+            vo_path = attempt_dirs[0] / "verify-output.txt"
+            self.assertTrue(vo_path.exists(), "verify-output.txt must be written on timeout")
+            vo = vo_path.read_text()
+        self.assertIn("<harness-imposed timeout after", vo)
+
+    def test_non_timeout_backend_does_not_set_timeout_flag(self) -> None:
+        """Regression: normal returns must keep scores.timeout == False."""
+        unregister_all_for_tests()
+        register_adapter("timeout-test", lambda: _MinimalAdapter(verify_pass=True))
+        register_backend("normal-stub", lambda model: _NormalBackend())
+
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_benchmark(
+                "timeout-test", "normal-stub", runs=1, runs_root=Path(td)
+            )
+            score = json.loads(next(run_dir.rglob("score.json")).read_text())
+        self.assertFalse(score["scores"]["timeout"])
+        self.assertEqual(score["result"], "pass")
+
+
+# ── B. Skip-to-next ─────────────────────────────────────────────────────
+
+
+class TestSkipToNext(unittest.TestCase):
+    """A timed-out attempt does not halt the campaign; subsequent runs execute."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+
+    def test_multiple_runs_all_continue_after_timeout(self) -> None:
+        """With runs=3, all 3 runs execute even though each times out."""
+        register_adapter("timeout-test", _MinimalAdapter)
+        register_backend("timed-out-stub", lambda model: _TimedOutBackend())
+
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_benchmark(
+                "timeout-test", "timed-out-stub", runs=3, runs_root=Path(td)
+            )
+            scores = list(run_dir.rglob("score.json"))
+
+            self.assertEqual(len(scores), 3, "all 3 runs must execute even on timeout")
+            for s_path in scores:
+                s = json.loads(s_path.read_text())
+                self.assertEqual(s["result"], "timeout")
+
+    def test_mixed_timeout_and_normal_both_recorded(self) -> None:
+        """One timed-out backend + one normal backend in a two-candidate compare
+        both produce score files — the campaign does not abort on timeout."""
+        from benchmark_runner import _register
+        from benchmark_runner.compare import Candidate as Can, run_comparison
+
+        _register.unregister_all_for_tests()
+        from benchmarks.adapters.stub.adapter import register as register_stub_adapter
+        register_stub_adapter()
+        from benchmark_runner.backends.stub import factory as stub_factory
+        register_backend("stub", stub_factory)
+        register_backend("timed-out-stub", lambda model: _TimedOutBackend())
+
+        cfg2 = CompareConfig(
+            benchmark="stub",
+            runs=1,
+            candidates=[
+                Can(name="normal", backend="stub", model="", env={}),
+                Can(name="hung", backend="timed-out-stub", model="", env={}),
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = run_comparison(cfg2, runs_root=Path(td), emit_report=False)
+            scores = list(run_dir.rglob("score.json"))
+
+            self.assertEqual(len(scores), 2, "both candidates must produce a score.json")
+            results = {json.loads(p.read_text())["result"] for p in scores}
+        self.assertIn("pass", results, "normal candidate must pass")
+        self.assertIn("timeout", results, "timed-out candidate must record timeout")
+
+
+# ── C. Progress line ─────────────────────────────────────────────────────
+
+
+class TestTimeoutProgressLine(unittest.TestCase):
+    """The heartbeat end line reads 'timeout after Ns — skipping'."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("timeout-test", _MinimalAdapter)
+        register_backend("timed-out-stub", lambda model: _TimedOutBackend(elapsed=5.2))
+
+    def test_end_line_says_timeout_after_skipping(self) -> None:
+        def _run():
+            with tempfile.TemporaryDirectory() as td:
+                with mock.patch(
+                    "benchmark_runner.run.ProgressLogger",
+                    return_value=ProgressLogger(heartbeat_interval=0.05),
+                ):
+                    run_benchmark(
+                        "timeout-test", "timed-out-stub", runs=1, runs_root=Path(td)
+                    )
+
+        lines = _capture_stderr(_run)
+        end_lines = [l for l in lines if "timeout after" in l and "skipping" in l]
+        self.assertGreater(
+            len(end_lines),
+            0,
+            f"Expected a 'timeout after ... — skipping' line. All lines: {lines}",
+        )
+
+
+# ── D. Aggregator tally ──────────────────────────────────────────────────
+
+
+class TestAggregatorTimeoutTally(unittest.TestCase):
+    """report.py group summary carries timed_out count; verdict calculus unchanged.
+
+    Constraint #8 proof: given two otherwise-identical run-dirs where one
+    has a timeout attempt and the other has that attempt relabeled fail, the
+    verdict (pass_rate_verdict, elapsed_seconds_verdict, etc.) is identical.
+    """
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_all()
+
+    def _make_score(
+        self,
+        td: str,
+        result: str,
+        timeout_flag: bool,
+    ) -> Path:
+        """Write a minimal score.json + run-record.json for one attempt."""
+        attempt_dir = Path(td) / "attempt-01-run-001"
+        attempt_dir.mkdir(parents=True)
+        score = {
+            "schema_version": "1.0",
+            "benchmark_id": "stub",
+            "task_id": "stub/hello-world",
+            "backend_id": "stub",
+            "run_id": "run-001",
+            "attempt": 1,
+            "scores": {
+                "tests_passed": False,
+                "lint_passed": None,
+                "typecheck_passed": None,
+                "required_files_present": True,
+                "timeout": timeout_flag,
+                "human_interventions": 0,
+            },
+            "derived": {
+                "elapsed_seconds": 5.0,
+                "files_changed": 0,
+                "lines_added": 0,
+                "lines_removed": 0,
+                "failed_commands": 1,
+            },
+            "result": result,
+        }
+        rr = {
+            "backend_id": "stub",
+            "backend_invocation": {"model": ""},
+            "backend": {"metadata": {}},
+        }
+        (attempt_dir / "score.json").write_text(json.dumps(score))
+        (attempt_dir / "run-record.json").write_text(json.dumps(rr))
+        return Path(td)
+
+    def test_timed_out_count_in_group_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = self._make_score(td, result="timeout", timeout_flag=True)
+            render_report(run_dir)
+            summary = json.loads((run_dir / "report.json").read_text())
+
+        # The group summary must carry a timed_out count.
+        groups = summary["groups"]
+        self.assertEqual(len(groups), 1)
+        group = next(iter(groups.values()))
+        self.assertIn("timed_out", group, "group summary must carry timed_out")
+        self.assertEqual(group["timed_out"], 1)
+
+    def test_no_timeouts_timed_out_is_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = self._make_score(td, result="fail", timeout_flag=False)
+            render_report(run_dir)
+            summary = json.loads((run_dir / "report.json").read_text())
+        group = next(iter(summary["groups"].values()))
+        self.assertEqual(group["timed_out"], 0)
+
+    def test_markdown_shows_timed_out_line(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_dir = self._make_score(td, result="timeout", timeout_flag=True)
+            render_report(run_dir)
+            md = (run_dir / "report.md").read_text()
+        self.assertIn("Timed out:", md)
+
+    def test_constraint_8_verdict_calculus_unchanged(self) -> None:
+        """The same attempt recorded as 'timeout' vs 'fail' must produce
+        byte-identical verdicts — only the visible tally differs.
+
+        This is the constraint #8 proof. We use two groups in each run-dir
+        (one with timeout+timeout, one with fail+fail for the same candidates)
+        to get pairwise verdicts, and assert the verdict tuples match.
+        """
+        # Build a compare-style run-dir with two groups, both having the
+        # same (backend, model) but different candidate names so they group
+        # distinctly. One run-dir uses result="timeout"; the other uses
+        # result="fail" for the same attempts. Both must produce the same
+        # pairwise verdict tuple.
+        def _make_compare_run_dir(td: str, result: str, timeout_flag: bool) -> Path:
+            """Two candidates ('A', 'B'), each with 2 attempts, all with result."""
+            parent = Path(td)
+            # candidate-runs.json
+            for cand_name, backend_id in [("A", "stub"), ("B", "stub2")]:
+                cand_dir = parent / f"run-{cand_name}"
+                for attempt_n in range(1, 3):
+                    attempt_dir = cand_dir / f"task-stub--hello-world" / f"attempt-0{attempt_n}-run-001"
+                    attempt_dir.mkdir(parents=True)
+                    score = {
+                        "schema_version": "1.0",
+                        "benchmark_id": "stub",
+                        "task_id": "stub/hello-world",
+                        "backend_id": backend_id,
+                        "run_id": "run-001",
+                        "attempt": attempt_n,
+                        "scores": {
+                            "tests_passed": False,
+                            "lint_passed": None,
+                            "typecheck_passed": None,
+                            "required_files_present": True,
+                            "timeout": timeout_flag,
+                            "human_interventions": 0,
+                        },
+                        "derived": {
+                            "elapsed_seconds": 5.0,
+                            "files_changed": 0,
+                            "lines_added": 0,
+                            "lines_removed": 0,
+                            "failed_commands": 1,
+                        },
+                        "result": result,
+                    }
+                    rr = {
+                        "backend_id": backend_id,
+                        "backend_invocation": {"model": ""},
+                        "backend": {"metadata": {}},
+                    }
+                    (attempt_dir / "score.json").write_text(json.dumps(score))
+                    (attempt_dir / "run-record.json").write_text(json.dumps(rr))
+            candidate_runs = {
+                "candidates": [
+                    {"name": "A", "run_dir": "run-A"},
+                    {"name": "B", "run_dir": "run-B"},
+                ]
+            }
+            (parent / "candidate-runs.json").write_text(json.dumps(candidate_runs))
+            return parent
+
+        with tempfile.TemporaryDirectory() as td1:
+            run_dir_timeout = _make_compare_run_dir(td1, "timeout", True)
+            render_report(run_dir_timeout)
+            summary_timeout = json.loads((run_dir_timeout / "report.json").read_text())
+
+        with tempfile.TemporaryDirectory() as td2:
+            run_dir_fail = _make_compare_run_dir(td2, "fail", False)
+            render_report(run_dir_fail)
+            summary_fail = json.loads((run_dir_fail / "report.json").read_text())
+
+        # Extract the pairwise verdicts — must be identical across both reports.
+        pairs_t = summary_timeout["verdicts"]["pairwise"]
+        pairs_f = summary_fail["verdicts"]["pairwise"]
+        self.assertEqual(len(pairs_t), len(pairs_f))
+        for pt, pf in zip(pairs_t, pairs_f):
+            self.assertEqual(
+                pt["pass_rate_verdict"],
+                pf["pass_rate_verdict"],
+                "pass_rate_verdict must be identical for timeout vs fail",
+            )
+            self.assertEqual(
+                pt["elapsed_seconds_verdict"],
+                pf["elapsed_seconds_verdict"],
+                "elapsed_seconds_verdict must be identical",
+            )
+            self.assertEqual(
+                pt["failed_commands_verdict"],
+                pf["failed_commands_verdict"],
+                "failed_commands_verdict must be identical",
+            )
+            self.assertEqual(
+                pt["human_interventions_verdict"],
+                pf["human_interventions_verdict"],
+                "human_interventions_verdict must be identical",
+            )
+
+        # But the timeout tally DOES differ.
+        group_t = next(iter(summary_timeout["groups"].values()))
+        group_f = next(iter(summary_fail["groups"].values()))
+        self.assertGreater(group_t["timed_out"], 0, "timeout run-dir must show timed_out > 0")
+        self.assertEqual(group_f["timed_out"], 0, "fail run-dir must show timed_out == 0")
+
+
+# ── E. compare._validate attempt_timeout_seconds ────────────────────────
+
+
+class TestCompareValidateTimeout(unittest.TestCase):
+    """compare._validate parses and validates attempt_timeout_seconds."""
+
+    def _base(self) -> dict:
+        return {
+            "benchmark": "stub",
+            "candidates": [
+                {"backend": "stub"},
+                {"backend": "stub2"},
+            ],
+        }
+
+    def test_valid_positive_integer_accepted(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = 300
+        cfg = _validate(raw)
+        self.assertEqual(cfg.attempt_timeout_seconds, 300)
+
+    def test_absent_is_none(self) -> None:
+        cfg = _validate(self._base())
+        self.assertIsNone(cfg.attempt_timeout_seconds)
+
+    def test_rejects_zero(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = 0
+        with self.assertRaisesRegex(CompareConfigError, "positive integer"):
+            _validate(raw)
+
+    def test_rejects_negative(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = -60
+        with self.assertRaisesRegex(CompareConfigError, "positive integer"):
+            _validate(raw)
+
+    def test_rejects_bool(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = True
+        with self.assertRaisesRegex(CompareConfigError, "positive integer"):
+            _validate(raw)
+
+    def test_rejects_float(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = 300.5
+        with self.assertRaisesRegex(CompareConfigError, "positive integer"):
+            _validate(raw)
+
+    def test_rejects_string(self) -> None:
+        raw = self._base()
+        raw["attempt_timeout_seconds"] = "300"
+        with self.assertRaisesRegex(CompareConfigError, "positive integer"):
+            _validate(raw)
+
+    def test_load_config_local_vs_cloud_retains_600(self) -> None:
+        """load_config on the committed local-vs-cloud.json retains attempt_timeout_seconds==600."""
+        presets_dir = (
+            Path(__file__).resolve().parent.parent.parent.parent
+            / "benchmarks" / "presets"
+        )
+        preset_path = presets_dir / "local-vs-cloud.json"
+        self.assertTrue(preset_path.exists(), f"preset not found: {preset_path}")
+        cfg = load_config(preset_path)
+        self.assertEqual(
+            cfg.attempt_timeout_seconds,
+            600,
+            "local-vs-cloud.json must retain attempt_timeout_seconds == 600",
+        )
+
+
+# ── F. Timeout threading into RunContext ─────────────────────────────────
+
+
+class TestTimeoutThreading(unittest.TestCase):
+    """attempt_timeout_seconds flows from run_benchmark → RunContext.timeout_seconds."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+
+    def test_run_context_carries_timeout(self) -> None:
+        """Backend receives RunContext.timeout_seconds == the value passed to run_benchmark."""
+        seen_timeouts: list[Optional[int]] = []
+
+        class _SpyBackend:
+            backend_id = "spy"
+
+            def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+                seen_timeouts.append(ctx.timeout_seconds)
+                return BackendResult(transcript_path=None, elapsed_seconds=0.1)
+
+        register_adapter("timeout-test", lambda: _MinimalAdapter(verify_pass=True))
+        register_backend("spy", lambda model: _SpyBackend())
+
+        with tempfile.TemporaryDirectory() as td:
+            run_benchmark(
+                "timeout-test", "spy", runs=1, runs_root=Path(td),
+                attempt_timeout_seconds=42,
+            )
+
+        self.assertEqual(seen_timeouts, [42], f"Expected [42], got {seen_timeouts}")
+
+    def test_none_timeout_passes_none_to_run_context(self) -> None:
+        seen_timeouts: list[Optional[int]] = []
+
+        class _SpyBackend:
+            backend_id = "spy2"
+
+            def run(self, prompt: str, ctx: RunContext) -> BackendResult:
+                seen_timeouts.append(ctx.timeout_seconds)
+                return BackendResult(transcript_path=None, elapsed_seconds=0.1)
+
+        register_adapter("timeout-test", lambda: _MinimalAdapter(verify_pass=True))
+        register_backend("spy2", lambda model: _SpyBackend())
+
+        with tempfile.TemporaryDirectory() as td:
+            run_benchmark(
+                "timeout-test", "spy2", runs=1, runs_root=Path(td),
+                # No attempt_timeout_seconds → None
+            )
+
+        self.assertEqual(seen_timeouts, [None])
+
+
+# ── G. Precedence unit tests ─────────────────────────────────────────────
+
+
+class TestTimeoutPrecedence(unittest.TestCase):
+    """_resolve_timeout precedence: explicit > preset > heuristic."""
+
+    def setUp(self) -> None:
+        # Import the private function directly for unit testing.
+        from benchmark_runner.bench import _resolve_timeout, ResolvedCandidate
+        self._resolve = _resolve_timeout
+        self._RC = ResolvedCandidate
+
+    def _cloud_candidate(self) -> object:
+        return self._RC(name="x", backend="claude-code", model="sonnet", env={}, is_anthropic=True)
+
+    def _local_candidate(self) -> object:
+        return self._RC(
+            name="y", backend="claude-code", model="qwen",
+            env={"ANTHROPIC_BASE_URL": "http://localhost:11434"}, is_anthropic=False,
+        )
+
+    def test_explicit_overrides_preset(self) -> None:
+        result = self._resolve(explicit=999, preset_timeout=600, candidates=[self._cloud_candidate()])
+        self.assertEqual(result, 999)
+
+    def test_explicit_overrides_heuristic(self) -> None:
+        result = self._resolve(explicit=42, candidates=[self._local_candidate()])
+        self.assertEqual(result, 42)
+
+    def test_preset_overrides_heuristic(self) -> None:
+        result = self._resolve(preset_timeout=777, candidates=[self._cloud_candidate()])
+        self.assertEqual(result, 777)
+
+    def test_heuristic_cloud_is_300(self) -> None:
+        result = self._resolve(candidates=[self._cloud_candidate()])
+        self.assertEqual(result, 300)
+
+    def test_heuristic_local_is_600(self) -> None:
+        result = self._resolve(candidates=[self._local_candidate()])
+        self.assertEqual(result, 600)
+
+    def test_heuristic_any_local_candidate_triggers_600(self) -> None:
+        """If ANY candidate is local, use the local (600s) heuristic."""
+        result = self._resolve(candidates=[self._cloud_candidate(), self._local_candidate()])
+        self.assertEqual(result, 600)
+
+    def test_no_candidates_returns_none(self) -> None:
+        result = self._resolve(candidates=[])
+        self.assertIsNone(result)
+
+
+# ── H. load_config retains attempt_timeout_seconds ──────────────────────
+# (Covered by TestCompareValidateTimeout.test_load_config_local_vs_cloud_retains_600 above.)
+
+
+# ── I. run_benchmark validates attempt_timeout_seconds ──────────────────
+
+
+class TestRunBenchmarkTimeoutValidation(unittest.TestCase):
+    """run_benchmark rejects non-positive or bool attempt_timeout_seconds."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+        register_adapter("timeout-test", _MinimalAdapter)
+        register_backend("normal-stub", lambda model: _NormalBackend())
+
+    def _run(self, timeout_val) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            run_benchmark(
+                "timeout-test", "normal-stub", runs=1,
+                runs_root=Path(td), attempt_timeout_seconds=timeout_val,
+            )
+
+    def test_zero_raises_value_error(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            self._run(0)
+
+    def test_negative_raises_value_error(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            self._run(-5)
+
+    def test_bool_raises_value_error(self) -> None:
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            self._run(True)
+
+    def test_none_does_not_raise(self) -> None:
+        # attempt_timeout_seconds=None is the default — must proceed normally.
+        self._run(None)  # no exception
+
+    def test_positive_int_does_not_raise(self) -> None:
+        # attempt_timeout_seconds=300 is valid.
+        self._run(300)  # no exception
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run-compare-anthropic-vs-vllm.sh
+++ b/scripts/run-compare-anthropic-vs-vllm.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # scripts/run-compare-anthropic-vs-vllm.sh
 #
+# NOTE: This script is one way to run an Anthropic-vs-vLLM comparison.
+# `./scripts/bench` is the daily tool — either is supported. The
+# LiteLLM proxy lifecycle below is now powered by the shared
+# benchmark_runner/proxy.py helper (extracted 2026-05-18).
+#
 # Automated 2-LLM benchmark: Claude Code → <anthropic-model> (Anthropic API)
 # vs. Claude Code → <vllm-model> (remote vLLM on an NVIDIA DGX Spark),
 # on Aider Polyglot.
@@ -9,7 +14,7 @@
 #
 #   claude-code  ──Anthropic shape──▶  LiteLLM proxy        ──OpenAI shape──▶  vLLM
 #   (claude -p)   /v1/messages         127.0.0.1:8787                          192.168.1.23:8000
-#                                      (this script starts & kills it)         /v1/chat/completions
+#                                      (proxy.py manages lifecycle)            /v1/chat/completions
 #
 #   Why the proxy: vLLM exposes an OpenAI-compatible API only
 #   (/v1/chat/completions, /v1/models). It does NOT serve an
@@ -106,7 +111,7 @@ set -euo pipefail
 # --- Help ---
 case "${1:-}" in
     -h|--help)
-        sed -n '2,102p' "$0" | sed -E 's/^# ?//'
+        sed -n '2,107p' "$0" | sed -E 's/^# ?//'
         exit 0
         ;;
 esac
@@ -135,11 +140,11 @@ LITELLM_PROXY_BASE="http://127.0.0.1:${LITELLM_PROXY_PORT}"
 # mid-conversation, 131072 runs clean 3/3.
 CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000
 VLLM_CTX_RECOMMENDED=131072
-# Per-run unique paths: two concurrent runs with different models/ports
-# must not clobber each other's config/log, and both are removed by the
-# trap on exit.
-LITELLM_CONFIG="$(mktemp -t cct-litellm-vllm.XXXXXX.yaml)"
-LITELLM_LOG="$(mktemp -t cct-litellm-vllm.XXXXXX.log)"
+# These are assigned by start_litellm_proxy() (via proxy.py) at runtime.
+# Declared empty here so cleanup() can reference them under `set -u`
+# even on an early exit before the proxy is started.
+LITELLM_CONFIG=""
+LITELLM_LOG=""
 # Same rule for the preflight scratch files (vLLM /v1/models dump,
 # harness registry dump) — mktemp'd, trap-removed.
 VLLM_MODELS_JSON="$(mktemp -t cct-vllm-models.XXXXXX.json)"
@@ -259,60 +264,41 @@ trap cleanup EXIT
 trap on_signal INT TERM HUP
 
 start_litellm_proxy() {
-    # 1. litellm present? It is pip-installed into the ephemeral venv by
-    #    setup_venv before any stage; this guards against a silent
-    #    install failure (pip succeeded but no console-script on PATH).
+    # Delegate to the shared proxy.py helper (benchmark_runner/proxy.py).
+    # This is the single source of truth for the LiteLLM lifecycle, the
+    # hosted_vllm/ prefix, and the SIGTERM→SIGKILL teardown shape.
+    # (Previously this function carried its own copy; extracted 2026-05-18.)
     if ! command -v litellm > /dev/null; then
         err "litellm missing after venv provisioning — inspect the pip output above"
         exit 1
     fi
     ok "litellm present in venv: $(litellm --version 2>/dev/null | head -1 || echo 'version unknown')"
 
-    # 2. Write the translation config. One alias that maps Anthropic-
-    #    shaped traffic to the remote vLLM's OpenAI API. The hosted_vllm/
-    #    prefix routes through LiteLLM's purpose-built vLLM adapter, which
-    #    pins to /v1/chat/completions. The generic openai/ provider on
-    #    LiteLLM >= 1.50 auto-detects vLLM's advertised /v1/responses
-    #    endpoint and routes multi-turn conversations through it; vLLM's
-    #    Responses API rejects LiteLLM's input-array shape with a
-    #    212-validation-error 400 (agent solves task at turn ~9, dies at
-    #    turn ~10 on the next continuation). hosted_vllm/ avoids that
-    #    route discovery. api_key is required by the SDK; vLLM ignores it.
-    cat > "$LITELLM_CONFIG" <<EOF
-model_list:
-  - model_name: "$VLLM_MODEL"
-    litellm_params:
-      model: "hosted_vllm/$VLLM_MODEL"
-      api_base: "${VLLM_BASE%/}/v1"
-      api_key: "dummy"
-litellm_settings:
-  drop_params: true
-EOF
-    ok "LiteLLM config written: $LITELLM_CONFIG"
+    note "Starting LiteLLM proxy on ${LITELLM_PROXY_BASE} → ${VLLM_BASE%/}/v1 (via proxy.py)…"
+    local proxy_output
+    proxy_output=$(
+        PYTHONPATH="${REPO_DIR}/scripts:${REPO_DIR}" \
+        python3 -m benchmark_runner.proxy start \
+            --vllm-base "$VLLM_BASE" \
+            --model "$VLLM_MODEL" \
+            --port "$LITELLM_PROXY_PORT" 2>&1
+    ) || {
+        err "proxy.py failed to start the LiteLLM proxy. Output:"
+        printf '%s\n' "$proxy_output" >&2
+        exit 1
+    }
 
-    # 3. Start the proxy in the background; capture PID for the trap.
-    note "Starting LiteLLM proxy on ${LITELLM_PROXY_BASE} → ${VLLM_BASE%/}/v1 …"
-    litellm --config "$LITELLM_CONFIG" --port "$LITELLM_PROXY_PORT" --host 127.0.0.1 \
-        > "$LITELLM_LOG" 2>&1 &
-    LITELLM_PID=$!
+    # Parse pid=, config=, log= from proxy output.
+    LITELLM_PID=$(printf '%s\n' "$proxy_output" | grep '^pid=' | cut -d= -f2-)
+    LITELLM_CONFIG=$(printf '%s\n' "$proxy_output" | grep '^config=' | cut -d= -f2-)
+    LITELLM_LOG=$(printf '%s\n' "$proxy_output" | grep '^log=' | cut -d= -f2-)
 
-    # 4. Wait up to 30s for /v1/models to answer.
-    local i
-    for i in $(seq 1 30); do
-        if ! kill -0 "$LITELLM_PID" 2>/dev/null; then
-            err "LiteLLM proxy process died during startup. Log:"
-            tail -40 "$LITELLM_LOG" >&2 || true
-            exit 1
-        fi
-        if curl -sS --max-time 2 "${LITELLM_PROXY_BASE}/v1/models" > /dev/null 2>&1; then
-            ok "LiteLLM proxy up (PID $LITELLM_PID), /v1/models responding"
-            return 0
-        fi
-        sleep 1
-    done
-    err "LiteLLM proxy did not answer /v1/models within 30s. Log:"
-    tail -40 "$LITELLM_LOG" >&2 || true
-    exit 1
+    if [[ -z "$LITELLM_PID" ]]; then
+        err "proxy.py did not print a PID. Output:"
+        printf '%s\n' "$proxy_output" >&2
+        exit 1
+    fi
+    ok "LiteLLM proxy up (PID $LITELLM_PID), /v1/models responding"
 }
 
 # --- Print parsed config ---

--- a/specs/benchmark-bench-driver/origin-alignment-2026-05-18-1900.md
+++ b/specs/benchmark-bench-driver/origin-alignment-2026-05-18-1900.md
@@ -1,0 +1,55 @@
+# Origin-Alignment Record — benchmark-bench-driver
+
+Date: 2026-05-18 19:00 UTC
+Gate: plan-approval (Phase A, pre-build)
+Origin: gosha70/code-copilot-team#36 (issue body + 2026-05-18 user clarifications)
+
+## What the user asked for
+
+Issue #36: a single user-facing `scripts/bench` wrapper with safe
+defaults, terse `provider:model[@endpoint]` specs, live progress to
+stderr, a per-attempt timeout with skip-to-next, a three-preset
+library, and a README quickstart rewrite — **without changing the
+harness's verdict logic**. Five tightly-coupled deliverables D1–D5 with
+a verbatim out-of-scope list.
+
+## What the spec/plan commit to
+
+A wrapper that resolves every invocation to the unchanged
+`compare`/`report` path; D1–D5 delivered in the issue's sequenced
+order; the verbatim out-of-scope list reproduced as binding
+constraints; no verdict/scoring/isolation change (D5 adds only a
+`timeout` result value counted as a failure).
+
+## Divergences (documented, user-confirmed 2026-05-18)
+
+1. **D2/D5 built on the merged PR #35 Popen+pgkill**, not the issue's
+   stale `subprocess.run` premise. Intent + acceptance criteria
+   unchanged. (OQ-3 → "build on existing, document divergence".)
+2. **D1 vLLM env-fill → probe-then-decide** (user-proxy vs.
+   ephemeral-proxy auto-detect) because Claude Code cannot speak raw
+   vLLM. (OQ-2.)
+3. **Legacy `run-compare-*.sh` kept + shared proxy helper extracted**,
+   not superseded/deleted. No capability discarded. (OQ-1.)
+
+All three are recorded in spec.md § "Deviation from origin" and were
+explicitly chosen by the user via the 2026-05-18 clarification
+exchange. They refine implementation basis; they do not rescope the
+deliverables or breach the out-of-scope list.
+
+## Assessment
+
+- Out-of-scope list: reproduced verbatim and binding. No scope creep
+  (the proxy helper is extraction of existing logic, not a new
+  backend/adapter/report).
+- Acceptance criteria: every issue #36 acceptance bullet maps to a
+  Success Criterion and a task.
+- Verdict logic: untouched.
+
+Verdict: aligned
+Confidence: high
+
+Divergences are documented and user-approved → origin-confirmation
+gate is satisfied for the plan-approval gate. Re-run
+`scripts/check-origin-alignment.sh benchmark-bench-driver` at the
+build-entry and phase-complete gates.

--- a/specs/benchmark-bench-driver/origin-alignment-2026-05-19-0102.md
+++ b/specs/benchmark-bench-driver/origin-alignment-2026-05-19-0102.md
@@ -1,0 +1,63 @@
+# Origin-Alignment Record — benchmark-bench-driver
+
+Date: 2026-05-19 01:02 UTC
+Gate: phase-complete (Phase B done — all five deliverables built, reviewed, committed)
+Origin: gosha70/code-copilot-team#36 (issue body + 2026-05-18/19 user clarifications)
+Supersedes: origin-alignment-2026-05-18-1900.md (plan-approval gate)
+
+## What shipped vs. what the user asked for
+
+Issue #36's five deliverables, all built, peer-reviewed, and committed
+on `feat/benchmark-bench-driver` in the issue's sequenced order:
+
+- D3 `dfc85c7` — three preset compare-configs + schema field.
+- D1 `68f1d5b` — `scripts/bench` wrapper, parser, env-fill, safe
+  defaults, confirmation gate, discovery, shared proxy helper.
+- D2 `2202f72` — live progress heartbeat to stderr.
+- D5 `10c590b` — per-attempt timeout + `result:"timeout"`
+  classification.
+- D4 `746d162` — README 60-second quickstart.
+
+Every issue #36 acceptance bullet maps to a shipped Success Criterion.
+The verbatim out-of-scope list was reproduced as binding constraints
+and not breached. Verdict/scoring/isolation logic unchanged (D5 adds
+only the `timeout` result value, counted as a failure — constraint #8
+verified: `report_winner.py` has zero timeout references).
+
+## Documented divergences (all user-confirmed)
+
+From the plan-approval record (unchanged): OQ-1 keep+extract legacy
+scripts; OQ-2 vLLM probe-then-decide; OQ-3 D2/D5 built on the merged
+PR #35 Popen+pgkill. Plus two surfaced during Phase B:
+
+- **OQ-4 (single-candidate routing).** issue #36's `cross-language-mini`
+  is one candidate; `compare` requires ≥2. The wrapper routes a
+  1-candidate invocation/preset to `./scripts/benchmark run`; the
+  compare schema's `minItems:2` guard is untouched. User-confirmed
+  2026-05-18. Recorded in spec.md § Design Decisions.
+- **Structured timeout signal.** D5 adds `BackendResult.timed_out:
+  bool` (default False) rather than substring-matching the human
+  `note` — a minimal, backward-compatible contracts-level addition;
+  the claude-code kill path is unchanged. Recorded in spec.md
+  § Deviation from origin / D5 contract.
+
+Both refine implementation basis; neither rescopes a deliverable nor
+breaches the out-of-scope list.
+
+## Outstanding pre-merge operational gate (not a divergence)
+
+`./scripts/run-compare-anthropic-vs-vllm.sh sonnet
+RedHatAI/Qwen3-Coder-Next-NVFP4` must be run against the operator's
+DGX Spark before merge — T1.4 extracted the verified LiteLLM launch
+recipe into `proxy.py`; the DGX is LAN-only and unreachable from the
+build environment. Captured in tasks.md and the PR description.
+
+## Assessment
+
+- Out-of-scope list: intact, no creep.
+- Acceptance criteria: all mapped + verified (369 per-module tests
+  pass; zero-config smoke + forced-hang E2E executed).
+- Divergences: documented + user-approved.
+
+Verdict: aligned
+Confidence: high

--- a/specs/benchmark-bench-driver/plan.md
+++ b/specs/benchmark-bench-driver/plan.md
@@ -1,0 +1,257 @@
+---
+spec_mode: full
+feature_id: benchmark-bench-driver
+risk_category: integration
+justification: "New user-facing wrapper translating a terse CLI into the existing compare-config JSON, touching scripts/ (new scripts/bench shim + benchmark_runner/bench.py + benchmark_runner/proxy.py), benchmarks/presets/ (new), benchmarks/README.md, and threading a timeout signal through run.py + claude_code.py classification. External integrations: Ollama/LM Studio HTTP probes, an ephemeral LiteLLM Anthropic→OpenAI proxy for raw-vLLM endpoints. Multi-deliverable single-PR delivery with regression coverage of the unchanged JSON config flow. The harness verdict/scoring/isolation logic is NOT modified; D5 adds a timeout result value only."
+status: draft
+date: 2026-05-18
+issue: 36
+origin:
+  issue: gosha70/code-copilot-team#36
+  urls:
+    - https://github.com/gosha70/code-copilot-team/issues/36
+    - https://github.com/gosha70/code-copilot-team/pull/35
+    - https://github.com/gosha70/code-copilot-team/issues/32
+    - https://github.com/ollama/ollama/releases
+    - https://code.claude.com/docs/en/llm-gateway
+    - https://code.claude.com/docs/en/headless
+  origin_claim: |
+    See spec.md `origin:` block. Issue #36 asks for a single
+    user-facing scripts/bench wrapper with safe defaults, terse
+    provider:model[@endpoint] specs, live progress, per-attempt
+    timeout + skip-to-next, a three-preset library, and a README
+    quickstart rewrite — without changing harness verdict logic.
+    Three planning decisions taken with the user 2026-05-18 refine
+    D1's vLLM path (probe-then-decide), the legacy-script fate (keep +
+    extract a shared proxy helper), and the D2/D5 basis (build on the
+    merged PR #35 Popen+pgkill, not re-introduce it). See spec.md
+    § Deviation from origin.
+---
+
+# Implementation Plan — Benchmark `bench` Driver
+
+> **Wrapper, not a rewrite.** This plan accompanies
+> `specs/benchmark-bench-driver/spec.md`. It changes no verdict,
+> scoring, isolation, or run-record logic. Three origin refinements
+> are recorded in spec.md § "Deviation from origin"; the
+> origin-alignment record dated alongside this plan covers them.
+
+## Approach
+
+One feature branch, **one PR** (issue #36 mandates a single PR; per the
+project rule a merged PR fully addresses its issue). Delivered in the
+issue's own sequenced order — D3 → D1 → D2 → D5 → D4 — because each
+later deliverable references the earlier one and D5 depends on D2's
+heartbeat infrastructure. Each deliverable ends with a reviewable
+commit and a working slice (the harness is runnable end-to-end after
+every commit; the JSON config flow never regresses).
+
+The wrapper is Python (`benchmark_runner/bench.py`) behind a thin
+`scripts/bench` bash shim, mirroring `scripts/benchmark`. It resolves
+every invocation to a compare-config and calls the **unchanged**
+`compare.run_comparison` + `report.render_report`. The only edits to
+existing harness modules are: a heartbeat hook in
+`run._execute_attempt` (D2), a `result: "timeout"` classification path
+in `run.py` + the aggregator (D5), and a one-paragraph header note in
+the two legacy scripts plus their adoption of the extracted proxy
+helper.
+
+## Phase boundaries
+
+| Deliverable | Working slice | Gate |
+|---|---|---|
+| D3 presets | 3 JSON presets validate against the compare-config schema | `./scripts/benchmark compare --config benchmarks/presets/anthropic-tour.json` parses (dry validation) |
+| D1 wrapper | `scripts/bench` parses, env-fills, gates, smokes, lists | stub×stub smoke green; parser unit tests green; legacy JSON flow regression green |
+| D2 progress | heartbeat thread + flush discipline | progress arrives < 1s under `2>&1 \| tee` (automated test) |
+| D5 timeout | per-attempt timeout + `result:"timeout"` + skip | forced-hang test: killed, classified, campaign continues |
+| D4 README | quickstart promoted, JSON demoted | README links resolve; quickstart is first section |
+
+## D3 — Preset library (~30 min)
+
+**Goal:** Three committed compare-configs under `benchmarks/presets/`.
+Lowest risk, useful even if everything else slips.
+
+- `anthropic-tour.json` — sonnet vs opus vs haiku, one Python task,
+  3 runs. Anthropic-auth only.
+- `local-vs-cloud.json` — sonnet + 2 Ollama candidates, 2 polyglot
+  tasks, 3 runs, `attempt_timeout_seconds: 600`.
+- `cross-language-mini.json` — sonnet alone on python/bowling,
+  go/bowling, rust/bowling, 3 runs (single-candidate bench preset;
+  the snapshot has no `*/leap` and no `rust/clock`, so the issue's
+  literal task examples are substituted with `bowling`, which exists
+  in python/go/java/javascript/rust).
+- D3 also adds an optional top-level `attempt_timeout_seconds`
+  (integer ≥ 1) to `compare-config.schema.json` so `local-vs-cloud`
+  validates; the runtime wiring lands in D5.
+
+**Acceptance:** `anthropic-tour` + `local-vs-cloud` validate against
+`benchmarks/schema/compare-config.schema.json`; `cross-language-mini`
+validates against the documented single-candidate bench-preset shape
+(NOT the compare schema — compare's minItems:2 guard stays untouched);
+all task ids exist in the pinned Polyglot snapshot.
+
+## D1 — `scripts/bench` wrapper (~3–3.5h incl. the +30 min vLLM probe)
+
+**Goal:** The terse CLI, safe default, confirmation gate, discovery,
+and the shared proxy helper extraction.
+
+- `scripts/bench` bash shim (PYTHONPATH + exec
+  `python3 -m benchmark_runner.bench`), copyright header per project
+  rule.
+- `benchmark_runner/bench.py`: arg parsing, spec-parser (provider
+  whitelist + colon-tag invariant), env-fill table, compare-config
+  construction to a tempfile, pass-through, stub×stub safe default,
+  confirmation gate (TTY-aware), `--list-presets`, `--list-providers`
+  (Ollama 3-check incl. ≥ 0.14.0).
+- `benchmark_runner/proxy.py`: extract the verified LiteLLM
+  Anthropic→OpenAI lifecycle (tempfile config with `hosted_vllm/`
+  prefix, background start, healthcheck loop, SIGTERM→SIGKILL teardown)
+  out of `run-compare-anthropic-vs-vllm.sh`.
+- vLLM probe-then-decide wired into candidate resolution.
+- **Single-candidate routing:** when a resolved invocation/preset has
+  exactly 1 candidate, the wrapper calls `./scripts/benchmark run`
+  (not `compare`); ≥2 → `compare`. (OQ-4.)
+
+**Acceptance:** parser unit tests (all colon-tag + every prefix +
+unknown-token-hint); env-fill correctness tests; `--preset`
+resolution + `--runs`/`--task` override; `--yes`/non-TTY; stub×stub
+smoke green; `./scripts/benchmark compare --config <file>` regression
+green.
+
+## D2 — Live progress to stderr (~3h)
+
+**Goal:** A heartbeat-thread + flush discipline so an active run is
+never silent for 60s.
+
+- `run._execute_attempt` wraps each attempt in an
+  `attempt_in_progress` `threading.Event`; a daemon thread emits
+  `[idx/total] cand task attempt running… Ns elapsed` every 30s while
+  set, and the start/end lines. Backend untouched.
+- Progress logger module: `print(..., file=sys.stderr, flush=True)`;
+  wrapper exports `PYTHONUNBUFFERED=1` to spawned subprocesses.
+
+**Acceptance:** automated test asserts a heartbeat line lands in a
+`tee`'d file within 1s of emission; no backend regression
+(`test_claude_code_backend` green).
+
+## D5 — Per-attempt timeout + skip-to-next (~1h core + 30 min tests)
+
+**Goal:** Configurable per-attempt timeout, correct classification,
+campaign continuity — built on the merged Popen+pgkill.
+
+- Wrapper resolves the timeout (300s cloud / 600s non-default
+  `ANTHROPIC_BASE_URL` heuristic; `--attempt-timeout` /
+  per-preset override) and threads it into the compare-config so the
+  existing `RunContext.timeout_seconds` carries it to the backend.
+- `run.py`: detect the backend's timeout signal (timeout note +
+  `exit_code=None` in `backend_metadata`) → `score.scores.timeout =
+  True`, `result: "timeout"`, `tests_output` records the harness-imposed
+  timeout. Heartbeat emits the final `timeout after Ns — skipping` line.
+- Aggregator (`report.py`/`report_winner.py`): count `timeout` as a
+  `pass_rate` failure but surface it as a distinct verdict flag.
+
+**Acceptance:** forced-hang test (`--attempt-timeout 5` + sleeping
+stub candidate) → process group killed, `score.json.result ==
+"timeout"`, next attempt runs, aggregate flags it separately.
+
+## D4 — README rewrite (~1h, last)
+
+**Goal:** "60-second quickstart" first; JSON/env-var docs demoted.
+
+- New `## 60-second quickstart` (the issue's literal block) becomes
+  the first section under the harness heading.
+- The current JSON-first "Quick start: compare multiple LLMs" content
+  moves under `### Advanced configuration`, alongside the
+  four-`ANTHROPIC_*` incantation, the `claude-code:` long form, and
+  `attempt_timeout_seconds`.
+
+**Acceptance:** quickstart is first; links resolve; advanced subsection
+retains every previously-documented knob.
+
+## Reuse map
+
+Defers to spec.md § "Reuse map". Headline: drive the unchanged
+`compare`/`report`; extract (don't duplicate) the proxy lifecycle;
+D5 reuses the existing process-group kill.
+
+## Test strategy
+
+Repo convention is stdlib `unittest` under
+`scripts/benchmark_runner/tests/`. New test modules:
+
+- `test_bench_parser.py` — spec-parser invariants (every colon-tag
+  case, every prefix, `@endpoint`, unknown-token hint).
+- `test_bench_envfill.py` — env-fill table correctness incl. vLLM
+  probe branches (probes mocked).
+- `test_bench_cli.py` — `--yes`/non-TTY, `--preset` + override,
+  zero-config smoke (stub×stub), `--list-providers` Ollama 3-check
+  (HTTP mocked, incl. < 0.14.0 → "unusable").
+- `test_progress_heartbeat.py` — heartbeat fires ≥ once for a >30s
+  fake attempt; line reaches a `tee`'d file within 1s.
+- `test_timeout_classification.py` — forced-hang → `result:"timeout"`,
+  campaign continues, aggregator flags separately.
+- `test_proxy_helper.py` — LiteLLM config emits `hosted_vllm/`;
+  teardown escalates SIGTERM→SIGKILL (subprocess mocked).
+- Regression: extend `test_compare.py` to assert the legacy
+  `--config` path is byte-for-byte unaffected.
+
+Per the project's pre-existing-failure memory
+(`project_benchmark_preexisting_env_test_failures`): run suites
+per-module; `test_polyglot_adapter` ×4 + `test_cli_skeleton` hang are
+known host-env failures, not regressions.
+
+## Delegation strategy
+
+Single build agent, phase-scoped per the deliverable order. The build
+agent reads spec.md + plan.md + this tasks.md first, implements one
+deliverable per scoped invocation, runs that deliverable's tests, and
+does not advance until green. No parallel sub-agents — the deliverables
+are sequential by construction (D5 ⟶ D2, D4 ⟶ all).
+
+## Files to create
+
+- `scripts/bench` (bash shim)
+- `scripts/benchmark_runner/bench.py`
+- `scripts/benchmark_runner/proxy.py`
+- `scripts/benchmark_runner/progress.py` (stderr heartbeat logger)
+- `benchmarks/presets/anthropic-tour.json`
+- `benchmarks/presets/local-vs-cloud.json`
+- `benchmarks/presets/cross-language-mini.json`
+- `scripts/benchmark_runner/tests/test_bench_parser.py`
+- `scripts/benchmark_runner/tests/test_bench_envfill.py`
+- `scripts/benchmark_runner/tests/test_bench_cli.py`
+- `scripts/benchmark_runner/tests/test_progress_heartbeat.py`
+- `scripts/benchmark_runner/tests/test_timeout_classification.py`
+- `scripts/benchmark_runner/tests/test_proxy_helper.py`
+- `specs/benchmark-bench-driver/origin-alignment-2026-05-18-HHMM.md`
+
+## Files to modify
+
+- `scripts/benchmark_runner/run.py` — heartbeat hook in
+  `_execute_attempt`; `result:"timeout"` classification + `scores.timeout`.
+- `scripts/benchmark_runner/report.py` / `report_winner.py` — count
+  `timeout` as failure, flag separately in verdicts.
+- `scripts/benchmark_runner/compare.py` — pass the resolved
+  per-attempt timeout through to `RunContext.timeout_seconds` (no
+  orchestration change beyond threading the value).
+- `scripts/run-compare-anthropic-vs-vllm.sh` — consume
+  `proxy.py`; add the header note.
+- `scripts/run-compare-anthropic-vs-ollama.sh` — header note.
+- `benchmarks/README.md` — quickstart promotion / JSON demotion (D4).
+- `scripts/benchmark_runner/tests/test_compare.py` — legacy-flow
+  regression assertion.
+
+## Rollout
+
+1. One branch `feat/benchmark-bench-driver`, one PR titled
+   `feat(benchmark): usable cross-LLM comparison driver (Closes #36)`.
+2. Commit chain follows the deliverable order: D3, D1, D2, D5, D4,
+   then a final "tests + origin-alignment" commit.
+3. PR opened only after all suites green (per-module),
+   `scripts/check-origin-alignment.sh benchmark-bench-driver` exits
+   ≤ 1, and the executable artifacts (`scripts/bench` zero-config
+   smoke, a real `--yes` stub run, the forced-hang test) have been
+   run, not just syntax-checked (infra-verification rule).
+4. Never push to master; PR via branch (memory
+   `feedback_never_push_to_master`). Diff shown + explicit approval
+   before every commit.

--- a/specs/benchmark-bench-driver/spec.md
+++ b/specs/benchmark-bench-driver/spec.md
@@ -138,8 +138,13 @@ Provider tokens are a **closed set**: `sonnet`, `opus`, `haiku`,
 `claude-code:`, `ollama:`, `vllm:`, `lmstudio:`, `openrouter:`.
 Anything else fails fast with a `did you mean…` hint. Parser rules:
 
-1. Token ∈ `{sonnet, opus, haiku}` → `claude-code:<token>`, ambient
-   Anthropic auth.
+1. Token ∈ `{sonnet, opus, haiku}` → `(backend=claude-code,
+   model=<token>)` with ambient Anthropic auth. The model id is the
+   **bare** alias (`sonnet`/`opus`/`haiku`) — matching the harness and
+   the D3 presets. It is **not** `model="claude-code:<token>"`: the
+   combined `claude-code:sonnet` form is explicitly rejected by
+   `cli.py`/`compare.py` and would reach `claude --model` as an
+   invalid id.
 2. Token starts `claude-code:` → suffix is the model verbatim.
 3. Token starts a known endpoint-bearing prefix (`ollama:`, `vllm:`,
    `lmstudio:`, `openrouter:`) → **strip only that one prefix**;

--- a/specs/benchmark-bench-driver/spec.md
+++ b/specs/benchmark-bench-driver/spec.md
@@ -1,0 +1,476 @@
+---
+feature_id: benchmark-bench-driver
+spec_mode: full
+status: draft
+issue: 36
+origin:
+  issue: gosha70/code-copilot-team#36
+  urls:
+    - https://github.com/gosha70/code-copilot-team/issues/36
+    - https://github.com/gosha70/code-copilot-team/pull/35
+    - https://github.com/gosha70/code-copilot-team/issues/32
+    - https://github.com/ollama/ollama/releases
+    - https://code.claude.com/docs/en/llm-gateway
+    - https://code.claude.com/docs/en/headless
+  origin_claim: |
+    Issue #36: "The harness's underlying machinery is correct but its
+    user-facing surface (./scripts/benchmark compare + 50-line JSON
+    configs + no live progress + no timeouts + dangerous zero-config
+    defaults) is not." Deliver a single user-facing wrapper
+    (scripts/bench) with safe defaults, terse provider:model[@endpoint]
+    specs, live progress to stderr, a per-attempt timeout with
+    skip-to-next, a three-preset library, and a rewritten README
+    quickstart. "It does not change the harness's verdict logic — only
+    how users invoke it." Five tightly-coupled deliverables D1–D5;
+    explicit verbatim out-of-scope list; empirically motivated by the
+    2026-05-09 release-day session (colon-parsing, subprocess hang,
+    silent-spend). Three planning decisions taken with the user
+    (2026-05-18) refine D1's vLLM path and the D2/D5 implementation
+    basis — see § Deviation from origin.
+---
+
+# Benchmark `bench` Driver — usable cross-LLM comparison wrapper
+
+> **Wrapper, not a rewrite (per issue #36).** This feature adds a
+> translation layer over the PR #35 harness. It changes **no**
+> verdict, scoring, isolation, or run-record logic. Every behaviour
+> here resolves down to a `./scripts/benchmark compare --config
+> <tempfile>` invocation the harness already supports. Where issue #36's
+> deliverable text (written 2026-05-09) contradicts the code that
+> actually merged in PR #35 (2026-05-17), the merged code is treated
+> as ground truth and the divergence is recorded in § Deviation from
+> origin — confirmed with the user 2026-05-18.
+
+## Problem
+
+PR #35 (closed #32) shipped a credible benchmark *framework*:
+reproducible run records, calibrated winner declaration, provider-routing
+capture, a benchmark-agnostic adapter contract, and a
+`./scripts/benchmark compare --config <json>` driver. It is not yet a
+credible *product*. The gaps, verbatim from issue #36:
+
+1. No one-line invocation for the 80% case ("Sonnet vs Ollama-Qwen on
+   one Python task" requires hand-authoring a JSON config).
+2. Provider env vars require expert knowledge (the four-`ANTHROPIC_*`
+   incantation, undiscoverable by a first-time user).
+3. No live progress — a 90-minute run is indistinguishable from a hung
+   one without a side-terminal monitor.
+4. No per-attempt timeout / hang recovery surfaced to the user
+   (empirically: `claude -p` hung on truncated Qwen thinking-mode
+   responses; the campaign blocked until manually killed).
+5. No preset library — every comparison shape is re-derived.
+6. No environment auto-detection (is Ollama up? which models?).
+7. Dangerous zero-config default — `./scripts/bench` with no args must
+   not bill the user's Anthropic account before they read what they
+   authorized.
+
+The cumulative effect: a user spent a release-day evening trying to run
+one comparison, the run silently hung, and the reflexive response was
+"throw the feature out." This feature fixes the UX so the framework's
+value becomes accessible without a guide and without surprise bills.
+
+## User Scenarios
+
+1. **First-time check (no spend).** A user clones the repo and types
+   `./scripts/bench`. It runs a stub×stub end-to-end smoke (< 30s, no
+   auth, no LLM call), prints which LLM endpoints the environment has,
+   and exits 0. No Anthropic spend.
+2. **The 80% comparison.** `./scripts/bench sonnet
+   ollama:qwen2.5-coder:7b` parses the colon-bearing tag correctly,
+   auto-fills the four `ANTHROPIC_*` vars for the Ollama candidate,
+   shows a confirmation gate (because `sonnet` bills Anthropic),
+   and on `y` runs end-to-end with live progress to stderr.
+3. **CI / non-interactive.** `./scripts/bench --yes sonnet
+   ollama:qwen2.5-coder:7b` skips the gate. A non-TTY stdin is treated
+   as `--yes`.
+4. **Curated comparison.** `./scripts/bench --preset local-vs-cloud
+   --runs 5` runs a hand-curated config with the run count overridden.
+5. **A hung attempt.** An attempt that exceeds its per-attempt timeout
+   is killed (process-group SIGKILL), recorded `result: "timeout"`, and
+   the campaign continues to the next attempt with no human action.
+6. **Local vLLM, user's own proxy.** `./scripts/bench sonnet
+   vllm:Qwen3-Coder@http://127.0.0.1:8787` — the wrapper probes the
+   endpoint, finds it answers the Anthropic Messages API (the user's
+   long-lived LiteLLM proxy), and uses it directly without spawning
+   anything.
+7. **Local vLLM, raw endpoint.** `./scripts/bench sonnet
+   vllm:Qwen3-Coder@http://192.168.1.23:8000` — the wrapper probes,
+   finds only an OpenAI `/v1/models` surface, spawns an ephemeral
+   LiteLLM Anthropic→OpenAI proxy in front of it (reusing the verified
+   `run-compare-anthropic-vs-vllm.sh` launch recipe), runs the
+   context-length/tool-parser preflight, and tears the proxy down on
+   exit.
+8. **Discovery.** `./scripts/bench --help`, `--list-presets`,
+   `--list-providers` each print useful, example-bearing output.
+   `--list-providers` flags an Ollama < 0.14.0 install as "detected but
+   unusable" with the version reason, not as a usable backend.
+
+## Interface
+
+### CLI surface — `scripts/bench`
+
+`scripts/bench` is a thin bash shim (mirroring `scripts/benchmark`)
+that sets `PYTHONPATH` and execs `python3 -m benchmark_runner.bench`.
+Rationale (design decision, user-delegated 2026-05-18): the deliverable
+is dominated by testable logic — spec-parsing with the provider
+whitelist, env-var construction, endpoint probes, preset resolution —
+which is far cheaper to unit-test in Python than in bash, and keeps one
+language with the rest of `benchmark_runner/`.
+
+```
+./scripts/bench                                   # safe default: stub×stub smoke + env detection
+./scripts/bench sonnet opus
+./scripts/bench sonnet ollama:qwen2.5-coder:7b
+./scripts/bench sonnet vllm:Qwen3-Coder@http://127.0.0.1:8787
+./scripts/bench --task python/bowling,go/leap --runs 5 sonnet ollama:qwen2.5-coder:7b
+./scripts/bench --preset local-vs-cloud
+./scripts/bench --yes sonnet ollama:qwen2.5-coder:7b   # bypass confirmation gate (CI)
+./scripts/bench --attempt-timeout 600 sonnet ollama:qwen3.6:27b
+./scripts/bench --help | --list-presets | --list-providers
+```
+
+Unknown flags pass through verbatim to `./scripts/benchmark compare`.
+`--report-only` and other compare flags translate 1:1.
+
+### Spec-parsing contract (provider whitelist — colons in model names are real)
+
+Provider tokens are a **closed set**: `sonnet`, `opus`, `haiku`,
+`claude-code:`, `ollama:`, `vllm:`, `lmstudio:`, `openrouter:`.
+Anything else fails fast with a `did you mean…` hint. Parser rules:
+
+1. Token ∈ `{sonnet, opus, haiku}` → `claude-code:<token>`, ambient
+   Anthropic auth.
+2. Token starts `claude-code:` → suffix is the model verbatim.
+3. Token starts a known endpoint-bearing prefix (`ollama:`, `vllm:`,
+   `lmstudio:`, `openrouter:`) → **strip only that one prefix**;
+   everything after is the `model[@endpoint]` blob. The parser does
+   **not** split on the second colon.
+4. `@endpoint` is recognised only as the final `@`-introduced segment.
+
+Testable invariant: `ollama:qwen2.5-coder:7b` →
+`(provider=ollama, model=qwen2.5-coder:7b, endpoint=default)`, **never**
+`(model=qwen2.5-coder, endpoint=7b)`.
+
+### Env-var auto-fill contract
+
+| Spec | `ANTHROPIC_BASE_URL` | `ANTHROPIC_AUTH_TOKEN` | `ANTHROPIC_DEFAULT_SONNET_MODEL` / `…_HAIKU_MODEL` |
+|---|---|---|---|
+| `sonnet`/`opus`/`haiku`/`claude-code:<m>` | unset (ambient) | unset (ambient) | unset |
+| `ollama:<m>[@ep]` | `<ep or http://localhost:11434>` | `ollama` | `<m>` |
+| `vllm:<m>@<ep>` | **probe-resolved** (see vLLM contract) | `vllm-user-proxy` or `vllm-ephemeral` | `<m>` |
+| `lmstudio:<m>[@ep]` | `<ep or http://localhost:1234>` | `lmstudio` | `<m>` |
+| `openrouter:<m>` | `https://openrouter.ai/api/v1` | `$OPENROUTER_API_KEY` (error if unset) | `<m>` |
+
+These map onto the existing compare-config `candidates[].env` block;
+the wrapper writes the JSON, the harness applies/restores env via the
+already-shipped `compare._patched_env`.
+
+### vLLM contract (probe-then-decide)
+
+For each `vllm:<model>@<endpoint>` candidate, at wrapper startup:
+
+1. Probe Anthropic Messages first (cheap, definitive): `POST
+   <endpoint>/v1/messages` with `anthropic-version: 2023-06-01` and a
+   minimal body. Any 2xx, or any non-404 4xx → endpoint is an
+   Anthropic-shape gateway (the user's proxy). Use it directly:
+   `ANTHROPIC_BASE_URL=<endpoint>`, `ANTHROPIC_AUTH_TOKEN=vllm-user-proxy`.
+2. Else probe OpenAI: `GET <endpoint>/v1/models` → 200 with `data: [...]`
+   → raw vLLM. Spawn an **ephemeral LiteLLM** Anthropic→OpenAI proxy
+   in front of it (shared helper, see Reuse map), point
+   `ANTHROPIC_BASE_URL` at the local proxy,
+   `ANTHROPIC_AUTH_TOKEN=vllm-ephemeral`, register a cleanup handler,
+   and run the vLLM preflight (context-length abort < 32000, warn <
+   131072; tool-call-parser warn).
+3. Else fail fast: `endpoint <ep> answers neither /v1/messages nor
+   /v1/models; check the URL or start vLLM via
+   run-compare-anthropic-vs-vllm.sh`.
+
+The ephemeral proxy uses the verified `hosted_vllm/` provider prefix
+(never `openai/` — that misroutes to `/v1/responses` and 400s
+mid-conversation; blocker #5 in `benchmarks/backends/vllm.md`). Proxy
+lifecycle: SIGTERM on wrapper exit, SIGKILL fallback after 5s — same
+escalation shape as D5's per-attempt kill.
+
+### Safe zero-config behaviour
+
+`./scripts/bench` with no candidates and no `--preset`:
+
+1. Run stub×stub end-to-end smoke (proves wrapper + harness + report
+   pipeline; free, < 30s, no auth).
+2. Print a detected-environments summary (Anthropic key last-4,
+   Ollama/LM Studio reachable + model count).
+3. If no endpoints detected, print only the wrapper-works message and
+   point at `--help` / README. Always exit 0 on a passing smoke; no
+   LLM call.
+
+### Confirmation gate
+
+Any invocation resolving to ≥1 Anthropic-API-bearing candidate
+(`sonnet`/`opus`/`haiku`/`claude-code:<m>` with **no** env override
+redirecting it elsewhere) prints the attempt/candidate/spend summary
+and prompts `Continue? [y/N]`. `--yes` / `--no-confirm`, or a non-TTY
+stdin, bypass it. Zero-Anthropic (all-local) invocations never prompt.
+No token/dollar estimates (cost reporting is permanently out of scope —
+the prompt says so and points at `spec.md § cost_reporting`).
+
+### `--list-providers` detection rules
+
+- **Anthropic.** `ANTHROPIC_API_KEY` set → `Anthropic API (key
+  sk-ant-…XXXX)` (last 4 chars only; never echo the key).
+- **Ollama.** Three checks, all must pass: (a) `which ollama` or
+  `OLLAMA_HOST` set; (b) `GET <host>:11434/api/version` ≥ 0.14.0
+  (when `/v1/messages` landed); (c) `GET /api/tags` enumerates models.
+  Any failure → `Ollama detected but unusable: <reason>`.
+- **vLLM.** Opt-in only — not probed. Resolved per-candidate via the
+  vLLM contract above.
+- **LM Studio.** Probe `GET http://localhost:1234/v1/models`,
+  enumerate if reachable.
+
+### Live progress contract (D2)
+
+Progress lines go to **stderr** (stdout stays clean JSON). Shapes:
+
+```
+[1/6] claude-code:sonnet  python/bowling  attempt 1  starting...
+[1/6] claude-code:sonnet  python/bowling  attempt 1  running... 30s elapsed
+[1/6] claude-code:sonnet  python/bowling  attempt 1  pass (87s, 12 tool calls)
+```
+
+A daemon **heartbeat thread** owned by the orchestration layer
+(`run._execute_attempt`) emits a line every 30s while an
+`attempt_in_progress` event is set; the orchestrator clears it on
+attempt completion. The backend is **not** modified for D2 (it already
+blocks in `proc.communicate(timeout=)` and returns nothing meanwhile —
+the heartbeat-thread design from issue #36 option (a) is correct and
+the only option compatible with the merged backend). Flush discipline
+is mandatory: every progress line uses `print(..., file=sys.stderr,
+flush=True)`; the wrapper additionally exports `PYTHONUNBUFFERED=1`
+into every subprocess it spawns.
+
+### Per-attempt timeout + skip-to-next contract (D5)
+
+Built **on** the merged backend's existing
+`subprocess.Popen(start_new_session=True)` + `os.killpg(SIGKILL)` path
+(the "Bug #6" fix) — not by re-introducing kill logic. The wrapper
+resolves a per-attempt timeout and threads it through the existing
+`RunContext.timeout_seconds` (already consumed by the claude-code
+backend; precedence is already `ctx.timeout_seconds →
+CCT_CLAUDE_TIMEOUT_SECONDS → 600`). What this feature adds:
+
+- Default: 300s for `claude-code:` cloud candidates; 600s for any
+  candidate with a non-default `ANTHROPIC_BASE_URL` (local-LLM
+  heuristic). Override: `--attempt-timeout <s>` (CLI) or per-preset
+  `attempt_timeout_seconds`.
+- On timeout the backend already kills the process group and returns a
+  `BackendResult` carrying the timeout note + `exit_code=None`. D5
+  plumbs that signal into a new `result: "timeout"` classification in
+  `score.json` (today a timed-out attempt is misclassified `fail`
+  because `_classify_result` only knows pass/fail/error and
+  `scores.timeout` is hardcoded `False`).
+- The aggregator counts `timeout` as a failure for `pass_rate` but
+  flags it separately in verdicts so reviewers can tell "the LLM
+  failed" from "the LLM hung."
+- The heartbeat thread emits a final
+  `… attempt K  timeout after <s>s — skipping` line.
+- Skip-to-next already works (the backend returns rather than raises);
+  D5 makes it observable and correctly classified.
+
+## Reuse map
+
+- **Stage 1 — reuse, do not duplicate.** The wrapper resolves every
+  invocation to a compare-config and calls the *unchanged*
+  `compare.load_config` / `compare.run_comparison` /
+  `report.render_report`. No fork of the orchestrator.
+- The shared LiteLLM proxy lifecycle is **extracted** from
+  `scripts/run-compare-anthropic-vs-vllm.sh` into a single source of
+  truth (`scripts/benchmark_runner/proxy.py`), then re-used by both the
+  wrapper (ephemeral spawn for raw-vLLM `vllm:` candidates) and the
+  legacy script (which sources/imports it instead of carrying its own
+  copy). The verified DGX launch recipe and `hosted_vllm/` prefix move
+  with it.
+- D5 reuses the merged backend's process-group kill; it adds only
+  classification, not a second kill path.
+- The env-fill writes the existing `candidates[].env` schema;
+  `compare._patched_env` applies/restores it unchanged.
+
+## Design Decisions
+
+- **Wrapper language: Python**, entrypoint a bash shim. (User-delegated;
+  rationale above.)
+- **Legacy scripts kept.** `run-compare-anthropic-vs-ollama.sh` and
+  `-vs-vllm.sh` stay runnable and authoritative as a reference path;
+  each gains a one-paragraph header note: "this script is one way to
+  run a comparison; `scripts/bench` is the daily tool — either is
+  supported." Their load-bearing proxy logic is not deleted but
+  extracted to the shared helper they then consume. Resolves OQ-1.
+- **vLLM: probe-then-decide.** One token (`vllm:m@ep`); the wrapper
+  picks user-proxy vs ephemeral-proxy by probing. Resolves the
+  contradiction between issue #36 D1's literal env-fill and the merged
+  PR #35 reality that Claude Code cannot speak raw vLLM. Resolves OQ-2.
+- **D2/D5 built on merged Popen+pgkill**, divergence documented.
+  Resolves OQ-3.
+- **Single-candidate presets route to `run`, not `compare`**
+  (user-confirmed 2026-05-18, build-time conflict OQ-4). issue #36's
+  `cross-language-mini` is explicitly one candidate (a liveness sweep),
+  but `compare` + `compare-config.schema.json` require ≥2 candidates.
+  The wrapper detects a 1-candidate resolved invocation/preset and
+  calls `./scripts/benchmark run --task … --runs …` instead of
+  `compare`. The compare schema's `minItems: 2` guard and
+  `compare.py`'s runtime ≥2 reject are **unchanged**;
+  `cross-language-mini.json` validates against the documented bench
+  preset shape, not the compare schema.
+
+## Requirements
+
+1. `scripts/bench` (bash shim) + `benchmark_runner/bench.py` implement
+   the CLI surface, spec-parser (provider whitelist), env-fill, JSON
+   construction, pass-through, safe zero-config smoke, confirmation
+   gate, `--list-presets`, `--list-providers` with the Ollama 3-check.
+2. The spec-parser satisfies the colon-tag invariant and every
+   whitelisted prefix; unknown tokens fail fast with a hint.
+3. vLLM probe-then-decide per the vLLM contract; ephemeral proxy via
+   the shared helper; preflight aborts on context-length < 32000.
+4. `benchmarks/presets/{anthropic-tour,local-vs-cloud,cross-language-mini}.json`
+   exist; `local-vs-cloud.json` carries `attempt_timeout_seconds: 600`
+   (top-level optional field added to `compare-config.schema.json` in
+   D3; made load-bearing in D5). `cross-language-mini.json` is a
+   single-candidate bench preset routed to `benchmark run` by the
+   wrapper (it is not a compare-config and is not validated against
+   that schema). Preset task ids must exist in the pinned Polyglot
+   snapshot — note the snapshot has **no `*/leap` and no `rust/clock`**;
+   `bowling` exists in python/go/java/javascript/rust.
+5. Live progress to stderr: attempt-start, 30s heartbeats,
+   attempt-end, for every attempt, with flush discipline; visible
+   within 1s under `2>&1 | tee`.
+6. Per-attempt timeout with the cloud/local default heuristic and
+   `--attempt-timeout` override; timed-out attempts recorded
+   `result: "timeout"`, counted as failure but flagged separately;
+   campaign continues.
+7. README: a "60-second quickstart" becomes the first section under
+   the harness heading; the JSON-config docs and the four-`ANTHROPIC_*`
+   incantation are demoted to an `### Advanced configuration`
+   subsection.
+8. The JSON config flow (`./scripts/benchmark compare --config`)
+   continues to work unchanged (regression-tested).
+9. The shared proxy helper is the single source of truth;
+   `run-compare-anthropic-vs-vllm.sh` consumes it (no duplicated
+   launch recipe) and still runs end-to-end.
+
+## Constraints / What NOT to Build
+
+Verbatim from issue #36's out-of-scope list (non-negotiable):
+
+1. **No additional copilot backends** (Aider, Codex, GH Copilot CLI) —
+   issue #33.
+2. **No additional benchmark adapters** (SWE-bench Verified,
+   BigCodeBench, LiveCodeBench) — issue #33.
+3. **No LLM-judge scoring** — issue #34.
+4. **No HTML / CSV / chart reports** — issue #34.
+5. **No cost reporting** — deferred permanently (`§ cost_reporting`:
+   the confirmation gate states call counts, never tokens/dollars).
+6. **No GUI / web UI** for inspecting run-dirs.
+7. **No cross-campaign regression mode** (`--baseline … --candidate …`
+   over time).
+8. **No change to verdict / scoring / isolation / run-record logic.**
+   D5 adds a `timeout` result *value*; it does not alter the
+   pass/fail/winner calculus beyond counting timeouts as failures.
+
+## Key Entities
+
+- **Candidate spec** — a parsed `provider:model[@endpoint]` token.
+- **Resolved candidate** — `{name, backend: "claude-code", model, env}`
+  ready to serialize into a compare-config `candidates[]` entry.
+- **Preset** — a committed JSON compare-config under
+  `benchmarks/presets/`, overridable by `--runs` / `--task` /
+  `--attempt-timeout`.
+- **Progress event** — a stderr line keyed by
+  `[idx/total] candidate task attempt state`.
+- **Ephemeral proxy** — a wrapper-owned LiteLLM subprocess for
+  raw-vLLM candidates; lifecycle bound to the wrapper process.
+
+## Success Criteria
+
+- [ ] `./scripts/bench` (no args) runs stub×stub, prints detected
+      environments, exits 0, makes no LLM call / no Anthropic spend.
+- [ ] `./scripts/bench sonnet ollama:qwen2.5-coder:7b` parses the
+      colon tag correctly, auto-fills the four `ANTHROPIC_*` vars for
+      the Ollama candidate, prompts, and runs end-to-end after `y`.
+- [ ] `./scripts/bench --yes …` skips the gate; non-TTY stdin is
+      treated as `--yes`.
+- [ ] Live progress shows start / 30s+60s heartbeats / end for every
+      attempt, with **no 60s silent window even under `2>&1 | tee
+      /tmp/log`**.
+- [ ] An attempt forced to hang (`--attempt-timeout 5` + a sleeping
+      candidate) is killed after the timeout, recorded
+      `result: "timeout"`, and the campaign continues.
+- [ ] All three presets execute when prerequisites are met
+      (`cross-language-mini` via `run`, the other two via `compare`);
+      `--preset … --runs N` overrides the preset run count.
+- [ ] `--help`, `--list-presets`, `--list-providers` produce useful
+      output with inline examples; an Ollama < 0.14.0 is flagged
+      "detected but unusable" with the version reason.
+- [ ] `vllm:m@<anthropic-proxy>` uses it directly; `vllm:m@<raw-vllm>`
+      spawns + tears down an ephemeral LiteLLM proxy and runs the
+      context-length preflight.
+- [ ] `./scripts/benchmark compare --config <file>` still works
+      unchanged (regression test green).
+- [ ] `run-compare-anthropic-vs-vllm.sh` still runs end-to-end after
+      consuming the extracted shared proxy helper.
+- [ ] README's 60-second quickstart is the first section under
+      `## Benchmark Harness`; JSON config docs demoted to
+      `### Advanced configuration`.
+- [ ] `scripts/check-origin-alignment.sh benchmark-bench-driver`
+      exits 0 (or 1 with the documented divergence) before the PR.
+
+## Deviation from origin
+
+Three refinements to issue #36's deliverable text, each confirmed with
+the user 2026-05-18. Issue #36's body was written 2026-05-09; PR #35
+merged 2026-05-17 with code that postdates and partly invalidates the
+issue's implementation premises. The issue's *intent* and *acceptance
+criteria* are delivered in full; the *implementation basis* is adjusted.
+
+- **D2/D5 implementation basis.** Issue #36 D2/D5 assume backends use
+  blocking `subprocess.run(capture_output=True)` and prescribe "pick
+  option (a), refactor it." The merged claude-code backend already uses
+  `subprocess.Popen(start_new_session=True)` + `os.killpg(SIGKILL)` +
+  a per-attempt timeout (the "Bug #6" fix, 2026-05-17). This feature
+  builds the heartbeat thread and the `result: "timeout"`
+  classification **on** that mechanism rather than re-introducing a
+  kill path. All D2/D5 acceptance criteria remain deliverable. (OQ-3.)
+- **D1 vLLM env-fill → probe-then-decide.** Issue #36 D1 specifies a
+  single `vllm:` env shape. Merged PR #35 + `benchmarks/backends/vllm.md`
+  prove Claude Code cannot speak raw vLLM (OpenAI-only); a literal
+  env-fill yields a broken candidate. The wrapper instead probes and
+  auto-selects user-proxy vs. ephemeral-proxy. +~30 min over the D1
+  budget; justified by the user requirement to retain the verified
+  `run-compare-*.sh` workflows. (OQ-1, OQ-2.)
+- **Legacy-script fate.** Issue #36 says `scripts/bench` "supersedes"
+  the two ad-hoc drivers. Decision: keep both runnable and
+  authoritative, extract their load-bearing LiteLLM proxy logic into a
+  shared helper consumed by both the wrapper and the scripts. No
+  capability is discarded. (OQ-1.)
+
+This section, plus a newer `origin-alignment-YYYY-MM-DD-HHMM.md`
+record, satisfies the origin-confirmation circuit breaker
+(`scripts/check-origin-alignment.sh`): documented divergence → exit ≤ 1.
+
+## Sources
+
+- `issue: gosha70/code-copilot-team#36` — the five deliverables,
+  acceptance criteria, verbatim out-of-scope list, implementation
+  budget.
+- `pr: gosha70/code-copilot-team#35` — the merged harness this wraps;
+  the Popen+pgkill "Bug #6" fix that D2/D5 build on.
+- `path: scripts/benchmark_runner/{compare,run,cli}.py` — the
+  unchanged orchestration the wrapper drives.
+- `path: scripts/benchmark_runner/backends/claude_code.py` — the
+  merged timeout/process-group mechanism D5 layers on.
+- `path: benchmarks/backends/vllm.md` — the four-blocker vLLM map;
+  `hosted_vllm/` prefix; the two follow-up preflight gates.
+- `path: scripts/run-compare-anthropic-vs-{ollama,vllm}.sh` — the
+  load-bearing legacy drivers; source of the extracted proxy helper.
+- `url: https://github.com/ollama/ollama/releases` — `/v1/messages`
+  added in 0.14.0; the `--list-providers` version-check rationale.
+- `decisions: 2026-05-18 user clarifications` — OQ-1 (keep + extract),
+  OQ-2 (probe-then-decide), OQ-3 (build on merged Popen+pgkill).

--- a/specs/benchmark-bench-driver/tasks.md
+++ b/specs/benchmark-bench-driver/tasks.md
@@ -1,0 +1,186 @@
+# Tasks — Benchmark `bench` Driver
+
+Single PR on `feat/benchmark-bench-driver`. Each task is bounded and
+independently verifiable. Deliverables ship in the issue's sequenced
+order (D3 → D1 → D2 → D5 → D4); a deliverable's tasks are sequential,
+and a later deliverable starts only after the earlier one's tasks are
+green. AC map: spec.md § Success Criteria ←→ tasks below.
+
+Pre-existing-failure note (memory
+`project_benchmark_preexisting_env_test_failures`): run test suites
+per-module; `test_polyglot_adapter` ×4 and a `test_cli_skeleton` hang
+are known host-env failures on this machine, NOT regressions.
+
+## D3 — Preset library
+
+### T3.1 — Three preset configs + schema field
+- **Output:** `benchmarks/presets/{anthropic-tour,local-vs-cloud,cross-language-mini}.json`
+  per plan.md § D3; `local-vs-cloud.json` carries
+  `attempt_timeout_seconds: 600`; optional top-level
+  `attempt_timeout_seconds` (integer ≥ 1) added to
+  `compare-config.schema.json` (`additionalProperties:false` kept).
+  `cross-language-mini.json` is single-candidate (bench-preset shape).
+- **Done when:** `anthropic-tour` + `local-vs-cloud` validate against
+  the compare-config schema; `cross-language-mini` is documented as a
+  single-candidate `run`-routed preset (not validated against the
+  compare schema; minItems:2 guard untouched); every `task` id
+  resolves in the pinned Polyglot snapshot (no `*/leap`, no
+  `rust/clock`; `bowling` exists in python/go/java/javascript/rust).
+
+**D3 commit:** `feat(benchmark): preset compare-configs (D3)`
+
+## D1 — `scripts/bench` wrapper
+
+### T1.1 — Bash shim
+- **Output:** `scripts/bench` (exec `python3 -m benchmark_runner.bench`
+  with PYTHONPATH set, mirroring `scripts/benchmark`), copyright header.
+- **Done when:** `./scripts/bench --help` exits 0 and prints the CLI
+  surface with inline examples.
+
+### T1.2 — Spec-parser (provider whitelist)
+- **Output:** parser in `benchmark_runner/bench.py`: closed provider
+  set, the 4 parse rules, `@endpoint` as final segment, unknown-token
+  `did you mean…` hint.
+- **Done when:** `test_bench_parser.py` green incl. the invariant
+  `ollama:qwen2.5-coder:7b → (ollama, qwen2.5-coder:7b, default)` and
+  every whitelisted prefix + an unknown token.
+
+### T1.3 — Env-fill + compare-config construction
+- **Output:** env-fill table (spec.md § Env-var auto-fill) →
+  `candidates[].env`; resolved JSON written to a tempfile; pass-through
+  of `--task`/`--runs`/unknown flags to `./scripts/benchmark compare`.
+- **Done when:** `test_bench_envfill.py` green; a constructed config
+  loads via the unchanged `compare.load_config`.
+
+### T1.4 — Shared LiteLLM proxy helper
+- **Output:** `benchmark_runner/proxy.py` — extract the verified
+  lifecycle (tempfile config with `hosted_vllm/` prefix, background
+  start, healthcheck loop, SIGTERM→SIGKILL teardown) from
+  `run-compare-anthropic-vs-vllm.sh`; that script now consumes it.
+- **Done when:** `test_proxy_helper.py` green (config emits
+  `hosted_vllm/`, teardown escalates); `run-compare-anthropic-vs-vllm.sh
+  --help` still works and the script no longer carries its own copy.
+
+> **Operational gate (user, 2026-05-18).** T1.4 is a refactor of
+> load-bearing code disguised as a new file — it moves the verified
+> two-day-debugged LiteLLM launch recipe out of
+> `run-compare-anthropic-vs-vllm.sh`. After T1.4 lands and **before**
+> starting T1.5, run `./scripts/run-compare-anthropic-vs-vllm.sh sonnet
+> RedHatAI/Qwen3-Coder-Next-NVFP4` against the DGX Spark once and
+> confirm no regression. (Requires the operator's DGX; if unreachable
+> from the build environment, surface this as a pre-merge manual check
+> the user must run, do not silently skip.)
+
+### T1.5 — vLLM probe-then-decide
+- **Output:** per `vllm:` candidate, probe `/v1/messages` then
+  `/v1/models`; use-directly vs. ephemeral-proxy vs. fail-fast;
+  context-length preflight (< 32000 abort, < 131072 warn).
+- **Done when:** unit tests (probes mocked) cover all three branches;
+  raw-vLLM branch spawns + tears down via `proxy.py`.
+
+### T1.6 — Safe zero-config + confirmation gate + discovery
+- **Output:** single-candidate routing (1 resolved candidate →
+  `./scripts/benchmark run`; ≥2 → `compare`);
+  no-arg stub×stub smoke + env summary + exit 0;
+  TTY-aware confirmation gate (`--yes`/`--no-confirm`/non-TTY bypass;
+  zero-Anthropic never prompts); `--list-presets`; `--list-providers`
+  with the Ollama 3-check (≥ 0.14.0 → usable; else "detected but
+  unusable: <reason>").
+- **Done when:** `test_bench_cli.py` green; `./scripts/bench` (no args)
+  exits 0 making no LLM call; `./scripts/benchmark compare --config
+  <file>` regression assertion in `test_compare.py` green.
+
+**D1 commit:** `feat(benchmark): scripts/bench wrapper + presets resolution + safe defaults (D1)`
+
+## D2 — Live progress to stderr
+
+### T2.1 — Heartbeat thread in orchestration
+- **Output:** `benchmark_runner/progress.py` (stderr logger,
+  `flush=True`); `run._execute_attempt` wraps each attempt in an
+  `attempt_in_progress` Event + daemon thread emitting start / 30s
+  heartbeats / end. Backend untouched. Wrapper exports
+  `PYTHONUNBUFFERED=1` to subprocesses.
+- **Done when:** `test_progress_heartbeat.py` green — a >30s fake
+  attempt emits ≥1 heartbeat and a line reaches a `tee`'d file within
+  1s; `test_claude_code_backend` still green.
+
+**D2 commit:** `feat(benchmark): live progress heartbeat to stderr (D2)`
+
+## D5 — Per-attempt timeout + skip-to-next
+
+### T5.1 — Timeout resolution + threading
+- **Output:** `compare._validate`/`CompareConfig` **parse and retain
+  the top-level `attempt_timeout_seconds`** key (D3 added it to the
+  schema but the parser ignores it — closes the D3→D5 carry-over P2
+  flagged in review 2026-05-18). Wrapper resolves 300s cloud / 600s
+  non-default `ANTHROPIC_BASE_URL` heuristic, `--attempt-timeout` +
+  per-preset override; value threaded through compare-config →
+  `RunContext.timeout_seconds` (backend already consumes it).
+  Precedence: explicit `--attempt-timeout` > config
+  `attempt_timeout_seconds` > heuristic default.
+- **Done when:** unit test asserts the heuristic + override
+  precedence AND that `load_config` on `local-vs-cloud.json` retains
+  `attempt_timeout_seconds == 600` and it reaches the backend's
+  effective timeout.
+
+### T5.2 — `result:"timeout"` classification + skip
+- **Output:** `run.py` detects the backend timeout signal (timeout
+  note + `exit_code=None`) → `scores.timeout=True`, `result:"timeout"`,
+  `tests_output` records it; heartbeat emits final `timeout after Ns —
+  skipping`; aggregator counts it as a `pass_rate` failure but flags it
+  as a distinct verdict.
+- **Done when:** `test_timeout_classification.py` green — forced hang
+  (`--attempt-timeout 5` + sleeping stub) is process-group killed,
+  `score.json.result == "timeout"`, the next attempt runs, the
+  aggregate flags it separately. Verdict/winner calculus otherwise
+  unchanged (assert against an existing report fixture).
+
+**D5 commit:** `feat(benchmark): per-attempt timeout + timeout classification (D5)`
+
+## D4 — README rewrite
+
+### T4.1 — Quickstart promotion / JSON demotion
+- **Output:** new `## 60-second quickstart` (issue #36's literal
+  block) is the first section under the harness heading; the current
+  JSON-first content + four-`ANTHROPIC_*` incantation +
+  `claude-code:` long form + `attempt_timeout_seconds` move under
+  `### Advanced configuration`.
+- **Done when:** quickstart is the first section; all README links
+  resolve; no previously-documented knob is lost.
+
+**D4 commit:** `docs(benchmark): README 60-second quickstart (D4)`
+
+## Closeout
+
+### TX.1 — Suites + origin-alignment + PR
+- **Output:** all new + adjacent suites green (per-module); executable
+  artifacts actually run (`./scripts/bench` zero-config smoke, a
+  `--yes` stub run, the forced-hang test) per the infra-verification
+  rule; a fresh `origin-alignment-2026-05-18-HHMM.md` written newer
+  than spec.md/plan.md with a `Verdict:` line.
+- **Done when:** `scripts/check-origin-alignment.sh
+  benchmark-bench-driver` exits ≤ 1; diff shown and explicitly
+  approved; single PR `feat(benchmark): usable cross-LLM comparison
+  driver (Closes #36)` opened from `feat/benchmark-bench-driver`
+  (never pushed to master).
+
+**PR-description requirements (user operational notes, 2026-05-18):**
+
+1. **Test-mode disclosure.** Name which suites were run, in which mode
+   (single pytest call vs. per-module), and which specific files were
+   per-module-invoked or skipped because of the known host-env
+   failures (`test_polyglot_adapter` ×4, `test_cli_skeleton` hang).
+   Reviewers must see this PR is the same shape as PR #38's history,
+   not a hidden test regression.
+2. **T5.2 metric-discontinuity flag.** State explicitly that
+   `result:"timeout"` classification is non-comparable across the T5.2
+   boundary: pre-T5.2 runs that recorded `fail` with elapsed near the
+   timeout were misclassified timeouts; historical reports are NOT
+   rescored. Aggregate pass-rates must not be compared across this
+   boundary — the metric definition changed.
+3. **Paired-example consistency.** Before merge, open this PR
+   side-by-side with PR #38 (wiki-audit-trail) and confirm the two
+   spec bundles share consistent conventions (frontmatter shape,
+   origin-block style, deviation-section presence). The two land
+   within days and will be cited as paired examples of the SDD
+   discipline.


### PR DESCRIPTION
Implements issue #36's five deliverables as a translation layer over the PR #35 harness — **no verdict/scoring/isolation logic changed**. SDD bundle: `specs/benchmark-bench-driver/`. Commit chain: D3 `dfc85c7` · D1 `68f1d5b` · D2 `2202f72` · D5 `10c590b` · D4 `746d162` · fix `237e724`.

**D1** `scripts/bench` (Python behind a bash shim): provider-whitelist parser (colon-tag-safe), env-fill, safe stub-smoke default, TTY-aware Anthropic confirmation gate, `--list-presets/-providers`, 1→`run`/≥2→`compare` routing, vLLM probe-then-decide, shared `proxy.py` extracted from `run-compare-anthropic-vs-vllm.sh`. **D2** heartbeat→stderr (stdout stays clean JSON), `PYTHONUNBUFFERED=1`. **D5** per-attempt timeout + `result:"timeout"` (built on the merged Popen+pgkill; `BackendResult.timed_out` structured signal), additive `timed_out` tally — winner calculus untouched. **D3** three presets. **D4** README 60-second quickstart promoted; JSON/env-var docs demoted.

**Origin divergences (user-approved, in spec.md § Deviation):** OQ-1 keep+extract legacy scripts · OQ-2 vLLM probe-then-decide · OQ-3 D2/D5 on merged pgkill · OQ-4 single-candidate→`run`. `check-origin-alignment` exit 0.

### ✅ DGX pre-merge check — DONE, green

`./scripts/run-compare-anthropic-vs-vllm.sh sonnet RedHatAI/Qwen3-Coder-Next-NVFP4` was run against the DGX Spark (2026-05-19). All stages completed: LiteLLM proxy up on `:8787`, full multi-turn loop intact (`hosted_vllm/` prefix — no `/v1/responses` 400), clean teardown. anthropic-sonnet 3/3, vLLM-Qwen 3/4, `directional, no winner declared` (matches the wiki playbook's expected outcome). This validated the T1.4 extraction and surfaced one regression — see below — now fixed and re-verified.

### proxy.py entrypoint-ordering fix (`237e724`)

The DGX gate caught a T1.4 extraction bug: the `__main__` block sat before the module-level helpers, so `python3 -m benchmark_runner.proxy` raised `NameError: _http_ok`. Unit tests missed it (importing binds all defs regardless of order). Fixed (block moved to EOF) + `TestEntrypointOrdering` AST regression test (passes post-fix, provably fails on the D1-committed code). This is why the "build it, run it via its real entrypoint" gate exists.

### Test-mode disclosure

Suites run **per-module** (not one pytest call). Full per-module sweep: **370 passed, 1 skipped, 3 subtests**. Deselected/ignored are the documented host failures, not regressions: `test_polyglot_adapter` ×4 (needs host `pytest`), `test_cli_skeleton` (host hang), `test_polyglot_dogfood_subset` (known-stale `*/leap` subset), and pytest auto-collecting `fixtures/polyglot_mini/**/leap_test.py` exercise scaffolding. Same shape as PR #38's history.

### ⚠️ T5.2 metric discontinuity

`result:"timeout"` classification is **non-comparable across the D5 boundary**. Pre-D5 runs that recorded `fail` with elapsed near the timeout were misclassified timeouts; historical reports are **not** rescored. Do not compare aggregate pass-rates across this boundary — the metric definition changed (the verdict *calculus* did not).

### Paired-example consistency

Reviewer: open side-by-side with PR #38 (wiki-audit-trail) and confirm the two SDD bundles share frontmatter shape, origin-block style, and deviation-section presence — they land within days and will be cited as paired examples of the discipline.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
