### PR TITLE
feat(benchmark): Judge protocol + judge runner + corpus-selection CLI + registry (Closes #48)

### DIFF
--- a/benchmarks/calibration/rubric-default-v1.md
+++ b/benchmarks/calibration/rubric-default-v1.md
@@ -1,0 +1,243 @@
+# Rubric v1 (default) — LLM-Judge prompt template + dimensions
+
+The judge rates four dimensions on a 1–5 scale, one rating per
+dimension per attempt. Ratings are integers in `{1,2,3,4,5}` —
+enforced by `scripts/benchmark_runner/judge/contracts.py`
+`DimensionRating.__post_init__` (out-of-range values are rejected
+at construction, before `judge.json` is written). The judge also
+produces a free-text explanation per dimension.
+
+## Dimensions
+
+### 1. `idiomaticity`
+
+How idiomatically the code is written for its language: naming
+conventions, control flow, standard-library use, paradigm fit
+(e.g. Pythonic vs. transliterated-from-Java; idiomatic-Go vs.
+"clever"-Go; Rust ownership patterns vs. lifetimes-fighting).
+Independent of correctness — code that is wrong but idiomatic
+still rates high here; code that is right but cramped or
+non-native rates low.
+
+**1 — Anti-idiomatic.** Reads like another language transliterated;
+ignores standard library; bespoke loops where comprehensions /
+streams / iterators would be obvious; naming violates language
+conventions throughout.
+
+**2 — Awkward.** Several local anti-idioms; a few stdlib opportunities
+missed; naming partially off. A native reader would notice and
+rephrase.
+
+**3 — Adequate.** Idiomatic where easy; awkward where not. A native
+reader would accept it but flag 2–3 specific spots in review.
+
+**4 — Idiomatic.** Naming, control flow, and library use match the
+language's conventions. A native reviewer would not call out
+specific phrasing.
+
+**5 — Exemplary.** Reads like the language's standard library
+or its most-respected open-source projects. Any deviation from
+the obvious idiom is a deliberate, defensible choice.
+
+### 2. `error_handling`
+
+How the code treats failure: input validation, exception
+discipline, partial-failure recovery, error propagation
+contracts, never-silently-swallow behavior. Language-aware:
+Rust `Result`, Python `try/except`, Go `if err != nil`, Java
+`throws` — the right shape for the language.
+
+**1 — Absent / dangerous.** No validation; bare `except:`; `if err
+!= nil { _ = err }`; panics on bad input; silently returns wrong
+results on edge cases.
+
+**2 — Weak.** Catches too broadly; loses original error context;
+ignores some obvious failure modes (empty input, type
+mismatch, IO error).
+
+**3 — Functional.** Handles common failure modes; some specificity
+in exception types or error returns; minor leaks (over-broad
+catch in one spot, unchecked cast in another).
+
+**4 — Thoughtful.** Specific exception/error types throughout;
+errors carry context up; documented failure modes match
+implemented behavior; input validation present where it matters.
+
+**5 — Defensive without being paranoid.** Every failure mode the
+code can produce has a clear path (handle, propagate with
+context, or document as panic-equivalent). No silent failures.
+Tests would prove out the error paths.
+
+### 3. `test_thoughtfulness`
+
+Quality of the tests the model wrote or modified, where
+applicable. Coverage of edge cases, test-naming clarity, AAA
+shape (arrange-act-assert), independence of test cases, mock
+discipline.
+
+**Null is NOT for ordinary absence.** If the task gave the model
+a meaningful opportunity to add or modify tests and it did not,
+that is a low-quality signal — rate `1`, not `null`. `null` is
+reserved for the narrow case where the task structurally does
+not afford a test contribution: the benchmark provides the test
+suite and the task instructions explicitly say the model must
+not modify tests (e.g. Aider Polyglot's "solve so that the
+provided tests pass — do not edit the test file" framing). The
+judge writes a one-line explanation justifying `null` in those
+cases. Anything else — model produced no tests on a task where
+adding tests was natural; model edited tests in trivial ways;
+model wrote a single tautological test — rates `1`.
+
+**1 — Tests absent or token.** No tests on a task where adding
+tests was natural; or a single happy-path test that always
+passes; or a tautological assertion (`assert True`, `assertEqual(x, x)`).
+
+**2 — Tests present but shallow.** One or two cases, only the
+golden path; no boundary / failure tests; cases are coupled.
+
+**3 — Tests cover the obvious.** Golden path + one boundary
+case; case names are descriptive; cases are independent.
+
+**4 — Tests cover the obvious + a few non-obvious.** Boundary
+cases (empty, single-element, max-size); failure cases
+(invalid input, IO failure); test names communicate intent.
+
+**5 — Tests as a specification.** A new contributor could
+understand the function's contract from the test suite alone.
+Edge cases enumerated systematically; failure modes asserted;
+no test depends on another test's order.
+
+### 4. `security_hygiene`
+
+Defensive posture against the OWASP-style failure modes the
+code's surface area exposes. Language- and task-aware: a string
+function's surface is different from a web handler's. Includes
+SQL injection (parameterized queries), command injection
+(no shell concatenation), path traversal, unsafe deserialization,
+secret-handling in logs, integer-overflow surface, and obviously
+"avoid `eval()`-class" patterns.
+
+**1 — Actively dangerous.** Concatenates user input into shell /
+SQL / paths; logs raw credentials; uses `eval` / `pickle.loads`
+on untrusted input; trusts file uploads without validation.
+
+**2 — Naive.** One or more of the above in lower-impact paths;
+no obvious malice but a hostile input would land.
+
+**3 — Adequate for the surface.** Standard tooling used where
+present (parameterized queries, `pathlib`, `shlex`); no shell
+concatenation; no obvious mishandling. Doesn't go beyond.
+
+**4 — Defensive.** Input validated at boundaries; secrets never
+logged; least-privilege where the task allows; explicit
+treatment of untrusted input.
+
+**5 — Hostile-input-ready.** Every external input is treated as
+hostile; failure modes are documented; the code would pass a
+focused security review without rewrites.
+
+## When a dimension does not apply
+
+`null` is reserved for cases where the dimension is
+**structurally inapplicable** to the attempt, NOT for cases of
+ordinary absence (e.g. model produced no test code on a task
+that allowed tests — that is `1`, not `null`; model produced
+unsafe code on a task with an external-input surface — that is
+`1`, not `null`).
+
+Examples of structural inapplicability:
+
+- `test_thoughtfulness` on a task whose instructions explicitly
+  forbid editing tests (the benchmark owns the test suite, e.g.
+  Aider Polyglot's "solve so that the provided tests pass —
+  do not edit the test file" framing). The model had no
+  opportunity to demonstrate test thoughtfulness.
+- `security_hygiene` on a task that has no external-input
+  surface and no security-relevant operations (pure-string
+  algorithm with no IO, no parsing, no shell, no SQL, no
+  deserialization). There is nothing for a defensive posture
+  to defend against.
+
+In every other case — the dimension applies and the rating is
+1–5. The judge writes a one-line explanation justifying `null`
+when it is recorded.
+
+`null` ratings are excluded from that dimension's calibration
+sample (a rating cannot agree or disagree with a non-rating);
+they do not count against the judge's Spearman score. But they
+are still LABELED records in the calibration set — see
+`benchmarks/calibration/<name>.jsonl` schema below: every
+(run_path, dimension) pair is labeled, with `rating: null +
+explanation` when the dimension is structurally inapplicable.
+
+## Prompt template (sent to the judge LLM)
+
+```
+You are an expert code reviewer rating one attempt at solving a
+benchmark task. Rate the model's work on four dimensions on a
+1-5 integer scale. Respond in strict JSON matching the schema
+below. Do not include any text outside the JSON.
+
+Task: {task_id} ({benchmark_id})
+
+Prompt the model received:
+---
+{prompt}
+---
+
+Diff the model produced (against the prepared starter):
+---
+{diff}
+---
+
+Verify-step output (what the deterministic harness measured):
+---
+{verify_output}
+---
+
+Rubric:
+
+{rubric_dimensions_block}
+
+When a dimension does not apply to this attempt, set its rating
+to null and use the explanation to say why. Never coerce a
+non-applicable dimension to a numeric rating.
+
+Output JSON only:
+{
+  "ratings": {
+    "idiomaticity":         { "rating": <1-5 or null>, "explanation": "<one paragraph>" },
+    "error_handling":       { "rating": <1-5 or null>, "explanation": "<one paragraph>" },
+    "test_thoughtfulness":  { "rating": <1-5 or null>, "explanation": "<one paragraph>" },
+    "security_hygiene":     { "rating": <1-5 or null>, "explanation": "<one paragraph>" }
+  }
+}
+```
+
+`{rubric_dimensions_block}` is rendered at prompt-format time by
+the judge from this file's "Dimensions" section above (anchor
+sentences only, one paragraph per dimension), so a rubric edit
+takes effect with no judge code change.
+
+## Versioning
+
+This is rubric v1. Any edit to the dimension list, anchor
+sentences, or prompt template MUST go to a new
+`rubric-default-vN.md`. Calibration reports record the rubric
+version they were generated against; reports built against the
+old rubric remain readable.
+
+## Out of scope for v1
+
+- Per-language sub-rubrics (a "Python idiomaticity" rubric
+  separate from a "Rust idiomaticity" rubric). v1 uses one
+  rubric across all languages; the judge LLM is responsible
+  for language-aware anchoring within each dimension.
+- Reviewer-vs-reviewer agreement bounding (a second human
+  reviewer overlapping ≥10% of the corpus). Useful for
+  bounding the achievable Spearman ceiling, but adds labeling
+  cost and is deferred.
+- Cost / performance dimensions (token usage, elapsed time).
+  These are deterministic signals, not judge-rated; they
+  remain in `score.json` / `stats.json` / the deterministic
+  report block.

--- a/scripts/benchmark_runner/_register.py
+++ b/scripts/benchmark_runner/_register.py
@@ -13,7 +13,17 @@
 
 from __future__ import annotations
 
+from .judge.registry import register_judge
 from .registry import register_backend
+
+
+# Judge family tokens accepted on the CLI. The canonical one is
+# ``claude-code`` (per spec.md scenarios). ``claude-code-judge``
+# is the internal ``judge_id`` recorded in judge.json; accepting
+# it as an alias lets a user copy that value verbatim into a
+# re-run command. Same factory, two tokens — register_judge
+# tolerates the shared factory by design (see judge/registry.py).
+_JUDGE_FAMILY_TOKENS = ("claude-code", "claude-code-judge")
 
 
 _REGISTERED = False
@@ -49,12 +59,23 @@ def register_all() -> None:
     register_backend(codex_backend.BACKEND_FAMILY, codex_backend.factory)
     from .backends import aider as aider_backend
     register_backend(aider_backend.BACKEND_FAMILY, aider_backend.factory)
+
+    # Judges (TB1.5). Each judge module exposes a ``factory``
+    # function; register it under every accepted family token. The
+    # shared factory makes ``claude-code`` and ``claude-code-judge``
+    # behave identically on the CLI.
+    from .judge import claude_code_judge
+    for token in _JUDGE_FAMILY_TOKENS:
+        register_judge(token, claude_code_judge.factory)
+
     _REGISTERED = True
 
 
 def unregister_all_for_tests() -> None:
     """Reset for test isolation. The test harness calls this."""
     global _REGISTERED
+    from .judge.registry import _reset_for_tests as _reset_judges
     from .registry import _reset_for_tests
     _reset_for_tests()
+    _reset_judges()
     _REGISTERED = False

--- a/scripts/benchmark_runner/calibration/__init__.py
+++ b/scripts/benchmark_runner/calibration/__init__.py
@@ -1,0 +1,10 @@
+# benchmark_runner.calibration — calibration corpus selection + validation.
+#
+# Sourcing the calibration corpus (this package) and validating it
+# (Spearman gate, TB1.5 / sub-issue B) are the two halves of the
+# calibration pipeline. The corpus selector reads the existing
+# ``runs/`` archive and writes ``<name>.corpus.jsonl`` +
+# ``<name>.meta.json`` under ``benchmarks/calibration/`` (or a
+# user-specified output dir). It never mutates ``runs/``.
+
+from __future__ import annotations

--- a/scripts/benchmark_runner/calibration/corpus_select.py
+++ b/scripts/benchmark_runner/calibration/corpus_select.py
@@ -1,0 +1,637 @@
+# benchmark_runner.calibration.corpus_select — corpus selection from runs/.
+#
+# Walks an existing run archive (a ``runs/`` tree at any depth — both
+# single-run layouts ``<run>/<task>/<attempt>`` and compare-run
+# layouts ``<compare>/<run>/<task>/<attempt>`` are handled by
+# rglob-discovery on the ``attempt-NN-run-MM`` directory pattern),
+# loads each attempt's ``run-record.json`` + ``score.json``, and
+# selects a subset that satisfies the requested axes of variation.
+#
+# Determinism + reproducibility (user-mandated 2026-05-20):
+#   - Discovery sorts attempt directories by relative path. Same input
+#     tree → same candidate order on every machine.
+#   - Selection is a deterministic stratified round-robin; no
+#     randomness, no time-of-day, no host-specific tiebreakers.
+#   - Skipped attempts (unparseable run-record.json / missing
+#     score.json / etc.) are reported in meta.json — never silently
+#     dropped.
+#
+# Output (additive to ``benchmarks/calibration/``, never to ``runs/``):
+#   - ``<name>.corpus.jsonl`` — one JSON record per selected attempt.
+#   - ``<name>.meta.json`` — selection command + axes + counts + skips,
+#     the reproducibility record.
+#
+# Acceptance axes per issue #34 v3:
+#   - ``model``         — distinct ``backend_invocation.model`` values.
+#   - ``adapter``       — distinct ``benchmark_id`` values.
+#   - ``backend``       — distinct ``backend_id`` values.
+#   - ``repeated-runs`` — ≥1 (task_id, backend_id, model) tuple has
+#                         ≥2 task-runs in the selection.
+# An axis is "represented" iff (for non-``repeated-runs``) ≥2 distinct
+# values appear in the selection, or (for ``repeated-runs``) the
+# per-tuple count condition above holds.
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+CORPUS_SCHEMA_VERSION = "1.0"
+
+# Axis identifiers (use these constants everywhere instead of bare
+# strings so a typo is a NameError, not a silent "axis ignored").
+AXIS_MODEL = "model"
+AXIS_ADAPTER = "adapter"
+AXIS_BACKEND = "backend"
+AXIS_REPEATED_RUNS = "repeated-runs"
+
+VALID_AXES: frozenset[str] = frozenset({
+    AXIS_MODEL, AXIS_ADAPTER, AXIS_BACKEND, AXIS_REPEATED_RUNS,
+})
+
+# Attempt directory name: ``attempt-NN-run-MM`` (matches the layout
+# written by benchmark_runner.run._execute_attempt).
+_ATTEMPT_DIR_RE = re.compile(r"^attempt-\d+-run-[A-Za-z0-9._-]+$")
+
+
+# ── Errors ────────────────────────────────────────────────────────────
+
+
+class InvalidAxisError(ValueError):
+    """Caller asked for an axis name we don't know about."""
+
+
+class EmptyCandidatePoolError(RuntimeError):
+    """No parseable attempt directories under runs-root."""
+
+
+class InsufficientAxisRepresentationError(RuntimeError):
+    """The candidate pool can't satisfy a requested axis.
+
+    E.g. requested ``--axes model`` but every attempt in ``runs/``
+    has the same model. Raised early (before round-robin) so the
+    user sees the constraint that actually fails, not a
+    target_n-shortfall downstream.
+    """
+
+
+# ── Data shapes ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One attempt directory's selection-relevant metadata.
+
+    ``rel_path`` is the path relative to ``runs_root``; used as the
+    deterministic sort key. ``abs_path`` is the absolute filesystem
+    path (for the caller's output records).
+    """
+
+    rel_path: str
+    abs_path: Path
+    benchmark_id: str
+    backend_id: str
+    model: str
+    task_id: str
+    result: str
+    attempt: int
+    run_id: str
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """Output of ``select_corpus``: selected candidates + diagnostics."""
+
+    selected: tuple[Candidate, ...]
+    candidate_pool_size: int
+    skipped: dict[str, str] = field(default_factory=dict)
+    axis_summary: dict[str, Any] = field(default_factory=dict)
+
+
+# ── Discovery (read-only on runs/) ────────────────────────────────────
+
+
+def discover_candidates(runs_root: Path) -> tuple[list[Candidate], dict[str, str]]:
+    """Walk ``runs_root`` and return (candidates, skipped_reasons).
+
+    Skipped reasons cover the documented failure modes: missing
+    score.json, missing/unparseable run-record.json, JSON parse
+    errors, etc. The corpus selector reports these in meta.json so
+    a reviewer can see WHY an attempt didn't enter the candidate
+    pool, never a silent disappearance.
+
+    The walker uses ``rglob`` on the ``attempt-NN-run-MM`` pattern so
+    BOTH single-run layouts (``<run>/<task>/<attempt>``) AND
+    compare-run layouts (``<compare>/<run>/<task>/<attempt>``) are
+    handled with one pass.
+    """
+    if not runs_root.exists():
+        raise FileNotFoundError(f"runs-root not found: {runs_root}")
+
+    candidates: list[Candidate] = []
+    skipped: dict[str, str] = {}
+
+    # Sort attempt directories by relative path for deterministic
+    # discovery order. (Path.rglob returns filesystem-order on most
+    # platforms — explicit sort is the load-bearing guarantee.)
+    attempt_dirs = sorted(
+        (p for p in runs_root.rglob("attempt-*") if p.is_dir() and _ATTEMPT_DIR_RE.match(p.name)),
+        key=lambda p: str(p.relative_to(runs_root)),
+    )
+
+    for attempt_dir in attempt_dirs:
+        rel = str(attempt_dir.relative_to(runs_root))
+        run_record_path = attempt_dir / "run-record.json"
+        score_path = attempt_dir / "score.json"
+        if not run_record_path.exists():
+            skipped[rel] = "run-record.json missing"
+            continue
+        if not score_path.exists():
+            skipped[rel] = "score.json missing"
+            continue
+        try:
+            rr = json.loads(run_record_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            skipped[rel] = f"run-record.json unparseable: {exc}"
+            continue
+        try:
+            sc = json.loads(score_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            skipped[rel] = f"score.json unparseable: {exc}"
+            continue
+        invocation_raw = rr.get("backend_invocation")
+        if invocation_raw is not None and not isinstance(invocation_raw, dict):
+            # Malformed type → reported skip, not silent default and
+            # not a fatal walk-aborting crash. The promised contract
+            # is "missing/malformed → reported skip, never silent or
+            # fatal."
+            skipped[rel] = (
+                f"run-record.json field 'backend_invocation' has "
+                f"wrong type {type(invocation_raw).__name__} "
+                f"(expected object)"
+            )
+            continue
+        invocation = invocation_raw or {}
+        # Required fields. Anything missing → skipped (don't silently
+        # default to "" because that would silently group runs under
+        # a phantom "empty model" axis).
+        benchmark_id = rr.get("benchmark_id")
+        backend_id = rr.get("backend_id")
+        model = invocation.get("model")
+        task_id = rr.get("task_id")
+        result = sc.get("result")
+        attempt_num = rr.get("attempt")
+        run_id = rr.get("run_id")
+        missing = [
+            name for name, val in (
+                ("benchmark_id", benchmark_id),
+                ("backend_id", backend_id),
+                ("backend_invocation.model", model),
+                ("task_id", task_id),
+                ("result", result),
+                ("attempt", attempt_num),
+                ("run_id", run_id),
+            ) if val is None
+        ]
+        if missing:
+            skipped[rel] = f"run-record.json missing fields: {missing}"
+            continue
+        # Type coercion guarded — a non-int ``attempt`` or otherwise
+        # malformed typed field must become a skip, not a walk-
+        # aborting crash. Same contract as for missing/unparseable.
+        try:
+            candidate = Candidate(
+                rel_path=rel,
+                abs_path=attempt_dir,
+                benchmark_id=str(benchmark_id),
+                backend_id=str(backend_id),
+                model=str(model),
+                task_id=str(task_id),
+                result=str(result),
+                attempt=int(attempt_num),
+                run_id=str(run_id),
+            )
+        except (TypeError, ValueError) as exc:
+            skipped[rel] = (
+                f"run-record.json has malformed typed field: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            continue
+        candidates.append(candidate)
+    return candidates, skipped
+
+
+# ── Selection ─────────────────────────────────────────────────────────
+
+
+def _axis_value(candidate: Candidate, axis: str) -> str:
+    if axis == AXIS_MODEL:
+        return candidate.model
+    if axis == AXIS_ADAPTER:
+        return candidate.benchmark_id
+    if axis == AXIS_BACKEND:
+        return candidate.backend_id
+    raise InvalidAxisError(axis)
+
+
+def _validate_axes(axes: list[str]) -> None:
+    if not axes:
+        raise InvalidAxisError("at least one axis required")
+    for a in axes:
+        if a not in VALID_AXES:
+            raise InvalidAxisError(
+                f"unknown axis {a!r}; valid axes: {sorted(VALID_AXES)}"
+            )
+
+
+def _validate_pool(candidates: list[Candidate], axes: list[str]) -> None:
+    """Fail-fast if the pool can't possibly satisfy a requested axis.
+
+    Raised BEFORE round-robin so the user sees the real constraint
+    (e.g. "only 1 model in the pool") rather than a downstream
+    target_n shortfall.
+    """
+    for axis in axes:
+        if axis == AXIS_REPEATED_RUNS:
+            tuples_with_repeats = sum(
+                1 for _, count in _tuple_counts(candidates).items() if count >= 2
+            )
+            if tuples_with_repeats < 1:
+                raise InsufficientAxisRepresentationError(
+                    "axis 'repeated-runs' requires at least one "
+                    "(task_id, backend_id, model) tuple with ≥2 "
+                    "attempts in the pool; none found"
+                )
+            continue
+        distinct = {_axis_value(c, axis) for c in candidates}
+        if len(distinct) < 2:
+            raise InsufficientAxisRepresentationError(
+                f"axis {axis!r} requires ≥2 distinct values in the "
+                f"candidate pool; found {len(distinct)} ({sorted(distinct)})"
+            )
+
+
+def _tuple_counts(candidates: Iterable[Candidate]) -> dict[tuple[str, str, str], int]:
+    """Count attempts per (task_id, backend_id, model) tuple."""
+    counts: dict[tuple[str, str, str], int] = {}
+    for c in candidates:
+        key = (c.task_id, c.backend_id, c.model)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _round_robin_select(
+    candidates: list[Candidate],
+    non_rr_axes: list[str],
+    target_n: int,
+) -> list[Candidate]:
+    """Stratified round-robin pick.
+
+    Groups candidates by the cartesian product of ``non_rr_axes``
+    values (e.g. for axes=[model, adapter], the key is
+    (model, benchmark_id)). Iterates groups in sorted order; pulls
+    one candidate from each group's path-sorted queue per pass;
+    stops at ``target_n`` or when every queue is empty.
+
+    With no non-rr axes (e.g. axes=[repeated-runs] alone — degenerate
+    but valid), there's one group and we just slice the first target_n.
+    """
+    if not non_rr_axes:
+        return list(candidates[:target_n])
+
+    groups: dict[tuple, list[Candidate]] = {}
+    for c in candidates:
+        key = tuple(_axis_value(c, a) for a in non_rr_axes)
+        groups.setdefault(key, []).append(c)
+    # Within each group, sort by rel_path for deterministic order.
+    for key in groups:
+        groups[key].sort(key=lambda c: c.rel_path)
+
+    group_keys = sorted(groups.keys())
+    indices = {k: 0 for k in group_keys}
+    selected: list[Candidate] = []
+    progress = True
+    while progress and len(selected) < target_n:
+        progress = False
+        for k in group_keys:
+            if len(selected) >= target_n:
+                break
+            idx = indices[k]
+            if idx < len(groups[k]):
+                selected.append(groups[k][idx])
+                indices[k] += 1
+                progress = True
+    return selected
+
+
+def _repair_repeated_runs(
+    selected: list[Candidate],
+    candidates: list[Candidate],
+) -> list[Candidate]:
+    """If repeated-runs not satisfied, deterministically extend a tuple
+    in the selection so at least one (task, backend, model) has ≥2 entries.
+
+    Strategy A (preferred): find a (task, backend, model) tuple
+    already in the selection that has ≥2 attempts in the pool. Add
+    one of its unselected siblings to the selection, replacing the
+    LAST entry (by rel_path) that does NOT belong to the same tuple
+    we're extending. This preserves target_n and minimises damage to
+    other axes.
+
+    Strategy B (fallback): if no selected tuple has siblings in the
+    pool, replace the LAST TWO selected entries (by rel_path) with
+    the first two attempts of the smallest-by-rel_path repeating
+    tuple in the pool. This degrades the other axes' representation
+    at small target_n but always satisfies the requested axis.
+
+    Pre-condition: ``_validate_pool`` already proved at least one
+    repeating tuple exists in the pool. ``select_corpus`` also
+    pre-validates ``target_n >= 2`` when repeated-runs is requested.
+    """
+    selected_paths = {c.rel_path for c in selected}
+    pool_tuples = _tuple_counts(candidates)
+    selected_keys = {(c.task_id, c.backend_id, c.model) for c in selected}
+
+    # Strategy A — extend an existing tuple.
+    for key in sorted(selected_keys):
+        if pool_tuples.get(key, 0) < 2:
+            continue
+        members = sorted(
+            (c for c in candidates
+             if (c.task_id, c.backend_id, c.model) == key),
+            key=lambda c: c.rel_path,
+        )
+        sibling: Optional[Candidate] = None
+        for m in members:
+            if m.rel_path not in selected_paths:
+                sibling = m
+                break
+        if sibling is None:
+            continue
+        # Replace the LAST selected entry (by rel_path) that does
+        # NOT belong to `key`, so we don't swap away the entry we're
+        # extending. Fall back to last-of-everything if all selected
+        # entries already belong to `key` (already a satisfied state,
+        # but defensive).
+        selected_sorted = sorted(selected, key=lambda c: c.rel_path)
+        for i in range(len(selected_sorted) - 1, -1, -1):
+            sc = selected_sorted[i]
+            if (sc.task_id, sc.backend_id, sc.model) != key:
+                selected_sorted[i] = sibling
+                return selected_sorted
+        return selected_sorted  # all entries already share `key`
+
+    # Strategy B — overwrite the last two entries with a fresh repeating tuple.
+    if len(selected) < 2:
+        raise InsufficientAxisRepresentationError(
+            "axis 'repeated-runs' requires target_n >= 2 to admit a repair"
+        )
+    for key, count in sorted(pool_tuples.items()):
+        if count < 2:
+            continue
+        members = sorted(
+            (c for c in candidates
+             if (c.task_id, c.backend_id, c.model) == key),
+            key=lambda c: c.rel_path,
+        )
+        if len(members) < 2:
+            continue
+        selected_sorted = sorted(selected, key=lambda c: c.rel_path)
+        selected_sorted[-2:] = [members[0], members[1]]
+        return selected_sorted
+
+    # _validate_pool should have caught this; defensive.
+    raise InsufficientAxisRepresentationError(
+        "axis 'repeated-runs' requested but no repair possible"
+    )
+
+
+def select_corpus(
+    candidates: list[Candidate],
+    axes: list[str],
+    target_n: int,
+) -> SelectionResult:
+    """Select ``target_n`` candidates satisfying ``axes``.
+
+    Pure function — no I/O, no env, no time. Determined entirely by
+    its inputs. Same (candidates, axes, target_n) → same selection
+    (Candidate objects are frozen + hashable on identity).
+    """
+    if target_n < 1:
+        raise ValueError(f"target_n must be >= 1; got {target_n}")
+    _validate_axes(axes)
+    if AXIS_REPEATED_RUNS in axes and target_n < 2:
+        raise InsufficientAxisRepresentationError(
+            f"axis 'repeated-runs' requires target_n >= 2; got {target_n}"
+        )
+    if not candidates:
+        raise EmptyCandidatePoolError(
+            "candidate pool is empty; nothing to select from"
+        )
+    pool_size = len(candidates)
+    if target_n > pool_size:
+        raise InsufficientAxisRepresentationError(
+            f"target_n ({target_n}) exceeds candidate pool size ({pool_size})"
+        )
+    _validate_pool(candidates, axes)
+
+    non_rr_axes = [a for a in axes if a != AXIS_REPEATED_RUNS]
+    # Sort candidates once; round-robin re-sorts within each group.
+    sorted_candidates = sorted(candidates, key=lambda c: c.rel_path)
+
+    selected = _round_robin_select(sorted_candidates, non_rr_axes, target_n)
+
+    # Verify all non-rr axes are represented post-selection. Round
+    # robin guarantees this when target_n >= len(group_keys); the
+    # check below catches the rare case where target_n is so small
+    # that some axis values weren't reached.
+    for axis in non_rr_axes:
+        distinct = {_axis_value(c, axis) for c in selected}
+        if len(distinct) < 2:
+            raise InsufficientAxisRepresentationError(
+                f"selection of target_n={target_n} produced only "
+                f"{len(distinct)} distinct values for axis {axis!r} "
+                f"({sorted(distinct)}); raise target_n"
+            )
+
+    # Repeated-runs check + repair.
+    if AXIS_REPEATED_RUNS in axes:
+        selected_tuple_counts = _tuple_counts(selected)
+        if not any(v >= 2 for v in selected_tuple_counts.values()):
+            selected = _repair_repeated_runs(selected, sorted_candidates)
+            # Re-validate the OTHER requested axes after repair —
+            # strategy B (replace last two entries with a fresh
+            # repeating tuple's siblings) can collapse the model /
+            # adapter / backend axes to a single distinct value if
+            # those entries were the only representatives. The
+            # contract is "all requested axes satisfied"; return
+            # success only if the post-repair selection still
+            # honours each one.
+            for axis in non_rr_axes:
+                distinct = {_axis_value(c, axis) for c in selected}
+                if len(distinct) < 2:
+                    raise InsufficientAxisRepresentationError(
+                        f"repaired selection for 'repeated-runs' "
+                        f"left axis {axis!r} with only {len(distinct)} "
+                        f"distinct value(s) ({sorted(distinct)}); "
+                        f"target_n={target_n} is too small to satisfy "
+                        f"axes {axes!r} simultaneously — raise target_n"
+                    )
+
+    # Final sort for deterministic output order.
+    selected = sorted(selected, key=lambda c: c.rel_path)
+
+    return SelectionResult(
+        selected=tuple(selected),
+        candidate_pool_size=pool_size,
+        axis_summary=_axis_summary(selected, axes),
+    )
+
+
+def _axis_summary(
+    selected: list[Candidate],
+    axes: list[str],
+) -> dict[str, Any]:
+    """Per-axis breakdown of the selection. Goes into meta.json."""
+    summary: dict[str, Any] = {}
+    for axis in axes:
+        if axis == AXIS_REPEATED_RUNS:
+            counts = _tuple_counts(selected)
+            multi = {f"{k[0]} / {k[1]} / {k[2]}": v
+                     for k, v in counts.items() if v >= 2}
+            summary[axis] = {
+                "tuples_with_>=2_runs": len(multi),
+                "details": dict(sorted(multi.items())),
+            }
+            continue
+        per_value: dict[str, int] = {}
+        for c in selected:
+            v = _axis_value(c, axis)
+            per_value[v] = per_value.get(v, 0) + 1
+        summary[axis] = dict(sorted(per_value.items()))
+    return summary
+
+
+# ── Output writers ────────────────────────────────────────────────────
+
+
+def write_corpus(
+    result: SelectionResult,
+    *,
+    name: str,
+    axes: list[str],
+    target_n: int,
+    runs_root: Path,
+    output_dir: Path,
+    selection_command: str = "",
+) -> tuple[Path, Path]:
+    """Write ``<name>.corpus.jsonl`` + ``<name>.meta.json`` under output_dir.
+
+    Returns the two written paths. Creates ``output_dir`` if missing.
+    NEVER writes under ``runs_root`` — outputs are additive.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    corpus_path = output_dir / f"{name}.corpus.jsonl"
+    meta_path = output_dir / f"{name}.meta.json"
+
+    # corpus.jsonl — one record per selected attempt.
+    with corpus_path.open("w", encoding="utf-8") as f:
+        for c in result.selected:
+            record = {
+                "run_path": c.rel_path,
+                "task_id": c.task_id,
+                "benchmark_id": c.benchmark_id,
+                "backend_id": c.backend_id,
+                "model": c.model,
+                "result": c.result,
+                "attempt": c.attempt,
+                "run_id": c.run_id,
+            }
+            f.write(json.dumps(record, sort_keys=False) + "\n")
+
+    meta = {
+        "schema_version": CORPUS_SCHEMA_VERSION,
+        "name": name,
+        "selected_at": datetime.datetime.now(datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "selection_command": selection_command,
+        "runs_root": str(runs_root.resolve()),
+        "axes": axes,
+        "target_n": target_n,
+        "actual_n": len(result.selected),
+        "candidate_pool_size": result.candidate_pool_size,
+        "axis_summary": result.axis_summary,
+        "skipped": dict(sorted(result.skipped.items())),
+    }
+    meta_path.write_text(
+        json.dumps(meta, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return corpus_path, meta_path
+
+
+def select_and_write(
+    *,
+    runs_root: Path,
+    axes: list[str],
+    target_n: int,
+    name: str,
+    output_dir: Path,
+    selection_command: str = "",
+) -> tuple[Path, Path, SelectionResult]:
+    """High-level entrypoint: discover, select, write.
+
+    Combines ``discover_candidates`` + ``select_corpus`` + ``write_corpus``
+    into one call for the CLI's use. The pure ``select_corpus`` stays
+    available for unit tests that don't want I/O.
+    """
+    candidates, skipped = discover_candidates(runs_root)
+    if not candidates:
+        raise EmptyCandidatePoolError(
+            f"no parseable attempt directories under {runs_root}; "
+            f"skipped {len(skipped)} due to missing/malformed records"
+        )
+    result = select_corpus(candidates, axes, target_n)
+    # Attach skips from discovery so meta.json carries them.
+    result = SelectionResult(
+        selected=result.selected,
+        candidate_pool_size=result.candidate_pool_size,
+        skipped=skipped,
+        axis_summary=result.axis_summary,
+    )
+    corpus_path, meta_path = write_corpus(
+        result,
+        name=name,
+        axes=axes,
+        target_n=target_n,
+        runs_root=runs_root,
+        output_dir=output_dir,
+        selection_command=selection_command,
+    )
+    return corpus_path, meta_path, result
+
+
+def parse_axes_arg(value: str) -> list[str]:
+    """Parse the CLI's ``--axes model,repeated-runs`` form.
+
+    Trims whitespace, drops empty entries, preserves order, rejects
+    duplicates. Raises ``InvalidAxisError`` on unknown axis names.
+    """
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    if not parts:
+        raise InvalidAxisError("--axes must list at least one axis")
+    seen: set[str] = set()
+    for p in parts:
+        if p not in VALID_AXES:
+            raise InvalidAxisError(
+                f"unknown axis {p!r}; valid axes: {sorted(VALID_AXES)}"
+            )
+        if p in seen:
+            raise InvalidAxisError(f"duplicate axis in --axes: {p!r}")
+        seen.add(p)
+    return parts

--- a/scripts/benchmark_runner/cli.py
+++ b/scripts/benchmark_runner/cli.py
@@ -122,6 +122,37 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_report.add_argument("--run-dir", required=True, type=Path)
 
+    # ── judge ─────────────────────────────────────────────────────────
+    p_judge = sub.add_parser(
+        "judge",
+        help=(
+            "Rate every attempt under a run-dir with a calibrated LLM "
+            "judge. Writes judge.json adjacent to score.json; never "
+            "modifies score.json. See specs/benchmark-llm-judge/spec.md."
+        ),
+    )
+    p_judge.add_argument("--run-dir", required=True, type=Path)
+    p_judge.add_argument(
+        "--judge",
+        required=True,
+        help=(
+            "Judge spec '<family>:<model>'. Currently supported family: "
+            "'claude-code' (e.g. claude-code:sonnet). The alias "
+            "'claude-code-judge' is also accepted for parity with the "
+            "internal judge_id recorded in judge.json."
+        ),
+    )
+    p_judge.add_argument(
+        "--rubric",
+        default="default-v1",
+        help="Rubric name; loaded from benchmarks/calibration/rubric-<name>.md.",
+    )
+    p_judge.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Re-rate every attempt even if judge.json already exists.",
+    )
+
     # ── compare ───────────────────────────────────────────────────────
     p_compare = sub.add_parser(
         "compare",
@@ -441,12 +472,105 @@ def _cmd_dogfood(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+_JUDGE_FACTORIES: dict[str, "callable"] = {}
+
+# User-facing family tokens accepted by the ``--judge`` CLI arg.
+# The SDD canonicalizes ``claude-code`` (spec.md scenarios + Interface
+# section); the internal ``judge_id`` recorded in judge.json is
+# ``claude-code-judge`` (claude_code_judge.JUDGE_FAMILY). Both spellings
+# are accepted as aliases so docs, judge.json values, and the
+# corresponding CLI command all work without a translation step.
+_JUDGE_FAMILY_ALIASES: dict[str, str] = {
+    "claude-code": "claude-code",
+    "claude-code-judge": "claude-code",
+}
+
+
+def _judge_factory(family: str):
+    """Resolve a judge family (or alias) to its factory function.
+
+    A TB1.5 follow-up will replace this with the canonical
+    judge/registry.py + _register.py pattern (parallel to backends').
+    For now: a lazy import keeps the CLI import cheap and avoids
+    pulling the judge subpackage into ``benchmark list`` / `run` paths.
+    """
+    canonical = _JUDGE_FAMILY_ALIASES.get(family)
+    if canonical is None:
+        return None
+    if canonical not in _JUDGE_FACTORIES:
+        if canonical == "claude-code":
+            from .judge.claude_code_judge import factory as _factory
+            _JUDGE_FACTORIES[canonical] = _factory
+    return _JUDGE_FACTORIES.get(canonical)
+
+
+def _cmd_judge(args: argparse.Namespace) -> int:
+    if not args.run_dir.exists():
+        print(f"benchmark: run-dir not found: {args.run_dir}", file=sys.stderr)
+        return EXIT_USAGE
+    if ":" not in args.judge:
+        print(
+            f"benchmark: --judge must be '<family>:<model>'; got {args.judge!r}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    family, model = args.judge.split(":", 1)
+    factory_fn = _judge_factory(family)
+    if factory_fn is None:
+        supported = ", ".join(sorted(_JUDGE_FAMILY_ALIASES))
+        print(
+            f"benchmark: unknown judge family {family!r}; "
+            f"supported: {supported}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    from .judge.rubric import RubricNotFoundError, RubricParseError, load_rubric
+    from .judge.runner import ScoreJsonMutatedError, run_judge
+
+    try:
+        rubric = load_rubric(args.rubric)
+    except RubricNotFoundError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except RubricParseError as exc:
+        print(f"benchmark: rubric parse error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    judge = factory_fn(model)
+    try:
+        stats = run_judge(args.run_dir, judge, rubric, overwrite=args.overwrite)
+    except ScoreJsonMutatedError as exc:
+        # Additivity invariant violation — hard fail.
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_RUNTIME
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"benchmark: judge failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_RUNTIME
+
+    print(json.dumps({
+        "run_dir": str(args.run_dir),
+        "judge": args.judge,
+        "rubric": args.rubric,
+        "attempts_processed": stats.attempts_processed,
+        "attempts_skipped": stats.attempts_skipped,
+        "attempts_failed": stats.attempts_failed,
+        "skip_reasons": stats.skip_reasons,
+        "failure_reasons": stats.failure_reasons,
+    }, indent=2))
+    return EXIT_OK
+
+
 _HANDLERS = {
     "list": _cmd_list,
     "run": _cmd_run,
     "report": _cmd_report,
     "compare": _cmd_compare,
     "dogfood": _cmd_dogfood,
+    "judge": _cmd_judge,
 }
 
 

--- a/scripts/benchmark_runner/cli.py
+++ b/scripts/benchmark_runner/cli.py
@@ -271,9 +271,12 @@ def _cmd_list(args: argparse.Namespace) -> int:
         print(json.dumps({"benchmark_id": args.benchmark, "tasks": tasks}, indent=2))
         return EXIT_OK
 
+    from .judge.registry import list_judge_ids
+
     payload = {
         "adapters": list_adapter_ids(),
         "backends": list_backend_ids(),
+        "judges": list_judge_ids(),
     }
     print(json.dumps(payload, indent=2))
     return EXIT_OK
@@ -515,38 +518,6 @@ def _cmd_dogfood(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-_JUDGE_FACTORIES: dict[str, "callable"] = {}
-
-# User-facing family tokens accepted by the ``--judge`` CLI arg.
-# The SDD canonicalizes ``claude-code`` (spec.md scenarios + Interface
-# section); the internal ``judge_id`` recorded in judge.json is
-# ``claude-code-judge`` (claude_code_judge.JUDGE_FAMILY). Both spellings
-# are accepted as aliases so docs, judge.json values, and the
-# corresponding CLI command all work without a translation step.
-_JUDGE_FAMILY_ALIASES: dict[str, str] = {
-    "claude-code": "claude-code",
-    "claude-code-judge": "claude-code",
-}
-
-
-def _judge_factory(family: str):
-    """Resolve a judge family (or alias) to its factory function.
-
-    A TB1.5 follow-up will replace this with the canonical
-    judge/registry.py + _register.py pattern (parallel to backends').
-    For now: a lazy import keeps the CLI import cheap and avoids
-    pulling the judge subpackage into ``benchmark list`` / `run` paths.
-    """
-    canonical = _JUDGE_FAMILY_ALIASES.get(family)
-    if canonical is None:
-        return None
-    if canonical not in _JUDGE_FACTORIES:
-        if canonical == "claude-code":
-            from .judge.claude_code_judge import factory as _factory
-            _JUDGE_FACTORIES[canonical] = _factory
-    return _JUDGE_FACTORIES.get(canonical)
-
-
 def _cmd_judge(args: argparse.Namespace) -> int:
     if not args.run_dir.exists():
         print(f"benchmark: run-dir not found: {args.run_dir}", file=sys.stderr)
@@ -558,16 +529,8 @@ def _cmd_judge(args: argparse.Namespace) -> int:
         )
         return EXIT_USAGE
     family, model = args.judge.split(":", 1)
-    factory_fn = _judge_factory(family)
-    if factory_fn is None:
-        supported = ", ".join(sorted(_JUDGE_FAMILY_ALIASES))
-        print(
-            f"benchmark: unknown judge family {family!r}; "
-            f"supported: {supported}",
-            file=sys.stderr,
-        )
-        return EXIT_USAGE
 
+    from .judge.registry import UnknownJudgeError, get_judge
     from .judge.rubric import RubricNotFoundError, RubricParseError, load_rubric
     from .judge.runner import ScoreJsonMutatedError, run_judge
 
@@ -580,7 +543,11 @@ def _cmd_judge(args: argparse.Namespace) -> int:
         print(f"benchmark: rubric parse error: {exc}", file=sys.stderr)
         return EXIT_USAGE
 
-    judge = factory_fn(model)
+    try:
+        judge = get_judge(family, model)
+    except UnknownJudgeError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_USAGE
     try:
         stats = run_judge(args.run_dir, judge, rubric, overwrite=args.overwrite)
     except ScoreJsonMutatedError as exc:

--- a/scripts/benchmark_runner/cli.py
+++ b/scripts/benchmark_runner/cli.py
@@ -153,6 +153,49 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Re-rate every attempt even if judge.json already exists.",
     )
 
+    # ── calibration-corpus ─────────────────────────────────────────
+    p_corpus = sub.add_parser(
+        "calibration-corpus",
+        help=(
+            "Select a corpus of attempt-records from runs/ for human "
+            "labeling. Writes <name>.corpus.jsonl + <name>.meta.json "
+            "under --output-dir (default benchmarks/calibration/). "
+            "Never mutates runs/."
+        ),
+    )
+    p_corpus.add_argument(
+        "--runs-root",
+        type=Path,
+        default=Path("runs"),
+        help="Directory to walk for attempt-NN-run-MM/ candidates (default ./runs).",
+    )
+    p_corpus.add_argument(
+        "--target-n",
+        required=True,
+        type=int,
+        help="Target number of attempts to select (>=1). Issue #34 v3 requires >=50.",
+    )
+    p_corpus.add_argument(
+        "--axes",
+        required=True,
+        help=(
+            "Comma-separated axes of variation: any of "
+            "'model', 'adapter', 'backend', 'repeated-runs'. "
+            "Issue #34 v3 requires >=2 distinct axes."
+        ),
+    )
+    p_corpus.add_argument(
+        "--name",
+        required=True,
+        help="Corpus name; outputs land at <output-dir>/<name>.{corpus.jsonl,meta.json}.",
+    )
+    p_corpus.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("benchmarks/calibration"),
+        help="Where to write the corpus files (default benchmarks/calibration/).",
+    )
+
     # ── compare ───────────────────────────────────────────────────────
     p_compare = sub.add_parser(
         "compare",
@@ -564,6 +607,79 @@ def _cmd_judge(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_calibration_corpus(args: argparse.Namespace) -> int:
+    if not args.runs_root.exists():
+        print(
+            f"benchmark: runs-root not found: {args.runs_root}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if args.target_n < 1:
+        print(
+            f"benchmark: --target-n must be >= 1; got {args.target_n}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    from .calibration.corpus_select import (
+        EmptyCandidatePoolError,
+        InsufficientAxisRepresentationError,
+        InvalidAxisError,
+        parse_axes_arg,
+        select_and_write,
+    )
+
+    try:
+        axes = parse_axes_arg(args.axes)
+    except InvalidAxisError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    selection_command = (
+        f"./scripts/benchmark calibration-corpus "
+        f"--target-n {args.target_n} --axes {args.axes} "
+        f"--name {args.name} --runs-root {args.runs_root} "
+        f"--output-dir {args.output_dir}"
+    )
+    try:
+        corpus_path, meta_path, result = select_and_write(
+            runs_root=args.runs_root,
+            axes=axes,
+            target_n=args.target_n,
+            name=args.name,
+            output_dir=args.output_dir,
+            selection_command=selection_command,
+        )
+    except EmptyCandidatePoolError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_RUNTIME
+    except InsufficientAxisRepresentationError as exc:
+        print(
+            f"benchmark: cannot satisfy requested axes: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_RUNTIME
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"benchmark: corpus selection failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_RUNTIME
+
+    print(json.dumps({
+        "corpus_path": str(corpus_path),
+        "meta_path": str(meta_path),
+        "target_n": args.target_n,
+        "actual_n": len(result.selected),
+        "candidate_pool_size": result.candidate_pool_size,
+        "axes": axes,
+        "skipped_count": len(result.skipped),
+        "axis_summary": result.axis_summary,
+    }, indent=2))
+    return EXIT_OK
+
+
 _HANDLERS = {
     "list": _cmd_list,
     "run": _cmd_run,
@@ -571,6 +687,7 @@ _HANDLERS = {
     "compare": _cmd_compare,
     "dogfood": _cmd_dogfood,
     "judge": _cmd_judge,
+    "calibration-corpus": _cmd_calibration_corpus,
 }
 
 

--- a/scripts/benchmark_runner/judge/__init__.py
+++ b/scripts/benchmark_runner/judge/__init__.py
@@ -1,0 +1,14 @@
+# benchmark_runner.judge — calibrated LLM-judge subsystem.
+#
+# Adds calibrated LLM-judge scoring on top of the deterministic
+# harness (#34). The judge READS what run.py already wrote (diff +
+# prompt + verify output per attempt) and WRITES judge.json adjacent
+# to score.json. score.json is never overwritten — running the judge
+# against a run-dir does not re-execute the benchmark.
+#
+# Importing this subpackage does NOT auto-register judges; the
+# top-level _register module is the single source of truth for which
+# judges are active in a given run, mirroring the backends/ package
+# convention.
+
+from __future__ import annotations

--- a/scripts/benchmark_runner/judge/claude_code_judge.py
+++ b/scripts/benchmark_runner/judge/claude_code_judge.py
@@ -1,0 +1,528 @@
+# benchmark_runner.judge.claude_code_judge — claude-code-headless Judge.
+#
+# Wraps the same ``claude -p`` headless invocation the claude_code
+# backend uses, but configured for rating rather than editing:
+# tools disabled (the judge produces a JSON rating, not file edits),
+# permission mode irrelevant (no edits to permit), output-format JSON.
+#
+# Determinism contract (peer-reviewed 2026-05-20). The local ``claude``
+# CLI exposes ``--model`` / ``--fallback-model`` only — re-confirmed
+# 2026-05-20 against the installed CLI. No ``--temperature``, no
+# ``--seed``. The judge therefore records:
+#     temperature: None, seed: None,
+#     temperature_control: "unsupported", seed_control: "unsupported"
+# Re-run stability is empirical, surfaced by the calibration step's
+# Spearman against human labels. NEVER silently claim T=0.
+#
+# Provider routing (mirrors the backend): the judge reads
+# ``ANTHROPIC_BASE_URL`` + ``ANTHROPIC_AUTH_TOKEN`` from the env to
+# record whether routing happened, but does NOT set or log those
+# values — presence boolean only.
+#
+# Subprocess hardening: ``start_new_session=True`` + ``os.killpg`` on
+# timeout, mirroring the backend's Bug #6 fix (Claude Code is a Node
+# binary that spawns MCP/hook grandchildren; killing the immediate
+# child alone leaves stdout/stderr FDs open and blocks ``communicate``).
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from .contracts import (
+    JUDGE_RATING_MAX,
+    JUDGE_RATING_MIN,
+    SEED_CONTROL_UNSUPPORTED,
+    TEMPERATURE_CONTROL_UNSUPPORTED,
+    DimensionRating,
+    JudgeInput,
+    JudgeInvocation,
+    JudgeResult,
+)
+
+JUDGE_FAMILY = "claude-code-judge"
+JUDGE_BACKEND_ID = "claude-code"
+
+# Env vars — judge-specific so backend and judge can coexist with
+# different bare/timeout settings on the same machine. Names mirror
+# the backend's ``CCT_CLAUDE_*`` convention but use ``CCT_JUDGE_*``.
+BARE_OPT_IN_ENV_VAR = "CCT_JUDGE_BARE"
+TIMEOUT_OPT_IN_ENV_VAR = "CCT_JUDGE_TIMEOUT_SECONDS"
+
+# Provider-routing env (shared with the backend — same gateway env
+# the user already configured for backend runs).
+GATEWAY_BASE_URL_ENV_VAR = "ANTHROPIC_BASE_URL"
+GATEWAY_AUTH_TOKEN_ENV_VAR = "ANTHROPIC_AUTH_TOKEN"
+
+# Default judge timeout. Tighter than the backend's 600s because the
+# judge does no file editing — typical claude_code rating call on
+# sonnet completes in 5–60s. Overridable per-attempt via
+# ``CCT_JUDGE_TIMEOUT_SECONDS``.
+_DEFAULT_TIMEOUT_SECONDS = 300
+
+_STDERR_TAIL_CHARS = 1024
+
+
+# ── Parse-status sentinels ─────────────────────────────────────────────
+# What the parser concluded. Distinct strings so the report can tell
+# "judge said it doesn't apply" apart from "judge output was garbage."
+# Recorded in ``JudgeResult.judge_metadata["parse_status"]``.
+PARSE_STATUS_OK = "ok"
+PARSE_STATUS_OUTER_UNPARSEABLE = "outer_unparseable"
+PARSE_STATUS_INNER_UNPARSEABLE = "inner_unparseable"
+PARSE_STATUS_MISSING_DIMENSIONS = "missing_dimensions"
+PARSE_STATUS_OUT_OF_BAND_RATING = "out_of_band_rating"
+
+
+class ClaudeCliNotFoundError(RuntimeError):
+    pass
+
+
+class InvalidJudgeTimeoutError(ValueError):
+    """Raised when ``CCT_JUDGE_TIMEOUT_SECONDS`` is non-positive-integer.
+
+    Fail-loud on bad values — silently dropping a typo'd timeout
+    would mask a configuration error and change which judge results
+    were used in calibration.
+    """
+
+
+# ── Judge implementation ───────────────────────────────────────────────
+
+
+class ClaudeCodeJudge:
+    """Rates one attempt by invoking ``claude -p`` headlessly.
+
+    Construction is cheap; the work happens in ``rate``. The model
+    string is the same alias convention as the backend
+    (``sonnet`` / ``opus`` / a full model ID like
+    ``claude-sonnet-4-6``).
+
+    The judge does NOT modify the attempt directory. It reads
+    ``attempt.diff_path`` + ``attempt.prompt_path`` + uses
+    ``attempt.verify_output`` to render the rubric prompt, invokes
+    claude with tools disabled, and returns a ``JudgeResult``. The
+    caller (runner) is responsible for writing ``judge.json``.
+    """
+
+    judge_id = JUDGE_FAMILY
+
+    def __init__(
+        self,
+        model: str = "sonnet",
+        *,
+        cli_executable: str = "claude",
+    ) -> None:
+        self._model = model
+        self._cli = cli_executable
+
+    # ── Judge protocol ─────────────────────────────────────────────────
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        if shutil.which(self._cli) is None:
+            raise ClaudeCliNotFoundError(
+                f"the claude-code judge needs the {self._cli!r} CLI on PATH; "
+                f"install it from https://code.claude.com or override "
+                f"--cli-executable in tests"
+            )
+
+        bare_mode = _bare_mode_enabled()
+        timeout = _timeout_override() or _DEFAULT_TIMEOUT_SECONDS
+        argv = self._build_argv(bare_mode=bare_mode)
+
+        # Capture provider-routing env vars BEFORE the call — presence
+        # boolean only, never the URL/token.
+        provider_endpoint_present = bool(os.environ.get(GATEWAY_BASE_URL_ENV_VAR))
+
+        # Render the rubric prompt with attempt evidence. The rubric
+        # is data (loaded by the caller); the judge just substitutes.
+        rendered_prompt = _render_prompt(attempt)
+        prompt_sha256 = hashlib.sha256(rendered_prompt.encode("utf-8")).hexdigest()
+
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(attempt.attempt_dir),
+            text=True,
+            env=dict(os.environ),
+            start_new_session=True,  # see backend.claude_code Bug #6
+        )
+        stderr_tail = ""
+        timed_out = False
+        try:
+            stdout_data, stderr_data = proc.communicate(
+                input=rendered_prompt, timeout=timeout
+            )
+            stderr_tail = _tail(stderr_data or "", _STDERR_TAIL_CHARS)
+            exit_code: Optional[int] = proc.returncode
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass  # already dead — race with normal exit
+            timed_out = True
+            stdout_data = ""
+            try:
+                _stdout_late, stderr_late = proc.communicate(timeout=10)
+                stderr_tail = _tail(stderr_late or "", _STDERR_TAIL_CHARS)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                try:
+                    proc.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+            exit_code = None
+
+        parsed = parse_judge_output(stdout_data or "", attempt.rubric.dimensions)
+
+        ratings: dict[str, DimensionRating] = {}
+        for dim in attempt.rubric.dimensions:
+            raw = parsed.ratings.get(dim)
+            ratings[dim] = _make_dimension_rating(
+                dim,
+                raw,
+                prompt_sha256=prompt_sha256,
+                parse_status=parsed.status,
+                timed_out=timed_out,
+            )
+
+        invocation = JudgeInvocation(
+            model=self._model,
+            temperature=None,
+            seed=None,
+            temperature_control=TEMPERATURE_CONTROL_UNSUPPORTED,
+            seed_control=SEED_CONTROL_UNSUPPORTED,
+            provider_endpoint_present=provider_endpoint_present,
+        )
+
+        metadata: dict[str, Any] = {
+            "claude_code_invocation": "bare" if bare_mode else "launcher",
+            "timeout_seconds": timeout,
+            "exit_code": exit_code,
+            "stderr_tail": stderr_tail,
+            "parse_status": parsed.status,
+            "session_id": parsed.session_id,
+        }
+        if parsed.note:
+            metadata["parse_note"] = parsed.note
+        if timed_out:
+            metadata["note"] = f"claude -p judge timed out after {timeout}s (process group killed)"
+
+        return JudgeResult(
+            judge_id=self.judge_id,
+            judge_model=self._model,
+            judge_backend_id=JUDGE_BACKEND_ID,
+            rubric_name=attempt.rubric.name,
+            ratings=ratings,
+            invocation=invocation,
+            tokens_input=parsed.tokens_input,
+            tokens_output=parsed.tokens_output,
+            judge_metadata=metadata,
+        )
+
+    # ── Internals ──────────────────────────────────────────────────────
+
+    def _build_argv(self, *, bare_mode: bool) -> list[str]:
+        argv = [
+            self._cli,
+            "-p",
+            "--output-format", "json",
+            # Disable all built-in tools — the judge produces a JSON
+            # rating, not file edits. Per ``claude --help``:
+            #   --tools <tools...>  Specify the list of available tools
+            #     from the built-in set. Use "" to disable all tools,
+            #     "default" to use all tools, or specify tool names.
+            # ``--tools ""`` is the documented disable; ``--allowedTools``
+            # is a different surface (controls which of the available
+            # tools are permitted to run) and would NOT prevent the
+            # judge from offering tools at all. Peer review 2026-05-20.
+            "--tools", "",
+        ]
+        if bare_mode:
+            argv.insert(1, "--bare")
+        if self._model:
+            argv.extend(["--model", self._model])
+        # Deliberate omissions (peer-reviewed):
+        # NO --temperature (CLI does not expose).
+        # NO --seed (CLI does not expose).
+        # NO --permission-mode (judge edits nothing).
+        # NO --allowedTools (no separate reason to allow specific tools;
+        #                   the available-tool set is already empty via
+        #                   ``--tools ""``).
+        return argv
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _bare_mode_enabled() -> bool:
+    val = os.environ.get(BARE_OPT_IN_ENV_VAR, "")
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _timeout_override() -> Optional[int]:
+    """Resolve ``CCT_JUDGE_TIMEOUT_SECONDS`` to a positive int or None.
+
+    Raises ``InvalidJudgeTimeoutError`` on non-numeric or non-positive
+    values — silently dropping would let a typo'd setting masquerade
+    as the default budget and silently change which judge results
+    were considered timely.
+    """
+    val = os.environ.get(TIMEOUT_OPT_IN_ENV_VAR, "").strip()
+    if not val:
+        return None
+    try:
+        seconds = int(val)
+    except ValueError as exc:
+        raise InvalidJudgeTimeoutError(
+            f"{TIMEOUT_OPT_IN_ENV_VAR}={val!r} is not an integer. "
+            f"Expected a positive integer number of seconds."
+        ) from exc
+    if seconds <= 0:
+        raise InvalidJudgeTimeoutError(
+            f"{TIMEOUT_OPT_IN_ENV_VAR}={val!r} must be positive; got {seconds}."
+        )
+    return seconds
+
+
+def _render_prompt(attempt: JudgeInput) -> str:
+    """Substitute attempt evidence into the rubric prompt template.
+
+    Reads ``attempt.diff_path`` and ``attempt.prompt_path`` and
+    formats the template with ``{task_id}``, ``{benchmark_id}``,
+    ``{prompt}``, ``{diff}``, ``{verify_output}``.
+
+    The rubric loader (TB1.3+) is responsible for pre-rendering any
+    ``{rubric_dimensions_block}`` placeholder + escaping literal
+    curly braces in the template's JSON-example sections; the judge
+    here just calls ``str.format`` and propagates a KeyError if the
+    caller passed an under-rendered template.
+    """
+    diff_text = Path(attempt.diff_path).read_text(encoding="utf-8")
+    prompt_text = Path(attempt.prompt_path).read_text(encoding="utf-8")
+    return attempt.rubric.prompt_template.format(
+        task_id=attempt.task_id,
+        benchmark_id=attempt.benchmark_id,
+        prompt=prompt_text,
+        diff=diff_text,
+        verify_output=attempt.verify_output,
+    )
+
+
+def _tail(text: str, max_chars: int) -> str:
+    if not text:
+        return ""
+    return text[-max_chars:] if len(text) > max_chars else text
+
+
+def _make_dimension_rating(
+    dim: str,
+    raw: Optional[Mapping[str, Any]],
+    *,
+    prompt_sha256: str,
+    parse_status: str,
+    timed_out: bool,
+) -> DimensionRating:
+    """Build a DimensionRating from the parser's per-dim raw dict.
+
+    Defensive paths (rating=None + diagnostic explanation):
+      - Judge timed out.
+      - Dimension missing from parsed output.
+      - Rating value is out of band (the contract dataclass would
+        reject; catch here and substitute null with explanation so
+        one bad rating doesn't crash the whole judge call).
+    """
+    if timed_out:
+        return DimensionRating(
+            rating=None,
+            explanation="judge timed out before producing a rating for this dimension",
+            prompt_sha256=prompt_sha256,
+        )
+    if raw is None:
+        return DimensionRating(
+            rating=None,
+            explanation=f"judge output missing dimension {dim!r}: {parse_status}",
+            prompt_sha256=prompt_sha256,
+        )
+    rating_val = raw.get("rating")
+    explanation = str(raw.get("explanation", "") or "")
+    if rating_val is None:
+        # Judge legitimately reported structural inapplicability.
+        return DimensionRating(
+            rating=None,
+            explanation=explanation or "judge reported dimension as inapplicable",
+            prompt_sha256=prompt_sha256,
+        )
+    # bool is a subclass of int — the contract dataclass would
+    # reject it. Catch here to surface as a parse anomaly rather
+    # than crashing the whole call.
+    if isinstance(rating_val, bool) or not isinstance(rating_val, int):
+        return DimensionRating(
+            rating=None,
+            explanation=(
+                f"judge returned non-integer rating "
+                f"{type(rating_val).__name__} {rating_val!r}; recorded as null"
+            ),
+            prompt_sha256=prompt_sha256,
+        )
+    if not (JUDGE_RATING_MIN <= rating_val <= JUDGE_RATING_MAX):
+        return DimensionRating(
+            rating=None,
+            explanation=(
+                f"judge returned out-of-band rating {rating_val} "
+                f"(expected {JUDGE_RATING_MIN}..{JUDGE_RATING_MAX}); recorded as null"
+            ),
+            prompt_sha256=prompt_sha256,
+        )
+    return DimensionRating(
+        rating=rating_val,
+        explanation=explanation,
+        prompt_sha256=prompt_sha256,
+    )
+
+
+# ── Parser (pure function for testability) ─────────────────────────────
+
+
+class _ParsedJudge:
+    __slots__ = (
+        "ratings",
+        "tokens_input",
+        "tokens_output",
+        "session_id",
+        "status",
+        "note",
+    )
+
+    def __init__(self) -> None:
+        self.ratings: dict[str, Mapping[str, Any]] = {}
+        self.tokens_input: Optional[int] = None
+        self.tokens_output: Optional[int] = None
+        self.session_id: Optional[str] = None
+        self.status: str = PARSE_STATUS_OK
+        self.note: str = ""
+
+
+# Token-field fallbacks reused from the backend's defensive shape.
+_INPUT_TOKEN_KEYS = ("input_tokens", "prompt_tokens", "tokens_input")
+_OUTPUT_TOKEN_KEYS = ("output_tokens", "completion_tokens", "tokens_output")
+
+
+def parse_judge_output(stdout: str, dimensions: tuple[str, ...]) -> _ParsedJudge:
+    """Parse the claude wrapper JSON and the inner ratings JSON.
+
+    The wrapper is what ``claude --output-format json`` emits:
+    ``{"result": "<inner>", "usage": {...}, "session_id": "..."}``.
+    The inner ``result`` is the LLM's free-text response, which the
+    rubric template asks the model to format as
+    ``{"ratings": {"<dim>": {"rating": int|null, "explanation": str}, ...}}``.
+
+    Returns a populated ``_ParsedJudge`` in every case — the
+    ``status`` field tells the caller what happened. Never raises
+    on malformed output; the judge's job is to surface a result
+    even when the LLM did not cooperate.
+    """
+    out = _ParsedJudge()
+    if not stdout.strip():
+        out.status = PARSE_STATUS_OUTER_UNPARSEABLE
+        out.note = "empty stdout from claude"
+        return out
+
+    try:
+        wrapper = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        out.status = PARSE_STATUS_OUTER_UNPARSEABLE
+        out.note = f"claude wrapper not JSON: {exc}"
+        return out
+    if not isinstance(wrapper, dict):
+        out.status = PARSE_STATUS_OUTER_UNPARSEABLE
+        out.note = f"claude wrapper not a JSON object (got {type(wrapper).__name__})"
+        return out
+
+    # Token usage (best-effort, mirrors backend's defensive shape).
+    usage = wrapper.get("usage") or {}
+    if isinstance(usage, dict):
+        out.tokens_input = _first_int(usage, _INPUT_TOKEN_KEYS)
+        out.tokens_output = _first_int(usage, _OUTPUT_TOKEN_KEYS)
+    if out.tokens_input is None:
+        out.tokens_input = _first_int(wrapper, _INPUT_TOKEN_KEYS)
+    if out.tokens_output is None:
+        out.tokens_output = _first_int(wrapper, _OUTPUT_TOKEN_KEYS)
+    sess = wrapper.get("session_id")
+    if isinstance(sess, str):
+        out.session_id = sess
+
+    inner_text = str(wrapper.get("result", "") or "")
+    if not inner_text.strip():
+        out.status = PARSE_STATUS_INNER_UNPARSEABLE
+        out.note = "claude result field empty"
+        return out
+
+    try:
+        inner = json.loads(inner_text)
+    except json.JSONDecodeError as exc:
+        out.status = PARSE_STATUS_INNER_UNPARSEABLE
+        out.note = f"inner ratings JSON not parseable: {exc}"
+        return out
+    if not isinstance(inner, dict):
+        out.status = PARSE_STATUS_INNER_UNPARSEABLE
+        out.note = (
+            f"inner ratings JSON not an object (got {type(inner).__name__})"
+        )
+        return out
+
+    ratings_block = inner.get("ratings")
+    if not isinstance(ratings_block, dict):
+        out.status = PARSE_STATUS_INNER_UNPARSEABLE
+        out.note = "inner JSON missing 'ratings' object"
+        return out
+
+    missing: list[str] = []
+    out_of_band: list[str] = []
+    for dim in dimensions:
+        entry = ratings_block.get(dim)
+        if not isinstance(entry, dict):
+            missing.append(dim)
+            continue
+        rating = entry.get("rating")
+        if rating is not None:
+            # Caller (``_make_dimension_rating``) re-validates and may
+            # downgrade to null+explanation. Flag here so the parse
+            # status reflects "the model returned values we had to
+            # reject," not just "looks fine."
+            if isinstance(rating, bool) or not isinstance(rating, int):
+                out_of_band.append(dim)
+            elif not (JUDGE_RATING_MIN <= rating <= JUDGE_RATING_MAX):
+                out_of_band.append(dim)
+        out.ratings[dim] = entry
+
+    if missing:
+        out.status = PARSE_STATUS_MISSING_DIMENSIONS
+        out.note = f"missing dimensions: {missing}"
+    elif out_of_band:
+        out.status = PARSE_STATUS_OUT_OF_BAND_RATING
+        out.note = f"out-of-band ratings on: {out_of_band}"
+    # else: status stays PARSE_STATUS_OK
+
+    return out
+
+
+def _first_int(d: Mapping[str, Any], keys: tuple[str, ...]) -> Optional[int]:
+    for key in keys:
+        v = d.get(key)
+        if isinstance(v, int) and not isinstance(v, bool):
+            return v
+    return None
+
+
+def factory(model: str) -> ClaudeCodeJudge:
+    return ClaudeCodeJudge(model)

--- a/scripts/benchmark_runner/judge/contracts.py
+++ b/scripts/benchmark_runner/judge/contracts.py
@@ -1,0 +1,253 @@
+# benchmark_runner.judge.contracts — Judge protocol + dataclasses.
+#
+# The Judge protocol mirrors the Backend protocol from
+# benchmark_runner.contracts: frozen input/output dataclasses + a
+# runtime_checkable Protocol with a single method.
+#
+# Additivity invariant (load-bearing): the judge produces a per-attempt
+# judge.json that lands adjacent to score.json. score.json is NEVER
+# overwritten by judge code; the deterministic verdict is authoritative
+# and the judge is strictly secondary. Calibration / re-running the
+# judge / changing the rubric MUST NOT require re-running the
+# underlying benchmark.
+#
+# Determinism contract (peer-reviewed 2026-05-20). The local ``claude``
+# CLI exposes only ``--model`` / ``--fallback-model`` — there is no
+# ``--temperature`` and no ``--seed`` flag. The claude_code judge
+# therefore records ``temperature: None`` / ``seed: None`` /
+# ``temperature_control: "unsupported"`` / ``seed_control:
+# "unsupported"``. Re-run stability is an EMPIRICAL property surfaced
+# by the calibration step's Spearman against human labels, not a
+# guarantee from a fixed T=0. A future judge whose backend exposes the
+# knob MAY set these fields to non-None / "supported"; the schema is
+# forward-compatible.
+#
+# All dataclasses are frozen — judge records must not mutate after
+# capture, mirroring the contracts.py convention.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Optional, Protocol, runtime_checkable
+
+
+# ── Identifier / enum constants ────────────────────────────────────────
+# Use these everywhere instead of bare strings so renames are caught
+# by the type checker rather than by surprise at runtime.
+
+# Rating bounds (inclusive). The rubric prompt + the validate step
+# both reference these; defining them here keeps the bounds grep-able
+# as one unit.
+JUDGE_RATING_MIN = 1
+JUDGE_RATING_MAX = 5
+
+# Sentinel values for ``JudgeInvocation.temperature_control`` and
+# ``seed_control``. ``"supported"`` means the judge backend can pin
+# the knob and did pin it; ``"unsupported"`` means the backend CLI
+# does not expose the knob at all (the claude-code judge case).
+# ``"available_not_pinned"`` is reserved for a future judge that
+# *could* pin the knob but deliberately left it at the model default
+# (e.g. for a fidelity-comparison run).
+TEMPERATURE_CONTROL_SUPPORTED = "supported"
+TEMPERATURE_CONTROL_UNSUPPORTED = "unsupported"
+TEMPERATURE_CONTROL_AVAILABLE_NOT_PINNED = "available_not_pinned"
+
+SEED_CONTROL_SUPPORTED = "supported"
+SEED_CONTROL_UNSUPPORTED = "unsupported"
+SEED_CONTROL_AVAILABLE_NOT_PINNED = "available_not_pinned"
+
+
+# ── Rubric ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RubricSpec:
+    """The rubric a Judge rates against.
+
+    ``name`` identifies the rubric version (e.g. ``"default-v1"``).
+    Calibration reports are recorded against this name so a future
+    reader can identify which rubric a report was generated against.
+
+    ``dimensions`` is the ordered tuple of dimension names; the judge
+    produces one rating per dimension. The rubric file at
+    ``benchmarks/calibration/rubric-<name>.md`` is the source of
+    truth for prompt phrasing and 1–5 anchor descriptions — this
+    dataclass carries only the data the judge code needs at runtime.
+
+    ``prompt_template`` is the rendered prompt sent to the judge,
+    with placeholders for ``{task_id}``, ``{benchmark_id}``,
+    ``{prompt}``, ``{diff}``, ``{verify_output}``, and
+    ``{rubric_dimensions_block}``. The loader that reads the .md
+    file is responsible for rendering the dimensions block into the
+    template.
+    """
+
+    name: str
+    dimensions: tuple[str, ...]
+    prompt_template: str
+
+
+# ── Judge input + output primitives ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class JudgeInput:
+    """Per-attempt context handed to a Judge.
+
+    The Judge READS the already-written attempt artifacts (it does
+    not re-execute the model). ``attempt_dir`` is the existing
+    ``<run-dir>/<task-slug>/attempt-NN-run-MM/`` directory; the judge
+    reads from it and writes ``judge.json`` into it. ``diff_path``,
+    ``prompt_path``, and ``verify_output`` are passed explicitly
+    rather than rediscovered from the directory so that fake-CLI
+    tests can stage attempts without a full run.
+
+    ``verify_output`` is the text emitted by the deterministic
+    verify step (typically the test runner's stdout/stderr tail).
+    Passed as a string rather than a path because (a) the runner
+    sometimes truncates it before writing, and (b) the judge's
+    prompt template wants the content inline.
+    """
+
+    attempt_dir: Path
+    task_id: str
+    benchmark_id: str
+    diff_path: Path
+    prompt_path: Path
+    verify_output: str
+    rubric: RubricSpec
+
+
+@dataclass(frozen=True)
+class DimensionRating:
+    """One dimension's rating in a JudgeResult.
+
+    ``rating`` is an integer in ``[JUDGE_RATING_MIN, JUDGE_RATING_MAX]``
+    when the dimension applies, or ``None`` when the dimension is
+    STRUCTURALLY INAPPLICABLE to the attempt (per the rubric's
+    "When a dimension does not apply" clause). ``None`` is the narrow
+    carve-out for cases like ``test_thoughtfulness`` on a task whose
+    instructions explicitly forbid editing tests, NOT for ordinary
+    absence (no tests on a task that allowed them is rating 1).
+
+    The 1..5-or-None invariant is enforced in ``__post_init__`` —
+    this dataclass is the API surface that parsers/runners trust
+    before writing ``judge.json`` and before calibration computes
+    Spearman, so out-of-range values are rejected at construction
+    rather than silently propagated.
+
+    ``explanation`` is REQUIRED in both cases — for numeric ratings
+    it explains the rating; for ``None`` ratings it justifies the
+    inapplicability claim.
+
+    ``prompt_sha256`` is the SHA-256 of the exact prompt the judge
+    sent for this dimension. Per-dimension rather than per-attempt
+    because a judge implementation MAY use separate prompts per
+    dimension (the v1 prompt template uses one combined prompt; the
+    field is per-dimension so a future judge can split without
+    schema migration).
+    """
+
+    rating: Optional[int]
+    explanation: str
+    prompt_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.rating is None:
+            return
+        # ``bool`` is a subclass of ``int`` in Python — reject it
+        # explicitly so ``True``/``False`` cannot quietly coerce to
+        # rating 1/0. This is the kind of silent-coercion bug the
+        # null-vs-zero discipline elsewhere already guards against.
+        if isinstance(self.rating, bool) or not isinstance(self.rating, int):
+            raise TypeError(
+                f"DimensionRating.rating must be int or None; "
+                f"got {type(self.rating).__name__} {self.rating!r}"
+            )
+        if not (JUDGE_RATING_MIN <= self.rating <= JUDGE_RATING_MAX):
+            raise ValueError(
+                f"DimensionRating.rating must be in "
+                f"[{JUDGE_RATING_MIN}, {JUDGE_RATING_MAX}] or None; "
+                f"got {self.rating!r}"
+            )
+
+
+@dataclass(frozen=True)
+class JudgeInvocation:
+    """Reproducibility record for one Judge invocation.
+
+    ``model`` is the model alias the judge passed to its backend
+    (e.g. ``"sonnet"``). ``temperature`` and ``seed`` are recorded
+    as the judge actually controlled them — ``None`` means "judge
+    did not pin this knob"; the ``*_control`` fields disambiguate
+    *why* ("unsupported" = the CLI does not expose the knob;
+    "available_not_pinned" = the knob exists but the judge chose
+    not to pin it; "supported" = the knob exists and was pinned to
+    the recorded value).
+
+    ``provider_endpoint_present`` is a PRESENCE BOOLEAN — never the
+    endpoint URL or any secret. Mirrors the backends' provider-env
+    discipline: report that routing happened, never what to.
+    """
+
+    model: str
+    temperature: Optional[float] = None
+    seed: Optional[int] = None
+    temperature_control: str = TEMPERATURE_CONTROL_UNSUPPORTED
+    seed_control: str = SEED_CONTROL_UNSUPPORTED
+    provider_endpoint_present: bool = False
+
+
+@dataclass(frozen=True)
+class JudgeResult:
+    """What a Judge produced on one attempt.
+
+    ``ratings`` is keyed by dimension name (matching the input
+    ``RubricSpec.dimensions`` tuple). The runner serializes this
+    into ``judge.json`` adjacent to ``score.json`` (the additivity
+    invariant — score.json is never modified by judge code).
+
+    ``tokens_input`` / ``tokens_output`` are ``Optional[int]``
+    because not all judge backends report them; mirrors
+    ``BackendResult``'s null-vs-zero discipline. ``None`` means
+    "judge did not provide"; ``0`` means "judge reported zero." Do
+    not coerce.
+    """
+
+    judge_id: str
+    judge_model: str
+    judge_backend_id: str
+    rubric_name: str
+    ratings: Mapping[str, DimensionRating]
+    invocation: JudgeInvocation
+    tokens_input: Optional[int] = None
+    tokens_output: Optional[int] = None
+    judge_metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+# ── Protocols ──────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class Judge(Protocol):
+    """Contract every Judge implementation must satisfy.
+
+    Implementations live under
+    ``scripts/benchmark_runner/judge/<id>_judge.py`` and register via
+    ``benchmark_runner._register`` (parallel to the backends'
+    registration pattern).
+    """
+
+    judge_id: str
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        """Rate one already-completed attempt against the rubric.
+
+        The judge does NOT re-execute the underlying model — it
+        reads ``attempt.diff_path``, ``attempt.prompt_path``, and
+        ``attempt.verify_output``, invokes its own LLM with the
+        rubric prompt template, and returns a ``JudgeResult``. The
+        runner is responsible for writing ``judge.json``; the Judge
+        produces the in-memory record only.
+        """

--- a/scripts/benchmark_runner/judge/registry.py
+++ b/scripts/benchmark_runner/judge/registry.py
@@ -1,0 +1,93 @@
+# benchmark_runner.judge.registry — judge discovery (parallel to
+# benchmark_runner.registry for adapters/backends).
+#
+# A judge spec on the CLI is ``<family>:<model>`` (e.g.
+# ``claude-code:sonnet``). The family is what registers; the model
+# is passed to the factory at resolution time, mirroring the
+# backend pattern.
+#
+# Aliases. The same factory may be registered under multiple family
+# tokens — this is how the SDD-canonical ``claude-code`` and the
+# internal ``claude-code-judge`` (the ``judge_id`` recorded in
+# judge.json) coexist as accepted CLI inputs (see the round-3 peer
+# review of TB1.2: spec.md scenarios use ``claude-code:sonnet``,
+# while a maintainer reading a judge.json sees ``judge_id:
+# "claude-code-judge"``; both spellings must work). Registering the
+# same factory under multiple tokens is explicitly supported and
+# not treated as a duplicate-registration error.
+#
+# Test isolation. ``_reset_for_tests`` clears the registry so the
+# test suite can selectively register what it needs without
+# coupling to the shipped set.
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .contracts import Judge
+
+_JudgeFactory = Callable[[str], Judge]  # accepts a model spec
+
+_JUDGES: Dict[str, _JudgeFactory] = {}
+
+
+# ── Public API ─────────────────────────────────────────────────────────
+
+
+def register_judge(family: str, factory: _JudgeFactory) -> None:
+    """Register a judge family + factory.
+
+    Registering the same factory under multiple tokens is allowed
+    (the canonical-name / alias pattern; see module docstring).
+    Re-registering the SAME family with a DIFFERENT factory raises
+    ``RuntimeError`` — that's a programmer error.
+    """
+    existing = _JUDGES.get(family)
+    if existing is not None and existing is not factory:
+        raise RuntimeError(
+            f"judge family {family!r} already registered with a "
+            f"different factory; aliases must share the underlying "
+            f"factory object"
+        )
+    _JUDGES[family] = factory
+
+
+def list_judge_ids() -> list[str]:
+    """Return registered family tokens, sorted lexicographically.
+
+    Sorting is the load-bearing determinism guarantee: callers
+    (e.g. ``benchmark list``) get the same order on every machine.
+    """
+    return sorted(_JUDGES)
+
+
+def get_judge(family: str, model: str = "") -> Judge:
+    """Resolve a judge by family token + model id.
+
+    Raises ``UnknownJudgeError`` if the family is not registered.
+    The error message lists every registered family (including
+    aliases) so the user sees what they could have typed.
+    """
+    try:
+        factory = _JUDGES[family]
+    except KeyError:
+        known = ", ".join(list_judge_ids()) or "(none)"
+        raise UnknownJudgeError(
+            f"unknown judge family: {family!r}; registered families: {known}"
+        ) from None
+    return factory(model)
+
+
+# ── Errors ─────────────────────────────────────────────────────────────
+
+
+class UnknownJudgeError(LookupError):
+    pass
+
+
+# ── Test-only helpers ──────────────────────────────────────────────────
+
+
+def _reset_for_tests() -> None:
+    """Clear the judge registry. Test-suite use only."""
+    _JUDGES.clear()

--- a/scripts/benchmark_runner/judge/rubric.py
+++ b/scripts/benchmark_runner/judge/rubric.py
@@ -1,0 +1,200 @@
+# benchmark_runner.judge.rubric — load a rubric from disk into a RubricSpec.
+#
+# The rubric file at ``benchmarks/calibration/rubric-<name>.md`` is the
+# source of truth for prompt phrasing and dimension definitions
+# ("rubric is data, not code"). This loader extracts:
+#
+#   - dimensions: from the ``### N. `<name>`` headers under the
+#     ``## Dimensions`` section.
+#   - prompt_template: from the fenced code block under the
+#     ``## Prompt template`` section.
+#   - rubric_dimensions_block: the verbatim content of the
+#     ``## Dimensions`` + ``## When a dimension does not apply``
+#     sections, pre-substituted into the prompt template so the
+#     judge LLM sees the full rubric context.
+#
+# Curly-brace discipline. The prompt template's JSON-example block
+# contains literal ``{`` / ``}`` that would crash ``str.format`` in
+# the judge. The loader escapes every brace to ``{{`` / ``}}`` and
+# then un-escapes the five known attempt-evidence placeholders
+# (``{task_id}``, ``{benchmark_id}``, ``{prompt}``, ``{diff}``,
+# ``{verify_output}``). The rendered ``{rubric_dimensions_block}``
+# content is also pre-escaped before substitution so its content
+# survives the judge's final ``.format`` call as literal text.
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from .contracts import RubricSpec
+
+
+DEFAULT_RUBRIC_DIR = Path(__file__).resolve().parents[3] / "benchmarks" / "calibration"
+
+# Live placeholders the JUDGE substitutes per attempt. Everything else
+# in the prompt template — including the JSON-example braces — is
+# escaped to literal text by the loader. Order does not matter; each
+# is un-escaped independently.
+ATTEMPT_PLACEHOLDERS: tuple[str, ...] = (
+    "task_id",
+    "benchmark_id",
+    "prompt",
+    "diff",
+    "verify_output",
+)
+
+
+# Heading shapes the loader recognizes. ``### 1. `idiomaticity``` —
+# numbered heading with a backtick-delimited dimension name.
+_DIMENSION_HEADER_RE = re.compile(r"^###\s+\d+\.\s+`([a-zA-Z_][a-zA-Z0-9_]*)`\s*$", re.MULTILINE)
+
+
+class RubricNotFoundError(FileNotFoundError):
+    pass
+
+
+class RubricParseError(ValueError):
+    """Rubric file present but missing a required section."""
+
+
+def load_rubric(name: str, *, rubric_dir: Optional[Path] = None) -> RubricSpec:
+    """Load ``benchmarks/calibration/rubric-<name>.md`` into a RubricSpec.
+
+    Raises ``RubricNotFoundError`` if the file is absent;
+    ``RubricParseError`` if the file is present but missing a
+    required section (``## Dimensions``, at least one ``### N.``
+    dimension header, or the ``## Prompt template`` code block).
+    """
+    base = rubric_dir or DEFAULT_RUBRIC_DIR
+    path = base / f"rubric-{name}.md"
+    if not path.exists():
+        raise RubricNotFoundError(
+            f"rubric-{name}.md not found under {base}; "
+            f"expected the rubric file at {path}"
+        )
+    text = path.read_text(encoding="utf-8")
+    dimensions = _extract_dimensions(text, path)
+    raw_template = _extract_prompt_template(text, path)
+    dimensions_block = _extract_dimensions_block(text, path)
+    rendered = _render_template(raw_template, dimensions_block)
+    return RubricSpec(name=name, dimensions=dimensions, prompt_template=rendered)
+
+
+# ── Section extraction ────────────────────────────────────────────────
+
+
+def _extract_dimensions(text: str, path: Path) -> tuple[str, ...]:
+    """Return the ordered tuple of dimension names from the file.
+
+    Reads the ``### N. `<dim>``` headers under the ``## Dimensions``
+    section. Maintains the order in which dimensions appear in the
+    file (left-to-right when scanning top-to-bottom).
+    """
+    dims_section = _section_text(text, "## Dimensions")
+    if not dims_section:
+        raise RubricParseError(
+            f"rubric file {path} missing '## Dimensions' section"
+        )
+    names = tuple(m.group(1) for m in _DIMENSION_HEADER_RE.finditer(dims_section))
+    if not names:
+        raise RubricParseError(
+            f"rubric file {path} has '## Dimensions' but no "
+            f"recognized '### N. `<name>`' dimension headers"
+        )
+    return names
+
+
+def _extract_prompt_template(text: str, path: Path) -> str:
+    """Return the first fenced code block under '## Prompt template'."""
+    tmpl_section = _section_text(text, "## Prompt template")
+    if not tmpl_section:
+        raise RubricParseError(
+            f"rubric file {path} missing '## Prompt template' section"
+        )
+    # Match the first ``` ... ``` fence. Allow an optional language tag
+    # on the opening fence (the rubric file uses a bare ```` ``` ````).
+    fence = re.search(r"```[^\n]*\n(.*?)\n```", tmpl_section, re.DOTALL)
+    if not fence:
+        raise RubricParseError(
+            f"rubric file {path} '## Prompt template' section missing "
+            f"a ``` code block"
+        )
+    return fence.group(1)
+
+
+def _extract_dimensions_block(text: str, path: Path) -> str:
+    """Return the verbatim text rendered into ``{rubric_dimensions_block}``.
+
+    For v1, that is the ``## Dimensions`` section's body plus the
+    ``## When a dimension does not apply`` section's body, joined
+    with a blank line. The judge LLM then sees the full per-dimension
+    descriptions + the null-rule explanation in its prompt.
+    """
+    dims = _section_text(text, "## Dimensions")
+    null_rule = _section_text(text, "## When a dimension does not apply")
+    if not dims:
+        # _extract_dimensions has already raised; defensive in case
+        # callers re-order.
+        raise RubricParseError(
+            f"rubric file {path} missing '## Dimensions' section"
+        )
+    parts = [dims.strip()]
+    if null_rule:
+        parts.append(null_rule.strip())
+    return "\n\n".join(parts)
+
+
+def _section_text(text: str, header: str) -> str:
+    """Return the body of a markdown section identified by its '## ' header.
+
+    The body is everything from the header line through (exclusive)
+    the next ``##``-level header at the same depth. The match is
+    by header *prefix* — ``"## Prompt template"`` matches both
+    ``## Prompt template`` and ``## Prompt template (sent to the
+    judge LLM)``, so the rubric file can carry a subtitle after the
+    header without breaking the loader. Returns ``""`` if the
+    header prefix is not found.
+    """
+    pattern = re.compile(
+        rf"^{re.escape(header)}\b[^\n]*\n(.*?)(?=^##\s|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    m = pattern.search(text)
+    if not m:
+        return ""
+    return m.group(1)
+
+
+# ── Template rendering ────────────────────────────────────────────────
+
+
+def _escape_braces(text: str) -> str:
+    """Escape every ``{`` to ``{{`` and ``}`` to ``}}`` for ``str.format``."""
+    return text.replace("{", "{{").replace("}", "}}")
+
+
+def _unescape_placeholder(template: str, name: str) -> str:
+    """Turn ``{{<name>}}`` back into ``{<name>}`` so format() will substitute."""
+    return template.replace("{{" + name + "}}", "{" + name + "}")
+
+
+def _render_template(raw_template: str, dimensions_block: str) -> str:
+    """Compose the final prompt template that the judge will ``.format``.
+
+    Step 1: escape every brace in the raw template — protects the
+    JSON-example block's literal braces from being misread as
+    format placeholders.
+    Step 2: un-escape the 5 attempt placeholders so the judge can
+    substitute them per call.
+    Step 3: substitute ``{rubric_dimensions_block}`` (also escaped
+    in step 1) with the dimensions-block content, itself
+    pre-escaped so its content survives the judge's
+    ``.format`` call as literal text.
+    """
+    escaped = _escape_braces(raw_template)
+    for name in ATTEMPT_PLACEHOLDERS:
+        escaped = _unescape_placeholder(escaped, name)
+    escaped_block = _escape_braces(dimensions_block)
+    return escaped.replace("{{rubric_dimensions_block}}", escaped_block)

--- a/scripts/benchmark_runner/judge/runner.py
+++ b/scripts/benchmark_runner/judge/runner.py
@@ -1,0 +1,268 @@
+# benchmark_runner.judge.runner — walk a run-dir, invoke a Judge per
+# attempt, write judge.json adjacent to score.json.
+#
+# Additivity invariant (load-bearing): the runner READS the existing
+# attempt artifacts (score.json, run-record.json, diff.patch, prompt.md,
+# verify-output.txt) and writes only ``judge.json`` next to score.json.
+# score.json is NEVER modified or replaced. The invariant is enforced
+# in two ways:
+#   1. The runner hashes score.json before and after each rate() call
+#      and raises ScoreJsonMutatedError if the digests differ.
+#   2. The runner uses Path.write_text only to write judge.json, never
+#      score.json.
+#
+# Schema. judge.json is the on-disk serialization of a JudgeResult,
+# plus a schema_version and a flat list of rubric_dimensions so
+# downstream tooling can read it without consulting the rubric file.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from .contracts import (
+    DimensionRating,
+    Judge,
+    JudgeInput,
+    JudgeInvocation,
+    JudgeResult,
+    RubricSpec,
+)
+
+
+JUDGE_JSON_SCHEMA_VERSION = "1.0"
+
+# Attempt directories under a run-dir match this pattern, produced by
+# benchmark_runner.run._execute_attempt:
+#   <run_dir>/<task-slug>/attempt-NN-run-MM/
+_ATTEMPT_DIR_RE = re.compile(r"^attempt-\d+-run-[A-Za-z0-9._-]+$")
+
+
+class ScoreJsonMutatedError(RuntimeError):
+    """Raised when a Judge implementation mutated score.json.
+
+    Hard failure: the additivity invariant is load-bearing for the
+    whole feature; any Judge that breaks it must be fixed before
+    its output is used.
+    """
+
+
+@dataclass(frozen=True)
+class RunJudgeStats:
+    """Per-call summary of what ``run_judge`` did.
+
+    ``attempts_processed`` is the number of attempts the judge
+    actually rated (a judge.json was written for each).
+    ``attempts_skipped`` is the number of attempt directories the
+    runner found but skipped (missing score.json, judge.json
+    already present and overwrite=False, etc.) with the reason
+    recorded in ``skip_reasons``.
+    ``attempts_failed`` is the number where rate() raised; the
+    exception is recorded in ``failure_reasons``. The runner
+    continues past per-attempt failures so one bad attempt does
+    not block a whole calibration pass.
+    """
+
+    attempts_processed: int = 0
+    attempts_skipped: int = 0
+    attempts_failed: int = 0
+    skip_reasons: dict[str, str] = field(default_factory=dict)
+    failure_reasons: dict[str, str] = field(default_factory=dict)
+
+
+def run_judge(
+    run_dir: Path,
+    judge: Judge,
+    rubric: RubricSpec,
+    *,
+    judge_output_name: str = "judge.json",
+    overwrite: bool = False,
+) -> RunJudgeStats:
+    """Run ``judge`` over every attempt under ``run_dir``.
+
+    Walks ``<run_dir>/<task-slug>/attempt-NN-run-MM/`` (the layout
+    benchmark_runner.run writes). For each attempt that has a
+    score.json, constructs a JudgeInput and calls judge.rate(),
+    then writes the serialized JudgeResult to ``<attempt_dir>/<judge_output_name>``.
+
+    ``overwrite=False`` (default): if ``judge_output_name`` already
+    exists, skip the attempt. Allows incremental re-runs that only
+    fill in missing judge.json files. ``overwrite=True`` re-rates
+    every attempt.
+    """
+    if not run_dir.exists():
+        raise FileNotFoundError(f"run-dir not found: {run_dir}")
+
+    attempt_dirs = _discover_attempt_dirs(run_dir)
+    processed = 0
+    skipped = 0
+    failed = 0
+    skip_reasons: dict[str, str] = {}
+    failure_reasons: dict[str, str] = {}
+
+    for attempt_dir in attempt_dirs:
+        rel = str(attempt_dir.relative_to(run_dir))
+        score_path = attempt_dir / "score.json"
+        if not score_path.exists():
+            skipped += 1
+            skip_reasons[rel] = "score.json missing"
+            continue
+        output_path = attempt_dir / judge_output_name
+        if output_path.exists() and not overwrite:
+            skipped += 1
+            skip_reasons[rel] = f"{judge_output_name} already exists (use overwrite=True)"
+            continue
+
+        try:
+            score_data = json.loads(score_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            skipped += 1
+            skip_reasons[rel] = f"score.json unparseable: {exc}"
+            continue
+
+        attempt = _build_input(attempt_dir, score_data, rubric)
+        if attempt is None:
+            skipped += 1
+            skip_reasons[rel] = "required artifact missing (diff.patch / prompt.md)"
+            continue
+
+        before_sha = _sha256_file(score_path)
+        result: Optional[JudgeResult] = None
+        rate_error: Optional[BaseException] = None
+        try:
+            result = judge.rate(attempt)
+        except Exception as exc:  # noqa: BLE001 — per-attempt isolation
+            rate_error = exc
+
+        # Additivity check runs whether rate() succeeded OR raised. A
+        # judge that mutates score.json and then raises must still
+        # trip the guard — otherwise per-attempt failure isolation
+        # would silently swallow an invariant violation and the CLI
+        # would return a normal summary. The guard takes precedence
+        # over the per-attempt failure recording: any mutation is a
+        # hard fail for the whole run, not a per-attempt skip.
+        after_sha = _sha256_file(score_path)
+        if before_sha != after_sha:
+            raise ScoreJsonMutatedError(
+                f"judge {judge.judge_id!r} mutated {score_path} during rate() "
+                f"(sha256 {before_sha} → {after_sha}); the additivity "
+                f"invariant forbids this. Fix the judge implementation."
+            )
+
+        if rate_error is not None:
+            failed += 1
+            failure_reasons[rel] = f"{type(rate_error).__name__}: {rate_error}"
+            continue
+
+        assert result is not None  # rate_error is None ⇒ result was assigned
+        _write_judge_json(output_path, result)
+        processed += 1
+
+    return RunJudgeStats(
+        attempts_processed=processed,
+        attempts_skipped=skipped,
+        attempts_failed=failed,
+        skip_reasons=skip_reasons,
+        failure_reasons=failure_reasons,
+    )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _discover_attempt_dirs(run_dir: Path) -> list[Path]:
+    """Find every ``attempt-NN-run-MM/`` directory under ``run_dir``.
+
+    Returns a sorted list so the runner's behavior is deterministic
+    across machines (sorting by path string is enough — attempts
+    sort first by task-slug then by attempt-run name).
+    """
+    found: list[Path] = []
+    for child in sorted(run_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        # Layout: run_dir / <task-slug> / attempt-NN-run-MM
+        for grand in sorted(child.iterdir()):
+            if grand.is_dir() and _ATTEMPT_DIR_RE.match(grand.name):
+                found.append(grand)
+    return found
+
+
+def _build_input(
+    attempt_dir: Path,
+    score_data: dict,
+    rubric: RubricSpec,
+) -> Optional[JudgeInput]:
+    """Assemble a JudgeInput from attempt artifacts. None if missing required files."""
+    diff_path = attempt_dir / "diff.patch"
+    prompt_path = attempt_dir / "prompt.md"
+    if not diff_path.exists() or not prompt_path.exists():
+        return None
+    verify_output_path = attempt_dir / "verify-output.txt"
+    verify_output = (
+        verify_output_path.read_text(encoding="utf-8")
+        if verify_output_path.exists()
+        else ""
+    )
+    return JudgeInput(
+        attempt_dir=attempt_dir,
+        task_id=str(score_data.get("task_id", "")),
+        benchmark_id=str(score_data.get("benchmark_id", "")),
+        diff_path=diff_path,
+        prompt_path=prompt_path,
+        verify_output=verify_output,
+        rubric=rubric,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _write_judge_json(path: Path, result: JudgeResult) -> None:
+    payload = _serialize_result(result)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def _serialize_result(result: JudgeResult) -> dict:
+    """JudgeResult → JSON-serializable dict (judge.json schema 1.0)."""
+    return {
+        "schema_version": JUDGE_JSON_SCHEMA_VERSION,
+        "judge_id": result.judge_id,
+        "judge_model": result.judge_model,
+        "judge_backend_id": result.judge_backend_id,
+        "rubric_name": result.rubric_name,
+        "rubric_dimensions": list(result.ratings.keys()),
+        "ratings": {
+            dim: _serialize_rating(r) for dim, r in result.ratings.items()
+        },
+        "judge_invocation": _serialize_invocation(result.invocation),
+        "tokens_input": result.tokens_input,
+        "tokens_output": result.tokens_output,
+        "judge_metadata": dict(result.judge_metadata),
+    }
+
+
+def _serialize_rating(r: DimensionRating) -> dict:
+    return {
+        "rating": r.rating,
+        "explanation": r.explanation,
+        "prompt_sha256": r.prompt_sha256,
+    }
+
+
+def _serialize_invocation(inv: JudgeInvocation) -> dict:
+    return {
+        "model": inv.model,
+        "temperature": inv.temperature,
+        "seed": inv.seed,
+        "temperature_control": inv.temperature_control,
+        "seed_control": inv.seed_control,
+        "provider_endpoint_present": inv.provider_endpoint_present,
+    }

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-missing-dim.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-missing-dim.json
@@ -1,0 +1,9 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE3333333333333333",
+  "result": "{\n  \"ratings\": {\n    \"idiomaticity\": {\n      \"rating\": 4,\n      \"explanation\": \"Idiomatic.\"\n    },\n    \"error_handling\": {\n      \"rating\": 3,\n      \"explanation\": \"Functional.\"\n    }\n  }\n}",
+  "usage": {
+    "input_tokens": 2700,
+    "output_tokens": 220
+  }
+}

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-no-usage.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-no-usage.json
@@ -1,0 +1,5 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE5555555555555555",
+  "result": "{\n  \"ratings\": {\n    \"idiomaticity\": {\"rating\": 3, \"explanation\": \"Adequate.\"},\n    \"error_handling\": {\"rating\": 3, \"explanation\": \"Functional.\"},\n    \"test_thoughtfulness\": {\"rating\": 2, \"explanation\": \"Token tests.\"},\n    \"security_hygiene\": {\"rating\": 3, \"explanation\": \"Adequate.\"}\n  }\n}"
+}

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-null-dim.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-null-dim.json
@@ -1,0 +1,9 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE1111111111111111",
+  "result": "{\n  \"ratings\": {\n    \"idiomaticity\": {\n      \"rating\": 3,\n      \"explanation\": \"Adequate for the language; nothing remarkable.\"\n    },\n    \"error_handling\": {\n      \"rating\": 3,\n      \"explanation\": \"Specific exception types; one over-broad catch.\"\n    },\n    \"test_thoughtfulness\": {\n      \"rating\": null,\n      \"explanation\": \"Task instructions explicitly forbid editing the test file (Aider Polyglot framing); model had no opportunity to demonstrate test thoughtfulness.\"\n    },\n    \"security_hygiene\": {\n      \"rating\": null,\n      \"explanation\": \"Pure-string algorithm; no IO, no parsing, no shell, no SQL — nothing for a defensive posture to defend against.\"\n    }\n  }\n}",
+  "usage": {
+    "input_tokens": 2950,
+    "output_tokens": 410
+  }
+}

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-out-of-band.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-out-of-band.json
@@ -1,0 +1,9 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE2222222222222222",
+  "result": "{\n  \"ratings\": {\n    \"idiomaticity\": {\n      \"rating\": 6,\n      \"explanation\": \"Model emitted a rating outside the 1-5 band.\"\n    },\n    \"error_handling\": {\n      \"rating\": 0,\n      \"explanation\": \"Zero is also outside the band.\"\n    },\n    \"test_thoughtfulness\": {\n      \"rating\": 3,\n      \"explanation\": \"Adequate.\"\n    },\n    \"security_hygiene\": {\n      \"rating\": 4,\n      \"explanation\": \"Defensive.\"\n    }\n  }\n}",
+  "usage": {
+    "input_tokens": 2800,
+    "output_tokens": 380
+  }
+}

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-success.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-success.json
@@ -1,0 +1,9 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE0000000000000000",
+  "result": "{\n  \"ratings\": {\n    \"idiomaticity\": {\n      \"rating\": 4,\n      \"explanation\": \"Naming and control flow match Python conventions. The list comprehension on line 12 is idiomatic; the manual loop on line 18 would also work but a comprehension would be more native.\"\n    },\n    \"error_handling\": {\n      \"rating\": 3,\n      \"explanation\": \"Catches ValueError on parse but uses a bare except in one spot. Common failure modes are handled; one over-broad catch.\"\n    },\n    \"test_thoughtfulness\": {\n      \"rating\": 2,\n      \"explanation\": \"One happy-path test only; no edge cases.\"\n    },\n    \"security_hygiene\": {\n      \"rating\": 4,\n      \"explanation\": \"Uses parameterized queries; no shell concatenation; input validated at boundaries.\"\n    }\n  }\n}",
+  "usage": {
+    "input_tokens": 3200,
+    "output_tokens": 480
+  }
+}

--- a/scripts/benchmark_runner/tests/fixtures/judge/transcript-unparseable-inner.json
+++ b/scripts/benchmark_runner/tests/fixtures/judge/transcript-unparseable-inner.json
@@ -1,0 +1,9 @@
+{
+  "type": "result",
+  "session_id": "01HV1JUDGE4444444444444444",
+  "result": "The four dimensions of this attempt are roughly: idiomaticity good, error handling weak, tests minimal, security adequate. (LLM forgot to format as JSON.)",
+  "usage": {
+    "input_tokens": 2650,
+    "output_tokens": 95
+  }
+}

--- a/scripts/benchmark_runner/tests/test_claude_code_judge.py
+++ b/scripts/benchmark_runner/tests/test_claude_code_judge.py
@@ -1,0 +1,546 @@
+# tests/test_claude_code_judge.py — ClaudeCodeJudge tests.
+#
+# These tests do NOT spawn the real ``claude`` CLI. The transcript
+# parser is exercised against committed fixtures, and the rate()
+# path is exercised against a fake `claude` shim that echoes a
+# chosen fixture. Mirrors the codex/aider/claude_code backend
+# fake-CLI pattern; no network, no auth, no live LLM.
+#
+# Coverage:
+#   - parse_judge_output (pure function): 7 fixture cases + edge cases.
+#   - ClaudeCodeJudge shape: protocol conformance, factory, CLI-missing.
+#   - End-to-end against the fake `claude` shim: argv contract
+#     flag-by-flag, prompt via stdin, cwd = attempt_dir, env-var
+#     recording, the corrected determinism contract (no --temperature,
+#     no --seed; judge_invocation records null/"unsupported"),
+#     defensive paths (out-of-band ratings, missing dimensions,
+#     unparseable inner, timeout).
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from benchmark_runner.judge.claude_code_judge import (
+    BARE_OPT_IN_ENV_VAR,
+    GATEWAY_AUTH_TOKEN_ENV_VAR,
+    GATEWAY_BASE_URL_ENV_VAR,
+    JUDGE_BACKEND_ID,
+    JUDGE_FAMILY,
+    PARSE_STATUS_INNER_UNPARSEABLE,
+    PARSE_STATUS_MISSING_DIMENSIONS,
+    PARSE_STATUS_OK,
+    PARSE_STATUS_OUTER_UNPARSEABLE,
+    PARSE_STATUS_OUT_OF_BAND_RATING,
+    TIMEOUT_OPT_IN_ENV_VAR,
+    ClaudeCliNotFoundError,
+    ClaudeCodeJudge,
+    InvalidJudgeTimeoutError,
+    factory,
+    parse_judge_output,
+)
+from benchmark_runner.judge.contracts import (
+    SEED_CONTROL_UNSUPPORTED,
+    TEMPERATURE_CONTROL_UNSUPPORTED,
+    Judge,
+    JudgeInput,
+    RubricSpec,
+)
+
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "judge"
+_DIMENSIONS = (
+    "idiomaticity",
+    "error_handling",
+    "test_thoughtfulness",
+    "security_hygiene",
+)
+
+# Minimal prompt template — exercises every placeholder the judge
+# substitutes. Real rubric-default-v1.md is richer; this synthetic
+# template keeps the test independent of the rubric loader (TB1.3).
+_TEST_PROMPT_TEMPLATE = (
+    "Task: {task_id} ({benchmark_id})\n"
+    "PROMPT:\n{prompt}\n"
+    "DIFF:\n{diff}\n"
+    "VERIFY:\n{verify_output}\n"
+    "Rate four dimensions and return JSON.\n"
+)
+
+
+_FAKE_CLAUDE = """#!{shebang}
+# Fake `claude` for judge tests: echoes a chosen fixture, captures
+# argv + cwd + stdin into CCT_FAKE_CLAUDE_LOG, exits with
+# CCT_FAKE_CLAUDE_EXIT_CODE (default 0).
+import json, os, sys
+log_path = os.environ.get("CCT_FAKE_CLAUDE_LOG", "")
+fixture_path = os.environ["CCT_FAKE_CLAUDE_TRANSCRIPT"]
+stdin_data = sys.stdin.read()
+if log_path:
+    with open(log_path, "w", encoding="utf-8") as f:
+        json.dump({{
+            "argv": sys.argv,
+            "cwd": os.getcwd(),
+            "stdin": stdin_data,
+            "env_keys": sorted(os.environ.keys()),
+        }}, f)
+with open(fixture_path, "r", encoding="utf-8") as src:
+    sys.stdout.write(src.read())
+sys.exit(int(os.environ.get("CCT_FAKE_CLAUDE_EXIT_CODE", "0")))
+"""
+
+
+def _install_fake_claude(tmpdir: Path) -> Path:
+    bindir = tmpdir / "fake-bin"
+    bindir.mkdir()
+    fake = bindir / "claude"
+    fake.write_text(_FAKE_CLAUDE.format(shebang=sys.executable), encoding="utf-8")
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return fake
+
+
+def _make_attempt(
+    tmp_path: Path,
+    *,
+    diff: str = "diff content\n",
+    prompt: str = "Implement leap.py\n",
+    verify: str = "1 passed\n",
+) -> JudgeInput:
+    attempt_dir = tmp_path / "attempt-01-run-001"
+    attempt_dir.mkdir()
+    (attempt_dir / "diff.patch").write_text(diff, encoding="utf-8")
+    (attempt_dir / "prompt.md").write_text(prompt, encoding="utf-8")
+    rubric = RubricSpec(
+        name="default-v1",
+        dimensions=_DIMENSIONS,
+        prompt_template=_TEST_PROMPT_TEMPLATE,
+    )
+    return JudgeInput(
+        attempt_dir=attempt_dir,
+        task_id="python/leap",
+        benchmark_id="aider-polyglot",
+        diff_path=attempt_dir / "diff.patch",
+        prompt_path=attempt_dir / "prompt.md",
+        verify_output=verify,
+        rubric=rubric,
+    )
+
+
+# ── Parser unit tests ─────────────────────────────────────────────────
+
+
+class TestParseJudgeOutput(unittest.TestCase):
+    def test_success_yields_full_ratings_and_usage(self) -> None:
+        stdout = (_FIXTURES / "transcript-success.json").read_text(encoding="utf-8")
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OK)
+        self.assertEqual(set(p.ratings.keys()), set(_DIMENSIONS))
+        self.assertEqual(p.ratings["idiomaticity"]["rating"], 4)
+        self.assertEqual(p.ratings["error_handling"]["rating"], 3)
+        self.assertEqual(p.ratings["test_thoughtfulness"]["rating"], 2)
+        self.assertEqual(p.ratings["security_hygiene"]["rating"], 4)
+        self.assertEqual(p.tokens_input, 3200)
+        self.assertEqual(p.tokens_output, 480)
+        self.assertEqual(p.session_id, "01HV1JUDGE0000000000000000")
+
+    def test_null_dim_preserved_as_null(self) -> None:
+        stdout = (_FIXTURES / "transcript-null-dim.json").read_text(encoding="utf-8")
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OK)
+        self.assertIsNone(p.ratings["test_thoughtfulness"]["rating"])
+        self.assertIsNone(p.ratings["security_hygiene"]["rating"])
+        self.assertEqual(p.ratings["idiomaticity"]["rating"], 3)
+
+    def test_out_of_band_flagged(self) -> None:
+        stdout = (_FIXTURES / "transcript-out-of-band.json").read_text(encoding="utf-8")
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OUT_OF_BAND_RATING)
+        self.assertIn("idiomaticity", p.note)
+        self.assertIn("error_handling", p.note)
+        # Parser preserves the raw values; the judge's per-dim
+        # builder downgrades them to null.
+        self.assertEqual(p.ratings["idiomaticity"]["rating"], 6)
+        self.assertEqual(p.ratings["error_handling"]["rating"], 0)
+
+    def test_missing_dim_flagged(self) -> None:
+        stdout = (_FIXTURES / "transcript-missing-dim.json").read_text(encoding="utf-8")
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_MISSING_DIMENSIONS)
+        self.assertIn("test_thoughtfulness", p.note)
+        self.assertIn("security_hygiene", p.note)
+        # Present dims still recorded.
+        self.assertEqual(p.ratings["idiomaticity"]["rating"], 4)
+
+    def test_unparseable_inner_flagged(self) -> None:
+        stdout = (_FIXTURES / "transcript-unparseable-inner.json").read_text(
+            encoding="utf-8"
+        )
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_INNER_UNPARSEABLE)
+        self.assertEqual(p.ratings, {})
+
+    def test_empty_stdout_flagged(self) -> None:
+        p = parse_judge_output("", _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OUTER_UNPARSEABLE)
+        self.assertIsNone(p.tokens_input)
+
+    def test_outer_unparseable_flagged(self) -> None:
+        p = parse_judge_output("not JSON at all", _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OUTER_UNPARSEABLE)
+
+    def test_no_usage_block_yields_none_tokens(self) -> None:
+        stdout = (_FIXTURES / "transcript-no-usage.json").read_text(encoding="utf-8")
+        p = parse_judge_output(stdout, _DIMENSIONS)
+        self.assertEqual(p.status, PARSE_STATUS_OK)
+        # Mirrors the backend's null-vs-zero discipline: missing usage
+        # block → None, never coerced to 0.
+        self.assertIsNone(p.tokens_input)
+        self.assertIsNone(p.tokens_output)
+
+
+# ── Judge shape tests ─────────────────────────────────────────────────
+
+
+class TestJudgeShape(unittest.TestCase):
+    def test_satisfies_judge_protocol(self) -> None:
+        self.assertIsInstance(ClaudeCodeJudge(model="sonnet"), Judge)
+
+    def test_judge_id_is_family(self) -> None:
+        self.assertEqual(ClaudeCodeJudge().judge_id, JUDGE_FAMILY)
+
+    def test_factory_carries_model(self) -> None:
+        j = factory("claude-sonnet-4-6")
+        self.assertEqual(j._model, "claude-sonnet-4-6")  # noqa: SLF001 (test-only)
+
+    def test_rate_raises_when_cli_missing(self) -> None:
+        j = ClaudeCodeJudge(model="", cli_executable="claude-not-installed-xyz")
+        tmp = tempfile.mkdtemp(prefix="cct-judge-test-")
+        try:
+            attempt = _make_attempt(Path(tmp))
+            with self.assertRaises(ClaudeCliNotFoundError):
+                j.rate(attempt)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ── End-to-end via fake claude shim ───────────────────────────────────
+
+
+class TestJudgeEndToEndAgainstFakeCli(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-test-")
+        self._tmp_path = Path(self._tmp)
+        self._fake = _install_fake_claude(self._tmp_path)
+        self._invocation_log = self._tmp_path / "invocation.json"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _rate(
+        self,
+        fixture_name: str,
+        *,
+        model: str = "sonnet",
+        env_overrides: dict[str, str] | None = None,
+    ) -> dict:
+        attempt = _make_attempt(self._tmp_path)
+        fixture_path = _FIXTURES / fixture_name
+        overrides = dict(env_overrides or {})
+        overrides.update({
+            "CCT_FAKE_CLAUDE_TRANSCRIPT": str(fixture_path),
+            "CCT_FAKE_CLAUDE_LOG": str(self._invocation_log),
+        })
+        judge = ClaudeCodeJudge(model=model, cli_executable=str(self._fake))
+        old_env = {k: os.environ.get(k) for k in overrides}
+        try:
+            os.environ.update(overrides)
+            result = judge.rate(attempt)
+        finally:
+            for k, v in old_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+        return {
+            "result": result,
+            "log": json.loads(self._invocation_log.read_text(encoding="utf-8")),
+            "attempt": attempt,
+        }
+
+    # ── Argv contract ──────────────────────────────────────────────
+
+    def test_argv_contract_flag_by_flag(self) -> None:
+        out = self._rate("transcript-success.json")
+        argv = out["log"]["argv"]
+        # The CLI binary name is fake-bin/claude — argv[0] is the
+        # full path; assert it ends with /claude rather than equals.
+        self.assertTrue(argv[0].endswith("/claude"))
+        self.assertIn("-p", argv)
+        # Output format JSON for the wrapper.
+        self.assertIn("--output-format", argv)
+        ofmt_idx = argv.index("--output-format")
+        self.assertEqual(argv[ofmt_idx + 1], "json")
+        # Tools disabled — judge produces a rating, not file edits.
+        # ``--tools ""`` is the documented disable per ``claude --help``;
+        # ``--allowedTools`` is a different surface (which tools are
+        # permitted, not which are available) and is deliberately NOT
+        # used here. Peer review 2026-05-20.
+        self.assertIn("--tools", argv)
+        tools_idx = argv.index("--tools")
+        self.assertEqual(argv[tools_idx + 1], "")
+        self.assertNotIn("--allowedTools", argv)
+        self.assertNotIn("--allowed-tools", argv)
+        # Model passed through when set.
+        self.assertIn("--model", argv)
+        model_idx = argv.index("--model")
+        self.assertEqual(argv[model_idx + 1], "sonnet")
+        # Launcher mode by default — no --bare unless opted in.
+        self.assertNotIn("--bare", argv)
+
+    def test_no_temperature_or_seed_flags_in_argv(self) -> None:
+        # Determinism contract: the CLI exposes neither knob, and the
+        # judge MUST NOT pretend to pass them. Catching this as an
+        # explicit test so a future contributor who adds the flag back
+        # has to update this test deliberately.
+        out = self._rate("transcript-success.json")
+        argv = out["log"]["argv"]
+        self.assertNotIn("--temperature", argv)
+        self.assertNotIn("--seed", argv)
+        # Also no --permission-mode — judge edits nothing.
+        self.assertNotIn("--permission-mode", argv)
+
+    def test_no_model_flag_when_model_empty(self) -> None:
+        out = self._rate("transcript-success.json", model="")
+        argv = out["log"]["argv"]
+        self.assertNotIn("--model", argv)
+
+    def test_bare_flag_added_under_env_opt_in(self) -> None:
+        out = self._rate(
+            "transcript-success.json",
+            env_overrides={BARE_OPT_IN_ENV_VAR: "1"},
+        )
+        self.assertIn("--bare", out["log"]["argv"])
+        # And recorded in metadata.
+        self.assertEqual(
+            out["result"].judge_metadata["claude_code_invocation"], "bare"
+        )
+
+    def test_launcher_is_default_metadata(self) -> None:
+        out = self._rate("transcript-success.json")
+        self.assertEqual(
+            out["result"].judge_metadata["claude_code_invocation"], "launcher"
+        )
+
+    # ── Prompt + cwd ──────────────────────────────────────────────
+
+    def test_prompt_sent_on_stdin_with_substitutions(self) -> None:
+        out = self._rate("transcript-success.json")
+        stdin = out["log"]["stdin"]
+        # All five substitutions present.
+        self.assertIn("python/leap", stdin)
+        self.assertIn("aider-polyglot", stdin)
+        self.assertIn("Implement leap.py", stdin)  # prompt
+        self.assertIn("diff content", stdin)       # diff
+        self.assertIn("1 passed", stdin)           # verify_output
+
+    def test_cwd_is_attempt_dir(self) -> None:
+        out = self._rate("transcript-success.json")
+        # ``os.getcwd()`` returns a resolved path; on macOS
+        # ``/var/folders/...`` resolves to ``/private/var/folders/...``.
+        # Compare resolved paths so the test isn't platform-fragile.
+        self.assertEqual(
+            Path(out["log"]["cwd"]).resolve(),
+            out["attempt"].attempt_dir.resolve(),
+        )
+
+    # ── Determinism contract on the result ──────────────────────────
+
+    def test_judge_invocation_records_unsupported_determinism(self) -> None:
+        # THE peer-reviewed correction: temperature/seed null +
+        # control "unsupported", never silent 0.0.
+        out = self._rate("transcript-success.json")
+        inv = out["result"].invocation
+        self.assertIsNone(inv.temperature)
+        self.assertIsNone(inv.seed)
+        self.assertEqual(inv.temperature_control, TEMPERATURE_CONTROL_UNSUPPORTED)
+        self.assertEqual(inv.seed_control, SEED_CONTROL_UNSUPPORTED)
+
+    def test_judge_metadata_contains_no_secrets(self) -> None:
+        out = self._rate(
+            "transcript-success.json",
+            env_overrides={GATEWAY_AUTH_TOKEN_ENV_VAR: "sk-test-redacted"},
+        )
+        meta_str = str(dict(out["result"].judge_metadata))
+        inv_str = str(out["result"].invocation)
+        # Token value must not appear anywhere on the result.
+        self.assertNotIn("sk-test-redacted", meta_str)
+        self.assertNotIn("sk-test-redacted", inv_str)
+        # And no "Bearer " prefix either.
+        self.assertNotIn("Bearer ", meta_str)
+        self.assertNotIn("Bearer ", inv_str)
+
+    def test_provider_endpoint_recorded_as_boolean(self) -> None:
+        # Presence recorded; URL never recorded.
+        out = self._rate(
+            "transcript-success.json",
+            env_overrides={GATEWAY_BASE_URL_ENV_VAR: "http://127.0.0.1:8787"},
+        )
+        inv = out["result"].invocation
+        self.assertIs(inv.provider_endpoint_present, True)
+        meta_str = str(dict(out["result"].judge_metadata))
+        inv_str = str(inv)
+        self.assertNotIn("127.0.0.1", meta_str)
+        self.assertNotIn("127.0.0.1", inv_str)
+
+    def test_provider_endpoint_false_when_unset(self) -> None:
+        # Make sure the env var isn't leaking from the host.
+        out = self._rate(
+            "transcript-success.json",
+            env_overrides={GATEWAY_BASE_URL_ENV_VAR: ""},
+        )
+        self.assertIs(out["result"].invocation.provider_endpoint_present, False)
+
+    # ── Result shape ──────────────────────────────────────────────
+
+    def test_result_carries_all_dimensions(self) -> None:
+        out = self._rate("transcript-success.json")
+        ratings = out["result"].ratings
+        self.assertEqual(set(ratings.keys()), set(_DIMENSIONS))
+        self.assertEqual(ratings["idiomaticity"].rating, 4)
+        self.assertEqual(ratings["security_hygiene"].rating, 4)
+
+    def test_result_tokens_passed_through(self) -> None:
+        out = self._rate("transcript-success.json")
+        self.assertEqual(out["result"].tokens_input, 3200)
+        self.assertEqual(out["result"].tokens_output, 480)
+
+    def test_result_rubric_name_passed_through(self) -> None:
+        out = self._rate("transcript-success.json")
+        self.assertEqual(out["result"].rubric_name, "default-v1")
+
+    def test_result_judge_ids(self) -> None:
+        out = self._rate("transcript-success.json")
+        self.assertEqual(out["result"].judge_id, JUDGE_FAMILY)
+        self.assertEqual(out["result"].judge_backend_id, JUDGE_BACKEND_ID)
+        self.assertEqual(out["result"].judge_model, "sonnet")
+
+    def test_prompt_sha256_consistent_across_dimensions(self) -> None:
+        # v1: one combined prompt per attempt → every dimension's
+        # rating carries the same prompt_sha256.
+        out = self._rate("transcript-success.json")
+        shas = {r.prompt_sha256 for r in out["result"].ratings.values()}
+        self.assertEqual(len(shas), 1)
+        self.assertEqual(len(next(iter(shas))), 64)  # sha256 hex
+
+    # ── Defensive paths ───────────────────────────────────────────
+
+    def test_null_dim_passes_through_to_result(self) -> None:
+        out = self._rate("transcript-null-dim.json")
+        ratings = out["result"].ratings
+        self.assertIsNone(ratings["test_thoughtfulness"].rating)
+        self.assertIn("forbid", ratings["test_thoughtfulness"].explanation.lower())
+        self.assertIsNone(ratings["security_hygiene"].rating)
+
+    def test_out_of_band_downgraded_to_null_with_explanation(self) -> None:
+        # The contract dataclass would reject rating=6 or rating=0.
+        # The judge catches and substitutes null + explanation so
+        # one bad rating from the LLM doesn't crash the whole call.
+        out = self._rate("transcript-out-of-band.json")
+        ratings = out["result"].ratings
+        self.assertIsNone(ratings["idiomaticity"].rating)
+        self.assertIn("out-of-band", ratings["idiomaticity"].explanation)
+        self.assertIn("6", ratings["idiomaticity"].explanation)
+        self.assertIsNone(ratings["error_handling"].rating)
+        self.assertIn("0", ratings["error_handling"].explanation)
+        # In-band ratings still come through.
+        self.assertEqual(ratings["test_thoughtfulness"].rating, 3)
+        self.assertEqual(ratings["security_hygiene"].rating, 4)
+        # parse_status flags the anomaly.
+        self.assertEqual(
+            out["result"].judge_metadata["parse_status"],
+            PARSE_STATUS_OUT_OF_BAND_RATING,
+        )
+
+    def test_missing_dim_recorded_as_null_with_diagnostic(self) -> None:
+        out = self._rate("transcript-missing-dim.json")
+        ratings = out["result"].ratings
+        self.assertIsNone(ratings["test_thoughtfulness"].rating)
+        self.assertIn("missing", ratings["test_thoughtfulness"].explanation)
+        self.assertEqual(
+            out["result"].judge_metadata["parse_status"],
+            PARSE_STATUS_MISSING_DIMENSIONS,
+        )
+
+    def test_unparseable_inner_all_null_with_status(self) -> None:
+        out = self._rate("transcript-unparseable-inner.json")
+        ratings = out["result"].ratings
+        for dim in _DIMENSIONS:
+            self.assertIsNone(ratings[dim].rating)
+        self.assertEqual(
+            out["result"].judge_metadata["parse_status"],
+            PARSE_STATUS_INNER_UNPARSEABLE,
+        )
+
+    def test_nonzero_exit_recorded(self) -> None:
+        out = self._rate(
+            "transcript-success.json",
+            env_overrides={"CCT_FAKE_CLAUDE_EXIT_CODE": "1"},
+        )
+        self.assertEqual(out["result"].judge_metadata["exit_code"], 1)
+
+
+# ── Env-var override validation ───────────────────────────────────────
+
+
+class TestTimeoutOverride(unittest.TestCase):
+    """``CCT_JUDGE_TIMEOUT_SECONDS`` must fail loud on bad values.
+
+    Silently dropping a typo would mask a configuration error and
+    let calibration use the wrong budget.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-test-")
+        self._fake = _install_fake_claude(Path(self._tmp))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _rate_with_timeout(self, value: str) -> None:
+        attempt = _make_attempt(Path(self._tmp))
+        judge = ClaudeCodeJudge(model="sonnet", cli_executable=str(self._fake))
+        old = os.environ.get(TIMEOUT_OPT_IN_ENV_VAR)
+        try:
+            os.environ[TIMEOUT_OPT_IN_ENV_VAR] = value
+            os.environ["CCT_FAKE_CLAUDE_TRANSCRIPT"] = str(
+                _FIXTURES / "transcript-success.json"
+            )
+            judge.rate(attempt)
+        finally:
+            if old is None:
+                os.environ.pop(TIMEOUT_OPT_IN_ENV_VAR, None)
+            else:
+                os.environ[TIMEOUT_OPT_IN_ENV_VAR] = old
+            os.environ.pop("CCT_FAKE_CLAUDE_TRANSCRIPT", None)
+
+    def test_non_integer_raises(self) -> None:
+        with self.assertRaises(InvalidJudgeTimeoutError):
+            self._rate_with_timeout("not-a-number")
+
+    def test_zero_raises(self) -> None:
+        with self.assertRaises(InvalidJudgeTimeoutError):
+            self._rate_with_timeout("0")
+
+    def test_negative_raises(self) -> None:
+        with self.assertRaises(InvalidJudgeTimeoutError):
+            self._rate_with_timeout("-10")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_cli_judge.py
+++ b/scripts/benchmark_runner/tests/test_cli_judge.py
@@ -1,0 +1,208 @@
+# tests/test_cli_judge.py — CLI 'judge' subcommand wiring tests.
+#
+# Argument parsing + dispatch + error paths only. The judge runner
+# and rubric loader have their own dedicated test modules; this
+# module just verifies the CLI handler routes through them with the
+# right error semantics.
+#
+# End-to-end through the real ``claude`` CLI is out of scope (no
+# live LLM in CI). The handler is tested by running the CLI against
+# a synthetic run-dir + a monkeypatched judge factory that returns a
+# stub.
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from benchmark_runner.cli import EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, main
+from benchmark_runner.judge.contracts import (
+    DimensionRating,
+    JudgeInput,
+    JudgeInvocation,
+    JudgeResult,
+)
+
+
+class _CannedJudge:
+    judge_id = "canned-judge"
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        return JudgeResult(
+            judge_id=self.judge_id,
+            judge_model="canned",
+            judge_backend_id="canned",
+            rubric_name=attempt.rubric.name,
+            ratings={
+                dim: DimensionRating(
+                    rating=3,
+                    explanation="canned",
+                    prompt_sha256="canned",
+                )
+                for dim in attempt.rubric.dimensions
+            },
+            invocation=JudgeInvocation(model="canned"),
+        )
+
+
+def _make_run_dir(tmp: Path) -> Path:
+    run_dir = tmp / "20260520T000000Z-aider-polyglot-claude-code-001"
+    run_dir.mkdir()
+    attempt_dir = run_dir / "python-bowling" / "attempt-01-run-001"
+    attempt_dir.mkdir(parents=True)
+    (attempt_dir / "score.json").write_text(
+        json.dumps({
+            "schema_version": "1.0",
+            "benchmark_id": "aider-polyglot",
+            "task_id": "python/bowling",
+            "result": "fail",
+        }) + "\n",
+        encoding="utf-8",
+    )
+    (attempt_dir / "diff.patch").write_text("diff\n", encoding="utf-8")
+    (attempt_dir / "prompt.md").write_text("prompt\n", encoding="utf-8")
+    (attempt_dir / "verify-output.txt").write_text("ok\n", encoding="utf-8")
+    return run_dir
+
+
+class TestCliJudge(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-cli-judge-test-")
+        self.tmpdir = Path(self._tmp)
+        self.run_dir = _make_run_dir(self.tmpdir)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _invoke(self, *argv: str) -> tuple[int, str, str]:
+        out = io.StringIO()
+        err = io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(list(argv))
+        return code, out.getvalue(), err.getvalue()
+
+    # ── error paths (no monkeypatch needed) ─────────────────────────
+
+    def test_run_dir_missing_returns_usage_error(self) -> None:
+        code, _, err = self._invoke(
+            "judge",
+            "--run-dir", str(self.tmpdir / "does-not-exist"),
+            "--judge", "claude-code:sonnet",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("run-dir not found", err)
+
+    def test_judge_arg_without_colon_returns_usage_error(self) -> None:
+        code, _, err = self._invoke(
+            "judge",
+            "--run-dir", str(self.run_dir),
+            "--judge", "claude-code",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("<family>:<model>", err)
+
+    def test_unknown_judge_family_returns_usage_error(self) -> None:
+        code, _, err = self._invoke(
+            "judge",
+            "--run-dir", str(self.run_dir),
+            "--judge", "totally-fake-judge:sonnet",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("unknown judge family", err)
+
+    def test_unknown_rubric_returns_usage_error(self) -> None:
+        # The default rubric (default-v1) is on disk and loadable;
+        # request a non-existent one.
+        code, _, err = self._invoke(
+            "judge",
+            "--run-dir", str(self.run_dir),
+            "--judge", "claude-code-judge:sonnet",
+            "--rubric", "does-not-exist",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("rubric-does-not-exist.md", err)
+
+    # ── happy path with monkeypatched factory ─────────────────────
+
+    def test_happy_path_invokes_runner_and_prints_summary(self) -> None:
+        # The SDD-canonical CLI surface is `claude-code:sonnet`
+        # (spec.md scenarios + Interface section). Monkeypatch the
+        # factory to return a stub so the test doesn't need the real
+        # `claude` CLI in CI.
+        with mock.patch(
+            "benchmark_runner.cli._JUDGE_FACTORIES",
+            new={"claude-code": lambda model: _CannedJudge()},
+        ):
+            code, out, err = self._invoke(
+                "judge",
+                "--run-dir", str(self.run_dir),
+                "--judge", "claude-code:sonnet",
+            )
+        self.assertEqual(code, EXIT_OK, msg=f"stderr: {err}")
+        payload = json.loads(out)
+        self.assertEqual(payload["attempts_processed"], 1)
+        self.assertEqual(payload["attempts_skipped"], 0)
+        self.assertEqual(payload["attempts_failed"], 0)
+        self.assertEqual(payload["judge"], "claude-code:sonnet")
+        self.assertEqual(payload["rubric"], "default-v1")
+        # judge.json was actually written.
+        produced = self.run_dir / "python-bowling" / "attempt-01-run-001" / "judge.json"
+        self.assertTrue(produced.exists())
+
+    def test_claude_code_judge_alias_also_accepted(self) -> None:
+        # ``claude-code-judge`` is the internal judge_id (recorded in
+        # judge.json's ``judge_id`` field). Accepting it as a CLI
+        # alias for ``claude-code`` lets a user copy that value
+        # verbatim into a re-run command without translation.
+        with mock.patch(
+            "benchmark_runner.cli._JUDGE_FACTORIES",
+            new={"claude-code": lambda model: _CannedJudge()},
+        ):
+            code, out, err = self._invoke(
+                "judge",
+                "--run-dir", str(self.run_dir),
+                "--judge", "claude-code-judge:sonnet",
+            )
+        self.assertEqual(code, EXIT_OK, msg=f"stderr: {err}")
+        payload = json.loads(out)
+        # Echoed as the user typed it (preserve their intent for log
+        # readability), not normalized to the canonical family.
+        self.assertEqual(payload["judge"], "claude-code-judge:sonnet")
+        self.assertEqual(payload["attempts_processed"], 1)
+
+    def test_runtime_error_on_score_mutation(self) -> None:
+        # A judge that mutates score.json must surface as EXIT_RUNTIME
+        # (not a silent success) — the additivity invariant is
+        # load-bearing and the CLI is the user-facing gate that
+        # surfaces the violation.
+
+        class _MutatingJudge:
+            judge_id = "mutating-judge"
+
+            def rate(self, attempt: JudgeInput) -> JudgeResult:
+                (attempt.attempt_dir / "score.json").write_text(
+                    "MUTATED\n", encoding="utf-8"
+                )
+                return _CannedJudge().rate(attempt)
+
+        with mock.patch(
+            "benchmark_runner.cli._JUDGE_FACTORIES",
+            new={"claude-code": lambda model: _MutatingJudge()},
+        ):
+            code, _, err = self._invoke(
+                "judge",
+                "--run-dir", str(self.run_dir),
+                "--judge", "claude-code:sonnet",
+            )
+        self.assertEqual(code, EXIT_RUNTIME)
+        self.assertIn("mutated", err.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_cli_judge.py
+++ b/scripts/benchmark_runner/tests/test_cli_judge.py
@@ -76,6 +76,15 @@ class TestCliJudge(unittest.TestCase):
         self._tmp = tempfile.mkdtemp(prefix="cct-cli-judge-test-")
         self.tmpdir = Path(self._tmp)
         self.run_dir = _make_run_dir(self.tmpdir)
+        # Call register_all() in setUp so mock.patch.dict can override
+        # already-registered entries inside individual tests. Without
+        # this, register_all() running inside the with-block would see
+        # a registry pre-populated by mock.patch.dict and raise
+        # "different factory" on the canonical token — TB1.5 registry
+        # contract is strict about same-key/different-factory
+        # collisions (test_different_factories_under_same_token_raises).
+        from benchmark_runner._register import register_all
+        register_all()
 
     def tearDown(self) -> None:
         shutil.rmtree(self._tmp, ignore_errors=True)
@@ -135,9 +144,12 @@ class TestCliJudge(unittest.TestCase):
         # (spec.md scenarios + Interface section). Monkeypatch the
         # factory to return a stub so the test doesn't need the real
         # `claude` CLI in CI.
-        with mock.patch(
-            "benchmark_runner.cli._JUDGE_FACTORIES",
-            new={"claude-code": lambda model: _CannedJudge()},
+        with mock.patch.dict(
+            "benchmark_runner.judge.registry._JUDGES",
+            {
+                "claude-code": lambda model: _CannedJudge(),
+                "claude-code-judge": lambda model: _CannedJudge(),
+            },
         ):
             code, out, err = self._invoke(
                 "judge",
@@ -160,9 +172,12 @@ class TestCliJudge(unittest.TestCase):
         # judge.json's ``judge_id`` field). Accepting it as a CLI
         # alias for ``claude-code`` lets a user copy that value
         # verbatim into a re-run command without translation.
-        with mock.patch(
-            "benchmark_runner.cli._JUDGE_FACTORIES",
-            new={"claude-code": lambda model: _CannedJudge()},
+        with mock.patch.dict(
+            "benchmark_runner.judge.registry._JUDGES",
+            {
+                "claude-code": lambda model: _CannedJudge(),
+                "claude-code-judge": lambda model: _CannedJudge(),
+            },
         ):
             code, out, err = self._invoke(
                 "judge",
@@ -191,9 +206,9 @@ class TestCliJudge(unittest.TestCase):
                 )
                 return _CannedJudge().rate(attempt)
 
-        with mock.patch(
-            "benchmark_runner.cli._JUDGE_FACTORIES",
-            new={"claude-code": lambda model: _MutatingJudge()},
+        with mock.patch.dict(
+            "benchmark_runner.judge.registry._JUDGES",
+            {"claude-code": lambda model: _MutatingJudge()},
         ):
             code, _, err = self._invoke(
                 "judge",

--- a/scripts/benchmark_runner/tests/test_cli_skeleton.py
+++ b/scripts/benchmark_runner/tests/test_cli_skeleton.py
@@ -45,6 +45,13 @@ class TestListCommand(CLITestBase):
         payload = json.loads(stdout)
         self.assertIn("stub", payload["adapters"])
         self.assertIn("stub", payload["backends"])
+        # TB1.5 — `judges` key now ships in the list output and
+        # both shipped claude-code tokens (canonical + alias)
+        # appear. Pin the contract so a future regression that
+        # drops one is caught here.
+        self.assertIn("judges", payload)
+        self.assertIn("claude-code", payload["judges"])
+        self.assertIn("claude-code-judge", payload["judges"])
 
     def test_list_after_extra_adapter_registration(self) -> None:
         # Pre-register an additional adapter under a name that does NOT

--- a/scripts/benchmark_runner/tests/test_corpus_select.py
+++ b/scripts/benchmark_runner/tests/test_corpus_select.py
@@ -1,0 +1,748 @@
+# tests/test_corpus_select.py — calibration corpus selector tests.
+#
+# Three layers:
+#   1. Synthetic-fixture unit tests for the pure select_corpus()
+#      function (no I/O).
+#   2. Filesystem-level tests for discover_candidates() against a
+#      tmpdir runs/ tree (synthetic run-record.json + score.json).
+#   3. Live-acceptance test against the real runs/ archive — gated by
+#      a skip when the archive is absent (fresh-clone CI safety).
+#      Asserts the issue #48 acceptance: target_n=50, axes=model +
+#      repeated-runs, both axes represented.
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+from benchmark_runner.calibration.corpus_select import (
+    AXIS_ADAPTER,
+    AXIS_BACKEND,
+    AXIS_MODEL,
+    AXIS_REPEATED_RUNS,
+    CORPUS_SCHEMA_VERSION,
+    Candidate,
+    EmptyCandidatePoolError,
+    InsufficientAxisRepresentationError,
+    InvalidAxisError,
+    SelectionResult,
+    discover_candidates,
+    parse_axes_arg,
+    select_and_write,
+    select_corpus,
+    write_corpus,
+)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LIVE_RUNS_ROOT = _REPO_ROOT / "runs"
+
+
+# ── Pure-function helpers ─────────────────────────────────────────────
+
+
+def _candidate(
+    *,
+    rel_path: str,
+    model: str,
+    task_id: str = "python/leap",
+    benchmark_id: str = "aider-polyglot",
+    backend_id: str = "claude-code",
+    result: str = "fail",
+    attempt: int = 1,
+    run_id: str = "run-001",
+) -> Candidate:
+    return Candidate(
+        rel_path=rel_path,
+        abs_path=Path(f"/tmp/{rel_path}"),
+        benchmark_id=benchmark_id,
+        backend_id=backend_id,
+        model=model,
+        task_id=task_id,
+        result=result,
+        attempt=attempt,
+        run_id=run_id,
+    )
+
+
+# ── select_corpus pure-function tests ─────────────────────────────────
+
+
+class TestParseAxesArg(unittest.TestCase):
+    def test_valid_axes(self) -> None:
+        self.assertEqual(
+            parse_axes_arg("model,repeated-runs"),
+            ["model", "repeated-runs"],
+        )
+
+    def test_preserves_order(self) -> None:
+        # Order matters for the round-robin's grouping key
+        # ((model, adapter) vs (adapter, model)). The CLI must
+        # preserve what the user typed.
+        self.assertEqual(
+            parse_axes_arg("adapter,model,backend"),
+            ["adapter", "model", "backend"],
+        )
+
+    def test_whitespace_tolerant(self) -> None:
+        self.assertEqual(
+            parse_axes_arg("  model , repeated-runs "),
+            ["model", "repeated-runs"],
+        )
+
+    def test_empty_string_raises(self) -> None:
+        with self.assertRaises(InvalidAxisError):
+            parse_axes_arg("")
+        with self.assertRaises(InvalidAxisError):
+            parse_axes_arg(",,,")
+
+    def test_unknown_axis_raises(self) -> None:
+        with self.assertRaisesRegex(InvalidAxisError, "unknown axis"):
+            parse_axes_arg("model,not-a-real-axis")
+
+    def test_duplicate_raises(self) -> None:
+        with self.assertRaisesRegex(InvalidAxisError, "duplicate"):
+            parse_axes_arg("model,model")
+
+
+class TestSelectCorpusModelAxis(unittest.TestCase):
+    """The acceptance hinge for #48: `--axes model` round-robins by
+    distinct model values to ensure ≥2 are represented."""
+
+    def setUp(self) -> None:
+        # 12 candidates across 3 models. Path-sorted such that the
+        # first 5 lexicographically are all model-A; without the
+        # round-robin guarantee, a naive head() would select 0 of B/C.
+        self.candidates = [
+            _candidate(rel_path=f"run-A/task-{i:02d}/attempt-01-run-001",
+                       model="model-A")
+            for i in range(5)
+        ] + [
+            _candidate(rel_path=f"run-B/task-{i:02d}/attempt-01-run-001",
+                       model="model-B")
+            for i in range(5)
+        ] + [
+            _candidate(rel_path=f"run-C/task-{i:02d}/attempt-01-run-001",
+                       model="model-C")
+            for i in range(5)
+        ]
+
+    def test_round_robin_includes_every_model_at_small_target(self) -> None:
+        # target_n=3, 3 models → exactly one of each (round-robin
+        # picks one per group on the first pass).
+        result = select_corpus(self.candidates, [AXIS_MODEL], target_n=3)
+        models = {c.model for c in result.selected}
+        self.assertEqual(models, {"model-A", "model-B", "model-C"})
+        self.assertEqual(len(result.selected), 3)
+
+    def test_balanced_distribution_at_larger_target(self) -> None:
+        result = select_corpus(self.candidates, [AXIS_MODEL], target_n=9)
+        per_model: dict[str, int] = {}
+        for c in result.selected:
+            per_model[c.model] = per_model.get(c.model, 0) + 1
+        # Round-robin → 3 per model.
+        self.assertEqual(per_model, {"model-A": 3, "model-B": 3, "model-C": 3})
+
+    def test_at_least_two_models_represented(self) -> None:
+        # The issue #48 acceptance: with --axes model, the selected
+        # set has ≥2 distinct values for model.
+        result = select_corpus(self.candidates, [AXIS_MODEL], target_n=5)
+        models = {c.model for c in result.selected}
+        self.assertGreaterEqual(len(models), 2)
+
+    def test_pool_with_single_model_raises_pre_selection(self) -> None:
+        single = [_candidate(rel_path=f"run-A/t{i:02d}/attempt-01-run-001",
+                             model="only-one")
+                  for i in range(10)]
+        with self.assertRaisesRegex(InsufficientAxisRepresentationError, "model"):
+            select_corpus(single, [AXIS_MODEL], target_n=5)
+
+
+class TestSelectCorpusRepeatedRunsAxis(unittest.TestCase):
+    """The other acceptance hinge: `--axes repeated-runs` ensures at
+    least one (task, backend, model) tuple has ≥2 selected attempts."""
+
+    def setUp(self) -> None:
+        # A pool with model variation AND repeated attempts. 5 distinct
+        # tasks for model-A; for one task, 3 attempts (genuine repeats).
+        # Other models have 1 attempt per task to avoid accidentally
+        # satisfying repeated-runs from elsewhere.
+        c = []
+        # model-A repeats on python/leap (3 attempts).
+        for run_n in (1, 2, 3):
+            c.append(_candidate(
+                rel_path=f"run-A-r{run_n}/python-leap/attempt-01-run-001",
+                model="model-A",
+                task_id="python/leap",
+                run_id=f"run-00{run_n}",
+            ))
+        # model-A on other tasks, single attempts.
+        for t in ("hello-world", "bowling", "raindrops", "leap-year-helper"):
+            c.append(_candidate(
+                rel_path=f"run-A-only/{t}/attempt-01-run-001",
+                model="model-A",
+                task_id=f"python/{t}",
+            ))
+        # model-B, single attempts each on distinct tasks.
+        for t in ("alpha", "beta", "gamma", "delta", "epsilon"):
+            c.append(_candidate(
+                rel_path=f"run-B/{t}/attempt-01-run-001",
+                model="model-B",
+                task_id=f"python/{t}",
+            ))
+        self.candidates = c
+
+    def test_repeated_runs_satisfied_naturally(self) -> None:
+        # With target_n large enough to naturally pull both repeats,
+        # the algorithm satisfies repeated-runs without repair.
+        result = select_corpus(
+            self.candidates,
+            [AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=10,
+        )
+        # At least one (task, backend, model) tuple has ≥2 entries.
+        tuples: dict = {}
+        for sc in result.selected:
+            k = (sc.task_id, sc.backend_id, sc.model)
+            tuples[k] = tuples.get(k, 0) + 1
+        self.assertTrue(any(v >= 2 for v in tuples.values()),
+                        msg=f"tuples: {tuples}")
+
+    def test_repeated_runs_strategy_a_extends_existing_tuple(self) -> None:
+        # target_n=10, axes=[model, repeated-runs] — round-robin pulls
+        # one of each model alternately; among model-A's picks is
+        # python/leap (the only repeating tuple in the pool). When
+        # repeated-runs isn't yet satisfied at the end of round-robin,
+        # repair Strategy A extends (python/leap, A) by adding its
+        # unselected sibling, replacing the LAST entry that doesn't
+        # belong to that tuple. Both axes remain satisfied because
+        # Strategy A only sacrifices a NON-key entry.
+        result = select_corpus(
+            self.candidates,
+            [AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=10,
+        )
+        # Repeated-runs satisfied.
+        tuples: dict = {}
+        for sc in result.selected:
+            k = (sc.task_id, sc.backend_id, sc.model)
+            tuples[k] = tuples.get(k, 0) + 1
+        self.assertTrue(any(v >= 2 for v in tuples.values()),
+                        msg=f"tuples: {tuples}")
+        # AND model axis still satisfied — Strategy A's whole point
+        # is to preserve the other axes.
+        models = {sc.model for sc in result.selected}
+        self.assertGreaterEqual(len(models), 2,
+                                msg=f"models lost after repair: {models}")
+
+    def test_repair_that_would_break_model_axis_raises(self) -> None:
+        # target_n=2, axes=[model, repeated-runs] — round-robin picks
+        # one of each model (no repeats), no selected tuple has a
+        # sibling in the pool, so Strategy A fails and Strategy B
+        # would replace the last two entries with siblings of a
+        # repeating tuple — which would collapse the model axis to
+        # 1 distinct value. With the post-repair re-validation
+        # (added 2026-05-20), this is now a hard error instead of
+        # a silent degradation.
+        with self.assertRaisesRegex(
+            InsufficientAxisRepresentationError, "left axis 'model'"
+        ):
+            select_corpus(
+                self.candidates,
+                [AXIS_MODEL, AXIS_REPEATED_RUNS],
+                target_n=2,
+            )
+
+    def test_repeated_runs_target_n_one_raises(self) -> None:
+        # target_n=1 can never satisfy repeated-runs (need at least
+        # 2 selections of the same tuple). Pre-validated before
+        # round-robin so the error message names the real constraint.
+        with self.assertRaisesRegex(
+            InsufficientAxisRepresentationError, "target_n >= 2"
+        ):
+            select_corpus(
+                self.candidates,
+                [AXIS_MODEL, AXIS_REPEATED_RUNS],
+                target_n=1,
+            )
+
+    def test_pool_with_no_repeats_raises_for_repeated_runs(self) -> None:
+        # Pool has model variation but every (task, backend, model)
+        # tuple is unique → repeated-runs axis cannot be satisfied.
+        unique = []
+        for i, m in enumerate(("a", "b", "c")):
+            for t in (f"t{i}-x", f"t{i}-y", f"t{i}-z"):
+                unique.append(_candidate(
+                    rel_path=f"run/{m}/{t}/attempt-01-run-001",
+                    model=m,
+                    task_id=t,
+                ))
+        with self.assertRaisesRegex(
+            InsufficientAxisRepresentationError, "repeated-runs"
+        ):
+            select_corpus(unique, [AXIS_MODEL, AXIS_REPEATED_RUNS], target_n=5)
+
+
+class TestSelectCorpusDeterminism(unittest.TestCase):
+    """Determinism + reproducibility (user-mandated constraint)."""
+
+    def _pool(self) -> list[Candidate]:
+        # Larger pool with varied paths to exercise sort stability.
+        out = []
+        for model in ("alpha", "beta", "gamma"):
+            for t in range(8):
+                for attempt in (1, 2):
+                    out.append(_candidate(
+                        rel_path=f"run-{model}/task-{t:02d}/attempt-{attempt:02d}-run-001",
+                        model=model,
+                        task_id=f"task-{t:02d}",
+                        attempt=attempt,
+                    ))
+        # Shuffle to verify the algorithm doesn't depend on input order.
+        return out[::-1]
+
+    def test_same_inputs_same_outputs(self) -> None:
+        r1 = select_corpus(self._pool(), [AXIS_MODEL, AXIS_REPEATED_RUNS], target_n=12)
+        r2 = select_corpus(self._pool(), [AXIS_MODEL, AXIS_REPEATED_RUNS], target_n=12)
+        self.assertEqual(
+            [c.rel_path for c in r1.selected],
+            [c.rel_path for c in r2.selected],
+        )
+
+    def test_output_sorted_by_rel_path(self) -> None:
+        result = select_corpus(self._pool(), [AXIS_MODEL], target_n=9)
+        paths = [c.rel_path for c in result.selected]
+        self.assertEqual(paths, sorted(paths))
+
+
+class TestSelectCorpusInputValidation(unittest.TestCase):
+    def test_empty_candidates_raises(self) -> None:
+        with self.assertRaises(EmptyCandidatePoolError):
+            select_corpus([], [AXIS_MODEL], target_n=5)
+
+    def test_target_n_zero_raises(self) -> None:
+        c = [_candidate(rel_path=f"r/{i}/attempt-01-run-001", model="m")
+             for i in range(2)]
+        with self.assertRaisesRegex(ValueError, "target_n"):
+            select_corpus(c, [AXIS_MODEL], target_n=0)
+
+    def test_target_n_exceeds_pool_raises(self) -> None:
+        c = [_candidate(rel_path=f"r/{i}/attempt-01-run-001", model="m")
+             for i in range(3)]
+        with self.assertRaisesRegex(
+            InsufficientAxisRepresentationError, "exceeds candidate pool"
+        ):
+            select_corpus(c, [AXIS_MODEL], target_n=100)
+
+    def test_unknown_axis_raises(self) -> None:
+        c = [_candidate(rel_path=f"r/{i}/attempt-01-run-001", model="m")
+             for i in range(2)]
+        with self.assertRaisesRegex(InvalidAxisError, "unknown axis"):
+            select_corpus(c, ["not-an-axis"], target_n=2)
+
+    def test_empty_axes_raises(self) -> None:
+        c = [_candidate(rel_path=f"r/{i}/attempt-01-run-001", model="m")
+             for i in range(2)]
+        with self.assertRaises(InvalidAxisError):
+            select_corpus(c, [], target_n=2)
+
+
+# ── discover_candidates filesystem tests ──────────────────────────────
+
+
+def _write_attempt(
+    base: Path,
+    *,
+    benchmark_id: str = "aider-polyglot",
+    backend_id: str = "claude-code",
+    model: str = "sonnet",
+    task_id: str = "python/leap",
+    result: str = "pass",
+    attempt: int = 1,
+    run_id: str = "run-001",
+    skip_run_record: bool = False,
+    skip_score: bool = False,
+    malformed_run_record: bool = False,
+    malformed_score: bool = False,
+    omit_fields: Optional[set[str]] = None,
+) -> Path:
+    """Stage one attempt directory + run-record.json + score.json."""
+    base.mkdir(parents=True, exist_ok=True)
+    omit_fields = omit_fields or set()
+    run_record = {
+        "schema_version": "1.0",
+        "benchmark_id": benchmark_id,
+        "task_id": task_id,
+        "backend_id": backend_id,
+        "run_id": run_id,
+        "attempt": attempt,
+        "backend_invocation": {"model": model},
+    }
+    for f in omit_fields:
+        # Allow tests to remove top-level fields to simulate corruption.
+        run_record.pop(f, None)
+    score = {
+        "schema_version": "1.0",
+        "benchmark_id": benchmark_id,
+        "task_id": task_id,
+        "result": result,
+    }
+    if not skip_run_record:
+        text = "NOT JSON {{" if malformed_run_record else json.dumps(run_record)
+        (base / "run-record.json").write_text(text + "\n", encoding="utf-8")
+    if not skip_score:
+        text = "ALSO NOT JSON" if malformed_score else json.dumps(score)
+        (base / "score.json").write_text(text + "\n", encoding="utf-8")
+    return base
+
+
+class TestDiscoverCandidates(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-corpus-test-")
+        self.runs_root = Path(self._tmp) / "runs"
+        self.runs_root.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_discovers_single_run_layout(self) -> None:
+        # runs/<run>/<task>/<attempt>
+        _write_attempt(
+            self.runs_root / "20260520-aider-001" / "python-leap" / "attempt-01-run-001",
+            model="sonnet",
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].model, "sonnet")
+        self.assertEqual(skipped, {})
+
+    def test_discovers_compare_run_layout(self) -> None:
+        # runs/<compare>/<run>/<task>/<attempt>
+        _write_attempt(
+            self.runs_root / "20260520-compare-001" / "20260520-aider-A"
+            / "python-leap" / "attempt-01-run-001",
+            model="sonnet",
+        )
+        _write_attempt(
+            self.runs_root / "20260520-compare-001" / "20260520-aider-B"
+            / "python-leap" / "attempt-01-run-001",
+            model="opus",
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(len(candidates), 2)
+        self.assertEqual(skipped, {})
+
+    def test_missing_score_json_reported_not_dropped(self) -> None:
+        _write_attempt(
+            self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001",
+            skip_score=True,
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(candidates, [])
+        # Skip recorded with reason.
+        self.assertEqual(len(skipped), 1)
+        reason = next(iter(skipped.values()))
+        self.assertIn("score.json missing", reason)
+
+    def test_missing_run_record_reported_not_dropped(self) -> None:
+        _write_attempt(
+            self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001",
+            skip_run_record=True,
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(candidates, [])
+        reason = next(iter(skipped.values()))
+        self.assertIn("run-record.json missing", reason)
+
+    def test_malformed_run_record_reported_not_dropped(self) -> None:
+        _write_attempt(
+            self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001",
+            malformed_run_record=True,
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(candidates, [])
+        reason = next(iter(skipped.values()))
+        self.assertIn("run-record.json unparseable", reason)
+
+    def test_malformed_score_json_reported_not_dropped(self) -> None:
+        _write_attempt(
+            self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001",
+            malformed_score=True,
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(candidates, [])
+        reason = next(iter(skipped.values()))
+        self.assertIn("score.json unparseable", reason)
+
+    def test_malformed_typed_attempt_reported_not_fatal(self) -> None:
+        # ``attempt: "not-int"`` is JSON-parseable but the type is
+        # wrong. The walker must record it as a skip (with reason)
+        # and CONTINUE — not abort on the int() coercion.
+        rec_dir = self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001"
+        rec_dir.mkdir(parents=True)
+        rec = {
+            "schema_version": "1.0",
+            "benchmark_id": "aider-polyglot",
+            "task_id": "python/leap",
+            "backend_id": "claude-code",
+            "run_id": "run-001",
+            "attempt": "not-int",  # malformed type
+            "backend_invocation": {"model": "sonnet"},
+        }
+        (rec_dir / "run-record.json").write_text(json.dumps(rec) + "\n", encoding="utf-8")
+        (rec_dir / "score.json").write_text(
+            json.dumps({"result": "fail"}) + "\n", encoding="utf-8",
+        )
+        # Add a HEALTHY second attempt so we can verify the walker
+        # didn't abort prematurely — the healthy record must come
+        # through even though the malformed one preceded it.
+        _write_attempt(
+            self.runs_root / "run-B" / "python-leap" / "attempt-01-run-001",
+            model="opus",
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(len(candidates), 1)  # the healthy one
+        self.assertEqual(candidates[0].model, "opus")
+        # The malformed one was recorded as a skip, not crashed.
+        self.assertEqual(len(skipped), 1)
+        reason = next(iter(skipped.values()))
+        self.assertIn("malformed typed field", reason)
+
+    def test_malformed_backend_invocation_type_reported_not_fatal(self) -> None:
+        # ``backend_invocation: "not-a-dict"`` would crash a
+        # ``.get("model")`` call. Walker must skip with a reason,
+        # not abort.
+        rec_dir = self.runs_root / "run-bad" / "python-leap" / "attempt-01-run-001"
+        rec_dir.mkdir(parents=True)
+        rec = {
+            "schema_version": "1.0",
+            "benchmark_id": "aider-polyglot",
+            "task_id": "python/leap",
+            "backend_id": "claude-code",
+            "run_id": "run-001",
+            "attempt": 1,
+            "backend_invocation": "this-should-be-a-dict",
+        }
+        (rec_dir / "run-record.json").write_text(json.dumps(rec) + "\n", encoding="utf-8")
+        (rec_dir / "score.json").write_text(
+            json.dumps({"result": "fail"}) + "\n", encoding="utf-8",
+        )
+        _write_attempt(
+            self.runs_root / "run-good" / "python-leap" / "attempt-01-run-001",
+            model="sonnet",
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].model, "sonnet")
+        self.assertEqual(len(skipped), 1)
+        reason = next(iter(skipped.values()))
+        self.assertIn("backend_invocation", reason)
+        self.assertIn("wrong type", reason)
+
+    def test_missing_required_field_reported_not_dropped(self) -> None:
+        # Drop benchmark_id from the run-record.json → required-field
+        # skip rather than silent default.
+        _write_attempt(
+            self.runs_root / "run-A" / "python-leap" / "attempt-01-run-001",
+            omit_fields={"benchmark_id"},
+        )
+        candidates, skipped = discover_candidates(self.runs_root)
+        self.assertEqual(candidates, [])
+        reason = next(iter(skipped.values()))
+        self.assertIn("missing fields", reason)
+        self.assertIn("benchmark_id", reason)
+
+    def test_runs_root_missing_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            discover_candidates(self.runs_root.parent / "nope")
+
+    def test_discovery_order_is_deterministic(self) -> None:
+        # Lay out three attempts; assert the order returned matches
+        # sorted-by-rel_path regardless of filesystem readdir order.
+        for letter in ("c", "a", "b"):
+            _write_attempt(
+                self.runs_root / f"run-{letter}" / "task" / "attempt-01-run-001",
+                model=letter,
+            )
+        candidates, _ = discover_candidates(self.runs_root)
+        rels = [c.rel_path for c in candidates]
+        self.assertEqual(rels, sorted(rels))
+
+
+# ── write_corpus + select_and_write ───────────────────────────────────
+
+
+class TestWriteCorpusAndEndToEnd(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-corpus-test-")
+        self.runs_root = Path(self._tmp) / "runs"
+        self.runs_root.mkdir()
+        # Stage 3 models × 2 tasks × 2 attempts = 12 attempts.
+        for m in ("alpha", "beta", "gamma"):
+            for t in ("t-x", "t-y"):
+                for a in (1, 2):
+                    _write_attempt(
+                        self.runs_root / f"run-{m}" / t
+                        / f"attempt-{a:02d}-run-001",
+                        model=m,
+                        task_id=f"python/{t}",
+                        attempt=a,
+                    )
+        self.output_dir = Path(self._tmp) / "out"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_select_and_write_produces_corpus_and_meta(self) -> None:
+        corpus_path, meta_path, result = select_and_write(
+            runs_root=self.runs_root,
+            axes=[AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=6,
+            name="test-corpus",
+            output_dir=self.output_dir,
+            selection_command="pretend command",
+        )
+        self.assertTrue(corpus_path.exists())
+        self.assertTrue(meta_path.exists())
+        # corpus.jsonl has one JSON record per line.
+        lines = corpus_path.read_text(encoding="utf-8").strip().splitlines()
+        self.assertEqual(len(lines), 6)
+        for line in lines:
+            rec = json.loads(line)
+            self.assertIn("run_path", rec)
+            self.assertIn("model", rec)
+            self.assertIn("task_id", rec)
+        # meta.json carries the reproducibility record.
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta["schema_version"], CORPUS_SCHEMA_VERSION)
+        self.assertEqual(meta["name"], "test-corpus")
+        self.assertEqual(meta["target_n"], 6)
+        self.assertEqual(meta["actual_n"], 6)
+        self.assertEqual(meta["axes"], [AXIS_MODEL, AXIS_REPEATED_RUNS])
+        self.assertEqual(meta["selection_command"], "pretend command")
+
+    def test_runs_root_never_mutated(self) -> None:
+        # Snapshot every file under runs/ pre- and post- and assert
+        # nothing changed. The selector is additive ONLY to output_dir.
+        before = {
+            p: p.read_bytes()
+            for p in self.runs_root.rglob("*") if p.is_file()
+        }
+        select_and_write(
+            runs_root=self.runs_root,
+            axes=[AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=6,
+            name="test-corpus",
+            output_dir=self.output_dir,
+        )
+        after = {
+            p: p.read_bytes()
+            for p in self.runs_root.rglob("*") if p.is_file()
+        }
+        self.assertEqual(before.keys(), after.keys())
+        for p, content in before.items():
+            self.assertEqual(after[p], content)
+
+    def test_meta_records_skipped_attempts(self) -> None:
+        # Add a deliberately malformed attempt and confirm meta.json
+        # surfaces it under "skipped".
+        _write_attempt(
+            self.runs_root / "run-bad" / "task" / "attempt-01-run-001",
+            malformed_score=True,
+        )
+        _, meta_path, _ = select_and_write(
+            runs_root=self.runs_root,
+            axes=[AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=6,
+            name="with-skips",
+            output_dir=self.output_dir,
+        )
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        # Exactly the malformed one was skipped (others were healthy).
+        self.assertEqual(len(meta["skipped"]), 1)
+        reason = next(iter(meta["skipped"].values()))
+        self.assertIn("score.json unparseable", reason)
+
+    def test_axis_summary_in_meta(self) -> None:
+        _, meta_path, _ = select_and_write(
+            runs_root=self.runs_root,
+            axes=[AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=6,
+            name="axis-summary",
+            output_dir=self.output_dir,
+        )
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertIn("model", meta["axis_summary"])
+        self.assertIn("repeated-runs", meta["axis_summary"])
+        # Model axis: ≥2 distinct values.
+        self.assertGreaterEqual(len(meta["axis_summary"]["model"]), 2)
+        # Repeated-runs: ≥1 tuple with ≥2 selections.
+        self.assertGreaterEqual(
+            meta["axis_summary"]["repeated-runs"]["tuples_with_>=2_runs"], 1,
+        )
+
+
+# ── Live acceptance against the real runs/ archive ────────────────────
+
+
+@unittest.skipUnless(
+    _LIVE_RUNS_ROOT.exists() and any(_LIVE_RUNS_ROOT.rglob("attempt-*")),
+    "live runs/ archive absent on this machine (fresh clone / CI)",
+)
+class TestLiveCorpusAcceptance(unittest.TestCase):
+    """Issue #48 acceptance gate.
+
+    Runs the real selector against the maintainer's runs/ archive
+    and asserts the corpus satisfies the documented threshold:
+    target_n >= 50 and ≥2 axes represented (model + repeated-runs).
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-corpus-live-")
+        self.output_dir = Path(self._tmp)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_target_n_50_axes_model_and_repeated_runs(self) -> None:
+        corpus_path, meta_path, result = select_and_write(
+            runs_root=_LIVE_RUNS_ROOT,
+            axes=[AXIS_MODEL, AXIS_REPEATED_RUNS],
+            target_n=50,
+            name="live-acceptance",
+            output_dir=self.output_dir,
+            selection_command="(test) live-acceptance probe",
+        )
+        # Acceptance bar #1: target_n hit.
+        self.assertGreaterEqual(len(result.selected), 50)
+        # Acceptance bar #2: model axis represented (≥2 distinct).
+        models = {c.model for c in result.selected}
+        self.assertGreaterEqual(
+            len(models), 2,
+            msg=f"only {len(models)} distinct models in selection: {models}",
+        )
+        # Acceptance bar #3: repeated-runs satisfied.
+        tuples: dict = {}
+        for c in result.selected:
+            k = (c.task_id, c.backend_id, c.model)
+            tuples[k] = tuples.get(k, 0) + 1
+        repeats = [(k, v) for k, v in tuples.items() if v >= 2]
+        self.assertGreaterEqual(
+            len(repeats), 1,
+            msg="no (task, backend, model) tuple has ≥2 attempts in the selection",
+        )
+        # meta.json was written + readable.
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(meta["axes"], [AXIS_MODEL, AXIS_REPEATED_RUNS])
+        # Sanity: runs_root in meta points at the live tree.
+        self.assertEqual(
+            Path(meta["runs_root"]).resolve(), _LIVE_RUNS_ROOT.resolve(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_judge_protocol.py
+++ b/scripts/benchmark_runner/tests/test_judge_protocol.py
@@ -1,0 +1,365 @@
+# tests/test_judge_protocol.py — Judge protocol + dataclass shape tests.
+#
+# Mirrors test_contracts.py for the backend contracts: frozen-ness,
+# null defaults, runtime_checkable conformance. No live LLM; no
+# fake-CLI shim either — this module covers the dataclass + Protocol
+# surface only. The fake-CLI suite for the claude_code judge lives
+# in test_claude_code_judge.py (TB1.2).
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+from benchmark_runner.judge.contracts import (
+    JUDGE_RATING_MAX,
+    JUDGE_RATING_MIN,
+    SEED_CONTROL_AVAILABLE_NOT_PINNED,
+    SEED_CONTROL_SUPPORTED,
+    SEED_CONTROL_UNSUPPORTED,
+    TEMPERATURE_CONTROL_AVAILABLE_NOT_PINNED,
+    TEMPERATURE_CONTROL_SUPPORTED,
+    TEMPERATURE_CONTROL_UNSUPPORTED,
+    DimensionRating,
+    Judge,
+    JudgeInput,
+    JudgeInvocation,
+    JudgeResult,
+    RubricSpec,
+)
+
+
+# ── Module constants ───────────────────────────────────────────────────
+
+
+class TestRatingBounds(unittest.TestCase):
+    def test_rating_bounds_are_inclusive_and_sane(self) -> None:
+        self.assertEqual(JUDGE_RATING_MIN, 1)
+        self.assertEqual(JUDGE_RATING_MAX, 5)
+        self.assertLess(JUDGE_RATING_MIN, JUDGE_RATING_MAX)
+
+
+class TestControlSentinels(unittest.TestCase):
+    def test_temperature_control_sentinels_distinct(self) -> None:
+        # The three sentinels must be distinct strings so the report
+        # can tell "knob doesn't exist" apart from "knob exists,
+        # judge chose not to pin" apart from "pinned to recorded
+        # value." A future schema migration would notice if any two
+        # collided.
+        sentinels = {
+            TEMPERATURE_CONTROL_SUPPORTED,
+            TEMPERATURE_CONTROL_UNSUPPORTED,
+            TEMPERATURE_CONTROL_AVAILABLE_NOT_PINNED,
+        }
+        self.assertEqual(len(sentinels), 3)
+
+    def test_seed_control_sentinels_distinct(self) -> None:
+        sentinels = {
+            SEED_CONTROL_SUPPORTED,
+            SEED_CONTROL_UNSUPPORTED,
+            SEED_CONTROL_AVAILABLE_NOT_PINNED,
+        }
+        self.assertEqual(len(sentinels), 3)
+
+
+# ── RubricSpec ─────────────────────────────────────────────────────────
+
+
+class TestRubricSpec(unittest.TestCase):
+    def test_frozen(self) -> None:
+        r = RubricSpec(
+            name="default-v1",
+            dimensions=("idiomaticity",),
+            prompt_template="rate {diff}",
+        )
+        with self.assertRaises(FrozenInstanceError):
+            r.name = "other"  # type: ignore[misc]
+
+    def test_dimensions_is_tuple_not_list(self) -> None:
+        # Tuple is immutable; List would allow caller-side mutation
+        # to silently change the rubric after the spec was captured.
+        r = RubricSpec(
+            name="x",
+            dimensions=("a", "b", "c"),
+            prompt_template="t",
+        )
+        self.assertIsInstance(r.dimensions, tuple)
+
+
+# ── JudgeInput ─────────────────────────────────────────────────────────
+
+
+class TestJudgeInput(unittest.TestCase):
+    def _rubric(self) -> RubricSpec:
+        return RubricSpec(
+            name="default-v1",
+            dimensions=("idiomaticity",),
+            prompt_template="rate {diff}",
+        )
+
+    def test_frozen(self) -> None:
+        ji = JudgeInput(
+            attempt_dir=Path("/tmp/a"),
+            task_id="python/bowling",
+            benchmark_id="aider-polyglot",
+            diff_path=Path("/tmp/a/diff.patch"),
+            prompt_path=Path("/tmp/a/prompt.md"),
+            verify_output="ok",
+            rubric=self._rubric(),
+        )
+        with self.assertRaises(FrozenInstanceError):
+            ji.task_id = "other"  # type: ignore[misc]
+
+    def test_verify_output_is_string_not_path(self) -> None:
+        # The runner sometimes truncates verify output before writing
+        # it; the judge prompt wants the content inline. Passing a
+        # path would force the judge to re-read and would lose the
+        # truncation context. The field is str by contract.
+        ji = JudgeInput(
+            attempt_dir=Path("/tmp/a"),
+            task_id="t",
+            benchmark_id="b",
+            diff_path=Path("/tmp/a/diff.patch"),
+            prompt_path=Path("/tmp/a/prompt.md"),
+            verify_output="multi\nline\noutput",
+            rubric=self._rubric(),
+        )
+        self.assertIsInstance(ji.verify_output, str)
+        self.assertIn("\n", ji.verify_output)
+
+
+# ── DimensionRating ────────────────────────────────────────────────────
+
+
+class TestDimensionRating(unittest.TestCase):
+    def test_frozen(self) -> None:
+        d = DimensionRating(rating=4, explanation="ok", prompt_sha256="abc")
+        with self.assertRaises(FrozenInstanceError):
+            d.rating = 5  # type: ignore[misc]
+
+    def test_null_rating_is_distinct_from_zero(self) -> None:
+        # rating=None means "structurally inapplicable"; rating=1 is
+        # the lowest-quality rating. They must not be coerced.
+        # (Zero is outside the rating bounds entirely; this test
+        # documents the None-vs-bottom-rating distinction.)
+        inapplicable = DimensionRating(
+            rating=None,
+            explanation="task forbids editing tests",
+            prompt_sha256="x",
+        )
+        low = DimensionRating(
+            rating=JUDGE_RATING_MIN,
+            explanation="no tests on a task that allowed them",
+            prompt_sha256="y",
+        )
+        self.assertIsNone(inapplicable.rating)
+        self.assertEqual(low.rating, 1)
+        self.assertNotEqual(inapplicable, low)
+
+    def test_explanation_required_for_null_rating(self) -> None:
+        # The rubric requires a one-line justification when rating
+        # is null. The dataclass doesn't enforce non-empty (that's
+        # the judge implementation's job), but the field is
+        # required (no default) — verified by attempting to
+        # construct without it.
+        with self.assertRaises(TypeError):
+            DimensionRating(  # type: ignore[call-arg]
+                rating=None,
+                prompt_sha256="x",
+            )
+
+    def test_rating_in_bounds_accepted(self) -> None:
+        # Every value in [JUDGE_RATING_MIN, JUDGE_RATING_MAX] must
+        # construct without raising. Documents the inclusive range.
+        for r in range(JUDGE_RATING_MIN, JUDGE_RATING_MAX + 1):
+            DimensionRating(rating=r, explanation="ok", prompt_sha256="x")
+
+    def test_rating_zero_rejected(self) -> None:
+        # Zero is outside the 1..5 band. The reviewer-flagged case:
+        # a parser bug that writes 0 must be rejected by the
+        # dataclass before judge.json is written, not silently
+        # propagated into Spearman.
+        with self.assertRaises(ValueError):
+            DimensionRating(rating=0, explanation="ok", prompt_sha256="x")
+
+    def test_rating_six_rejected(self) -> None:
+        # Six is above the band — the reviewer-flagged symmetric
+        # case.
+        with self.assertRaises(ValueError):
+            DimensionRating(rating=6, explanation="ok", prompt_sha256="x")
+
+    def test_rating_far_out_of_range_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            DimensionRating(rating=99, explanation="ok", prompt_sha256="x")
+        with self.assertRaises(ValueError):
+            DimensionRating(rating=-1, explanation="ok", prompt_sha256="x")
+
+    def test_rating_bool_rejected(self) -> None:
+        # ``bool`` is a subclass of ``int``; ``True``/``False`` would
+        # otherwise pass the range check (True == 1, False == 0).
+        # Rejecting them defends the null-vs-zero / null-vs-true
+        # silent-coercion failure mode.
+        with self.assertRaises(TypeError):
+            DimensionRating(rating=True, explanation="ok", prompt_sha256="x")
+        with self.assertRaises(TypeError):
+            DimensionRating(rating=False, explanation="ok", prompt_sha256="x")
+
+    def test_rating_float_rejected(self) -> None:
+        # Spearman ranks floats fine, but the rubric is integers
+        # 1..5; a float would indicate a parser bug.
+        with self.assertRaises(TypeError):
+            DimensionRating(rating=3.5, explanation="ok", prompt_sha256="x")  # type: ignore[arg-type]
+
+
+# ── JudgeInvocation ────────────────────────────────────────────────────
+
+
+class TestJudgeInvocation(unittest.TestCase):
+    def test_temperature_and_seed_default_to_none(self) -> None:
+        # Default = the corrected determinism contract: claude-code
+        # CLI exposes neither knob, so the judge does not pretend
+        # to pin them.
+        inv = JudgeInvocation(model="sonnet")
+        self.assertIsNone(inv.temperature)
+        self.assertIsNone(inv.seed)
+        self.assertEqual(inv.temperature_control, TEMPERATURE_CONTROL_UNSUPPORTED)
+        self.assertEqual(inv.seed_control, SEED_CONTROL_UNSUPPORTED)
+
+    def test_temperature_zero_distinct_from_temperature_none(self) -> None:
+        # A future judge backend whose CLI does expose --temperature
+        # would record temperature=0.0 + control="supported". That
+        # is distinct from temperature=None + control="unsupported",
+        # which is the claude-code path. The two must never be
+        # silently coerced.
+        pinned = JudgeInvocation(
+            model="m",
+            temperature=0.0,
+            temperature_control=TEMPERATURE_CONTROL_SUPPORTED,
+        )
+        unsupported = JudgeInvocation(model="m")
+        self.assertEqual(pinned.temperature, 0.0)
+        self.assertIsNone(unsupported.temperature)
+        self.assertNotEqual(pinned.temperature_control, unsupported.temperature_control)
+
+    def test_provider_endpoint_present_is_boolean_not_url(self) -> None:
+        # Per the backends' provider-env discipline: presence
+        # boolean only, NEVER the endpoint URL or any secret.
+        inv = JudgeInvocation(
+            model="sonnet",
+            provider_endpoint_present=True,
+        )
+        self.assertIs(inv.provider_endpoint_present, True)
+        # And the field type is bool — not Optional[str], not
+        # Optional[bool]. A future contributor cannot stuff a URL
+        # in without changing the dataclass signature.
+        self.assertIsInstance(inv.provider_endpoint_present, bool)
+
+    def test_frozen(self) -> None:
+        inv = JudgeInvocation(model="sonnet")
+        with self.assertRaises(FrozenInstanceError):
+            inv.model = "other"  # type: ignore[misc]
+
+
+# ── JudgeResult ────────────────────────────────────────────────────────
+
+
+class TestJudgeResult(unittest.TestCase):
+    def _make_result(
+        self,
+        *,
+        tokens_input: object = "__unset__",
+        tokens_output: object = "__unset__",
+    ) -> JudgeResult:
+        kwargs: dict = dict(
+            judge_id="claude-code-judge",
+            judge_model="sonnet",
+            judge_backend_id="claude-code",
+            rubric_name="default-v1",
+            ratings={
+                "idiomaticity": DimensionRating(
+                    rating=4, explanation="ok", prompt_sha256="x"
+                ),
+            },
+            invocation=JudgeInvocation(model="sonnet"),
+        )
+        if tokens_input != "__unset__":
+            kwargs["tokens_input"] = tokens_input
+        if tokens_output != "__unset__":
+            kwargs["tokens_output"] = tokens_output
+        return JudgeResult(**kwargs)
+
+    def test_token_fields_default_none(self) -> None:
+        r = self._make_result()
+        self.assertIsNone(r.tokens_input)
+        self.assertIsNone(r.tokens_output)
+
+    def test_token_zero_distinct_from_none(self) -> None:
+        # Mirrors BackendResult: None means "judge did not provide";
+        # 0 means "judge reported zero." Do not coerce.
+        none_r = self._make_result()
+        zero_r = self._make_result(tokens_input=0, tokens_output=0)
+        self.assertIsNone(none_r.tokens_input)
+        self.assertEqual(zero_r.tokens_input, 0)
+        self.assertNotEqual(none_r.tokens_input, zero_r.tokens_input)
+
+    def test_metadata_default_empty(self) -> None:
+        r = self._make_result()
+        self.assertEqual(dict(r.judge_metadata), {})
+
+    def test_frozen(self) -> None:
+        r = self._make_result()
+        with self.assertRaises(FrozenInstanceError):
+            r.judge_id = "other"  # type: ignore[misc]
+
+
+# ── Protocol conformance ───────────────────────────────────────────────
+
+
+class _MinimalJudge:
+    """Smallest possible Judge implementation — satisfies the Protocol
+    without doing real work. Used to verify ``isinstance(..., Judge)``
+    accepts a structural match.
+    """
+
+    judge_id = "minimal"
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        return JudgeResult(
+            judge_id=self.judge_id,
+            judge_model="",
+            judge_backend_id="",
+            rubric_name=attempt.rubric.name,
+            ratings={
+                d: DimensionRating(rating=None, explanation="stub", prompt_sha256="")
+                for d in attempt.rubric.dimensions
+            },
+            invocation=JudgeInvocation(model=""),
+        )
+
+
+class _NotAJudge:
+    """Missing both the attribute and the method."""
+
+
+class _MissingMethod:
+    judge_id = "incomplete"
+
+
+class TestJudgeProtocol(unittest.TestCase):
+    def test_minimal_judge_satisfies_protocol(self) -> None:
+        j = _MinimalJudge()
+        self.assertIsInstance(j, Judge)
+
+    def test_non_judge_rejected(self) -> None:
+        self.assertNotIsInstance(_NotAJudge(), Judge)
+
+    def test_missing_method_rejected(self) -> None:
+        # runtime_checkable Protocols check method existence, not
+        # signature. A class with judge_id but no rate() should not
+        # satisfy the Protocol.
+        self.assertNotIsInstance(_MissingMethod(), Judge)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_judge_registry.py
+++ b/scripts/benchmark_runner/tests/test_judge_registry.py
@@ -1,0 +1,208 @@
+# tests/test_judge_registry.py — judge registry contract tests.
+#
+# Mirrors test_contracts.py / test_cli_skeleton.py style: small,
+# behaviour-focused, no live LLM. The registry itself is a small
+# in-memory dispatch table; these tests cover the public contract
+# (register / list / get / unknown) plus the canonical-vs-alias
+# pattern that lets ``claude-code`` and ``claude-code-judge``
+# share the same factory.
+
+from __future__ import annotations
+
+import unittest
+
+from benchmark_runner._register import register_all, unregister_all_for_tests
+from benchmark_runner.judge.claude_code_judge import (
+    ClaudeCodeJudge,
+    JUDGE_FAMILY as CLAUDE_CODE_JUDGE_FAMILY,
+)
+from benchmark_runner.judge.contracts import Judge
+from benchmark_runner.judge.registry import (
+    UnknownJudgeError,
+    _reset_for_tests,
+    get_judge,
+    list_judge_ids,
+    register_judge,
+)
+
+
+# ── Pure registry behaviour ───────────────────────────────────────────
+
+
+class TestRegisterListGet(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_for_tests()
+
+    def tearDown(self) -> None:
+        _reset_for_tests()
+
+    def test_empty_registry_lists_nothing(self) -> None:
+        self.assertEqual(list_judge_ids(), [])
+
+    def test_register_makes_family_resolvable(self) -> None:
+        register_judge("family-x", lambda m: _StubJudge("family-x", m))
+        self.assertIn("family-x", list_judge_ids())
+        j = get_judge("family-x", "model-1")
+        self.assertIsInstance(j, _StubJudge)
+        self.assertEqual(j.model, "model-1")
+
+    def test_get_with_default_model_passes_empty_string(self) -> None:
+        # Mirrors the backend registry contract: stub-shaped factories
+        # take ``model=""`` by default.
+        register_judge("family-x", lambda m: _StubJudge("family-x", m))
+        j = get_judge("family-x")
+        self.assertEqual(j.model, "")
+
+    def test_unknown_family_raises_with_known_listed(self) -> None:
+        register_judge("a", lambda m: _StubJudge("a", m))
+        register_judge("b", lambda m: _StubJudge("b", m))
+        with self.assertRaises(UnknownJudgeError) as ctx:
+            get_judge("not-registered", "")
+        msg = str(ctx.exception)
+        self.assertIn("not-registered", msg)
+        # Every registered family appears in the error message so the
+        # user sees what they could have typed.
+        self.assertIn("a", msg)
+        self.assertIn("b", msg)
+
+    def test_unknown_family_when_empty_registry(self) -> None:
+        with self.assertRaisesRegex(UnknownJudgeError, "\\(none\\)"):
+            get_judge("any", "")
+
+
+class TestRegistryDeterminism(unittest.TestCase):
+    """list_judge_ids() must be deterministic (sorted) so callers
+    like ``benchmark list`` produce identical output across machines."""
+
+    def setUp(self) -> None:
+        _reset_for_tests()
+
+    def tearDown(self) -> None:
+        _reset_for_tests()
+
+    def test_list_judge_ids_is_sorted(self) -> None:
+        # Register in non-alphabetical order; expect sorted output.
+        for name in ("zebra", "alpha", "mid"):
+            register_judge(name, lambda m, _n=name: _StubJudge(_n, m))
+        self.assertEqual(list_judge_ids(), ["alpha", "mid", "zebra"])
+
+    def test_list_judge_ids_stable_across_calls(self) -> None:
+        for name in ("c", "a", "b"):
+            register_judge(name, lambda m, _n=name: _StubJudge(_n, m))
+        self.assertEqual(list_judge_ids(), list_judge_ids())
+
+
+class TestAliasPattern(unittest.TestCase):
+    """The canonical-vs-alias contract: ``claude-code`` and
+    ``claude-code-judge`` share one factory and behave identically."""
+
+    def setUp(self) -> None:
+        _reset_for_tests()
+
+    def tearDown(self) -> None:
+        _reset_for_tests()
+
+    def test_shared_factory_under_two_tokens_allowed(self) -> None:
+        factory = lambda m: _StubJudge("shared", m)
+        register_judge("canonical", factory)
+        register_judge("alias", factory)  # same factory object — OK
+        self.assertEqual(list_judge_ids(), ["alias", "canonical"])
+        a = get_judge("canonical", "m")
+        b = get_judge("alias", "m")
+        # Both resolve via the same factory, so they produce
+        # instances with the same internal state shape.
+        self.assertEqual(a.family, b.family)
+
+    def test_different_factories_under_same_token_raises(self) -> None:
+        f1 = lambda m: _StubJudge("f1", m)
+        f2 = lambda m: _StubJudge("f2", m)
+        register_judge("canonical", f1)
+        with self.assertRaisesRegex(RuntimeError, "already registered"):
+            register_judge("canonical", f2)
+
+    def test_idempotent_re_register_same_factory(self) -> None:
+        # Calling register_all() twice (the test harness commonly
+        # does this between cases) MUST be a no-op for the registry
+        # rather than a duplicate-registration error.
+        factory = lambda m: _StubJudge("idempotent", m)
+        register_judge("canonical", factory)
+        register_judge("canonical", factory)  # exact same factory object — no-op
+        self.assertEqual(list_judge_ids(), ["canonical"])
+
+
+# ── Integration with _register.register_all ───────────────────────────
+
+
+class TestShippedJudgeRegistration(unittest.TestCase):
+    """Verifies that ``register_all()`` registers the shipped judges
+    under the documented family tokens. This is the contract the
+    CLI's ``benchmark list`` and ``benchmark judge`` depend on."""
+
+    def setUp(self) -> None:
+        unregister_all_for_tests()
+
+    def tearDown(self) -> None:
+        unregister_all_for_tests()
+
+    def test_register_all_registers_both_claude_code_tokens(self) -> None:
+        register_all()
+        ids = list_judge_ids()
+        self.assertIn("claude-code", ids)
+        self.assertIn("claude-code-judge", ids)
+
+    def test_expected_ids_match_documented_set(self) -> None:
+        # The full set of shipped judge tokens — pin it so a future
+        # contributor who adds/removes a judge has to update this
+        # test deliberately.
+        register_all()
+        self.assertEqual(
+            list_judge_ids(),
+            ["claude-code", "claude-code-judge"],
+        )
+
+    def test_both_tokens_resolve_to_a_claude_code_judge(self) -> None:
+        register_all()
+        a = get_judge("claude-code", "sonnet")
+        b = get_judge("claude-code-judge", "sonnet")
+        self.assertIsInstance(a, ClaudeCodeJudge)
+        self.assertIsInstance(b, ClaudeCodeJudge)
+        # The internal judge_id is the SDD-canonical value (not the
+        # token the user typed) — that's the value recorded in
+        # judge.json.
+        self.assertEqual(a.judge_id, CLAUDE_CODE_JUDGE_FAMILY)
+        self.assertEqual(b.judge_id, CLAUDE_CODE_JUDGE_FAMILY)
+
+    def test_resolved_judge_satisfies_judge_protocol(self) -> None:
+        register_all()
+        self.assertIsInstance(get_judge("claude-code", "sonnet"), Judge)
+
+    def test_register_all_is_idempotent(self) -> None:
+        # The test harness sometimes calls register_all() more than
+        # once per process (e.g. across unrelated CLI invocations).
+        # MUST NOT raise on the second call.
+        register_all()
+        register_all()
+        self.assertEqual(
+            list_judge_ids(),
+            ["claude-code", "claude-code-judge"],
+        )
+
+
+# ── Stub Judge for the unit tests ────────────────────────────────────
+
+
+class _StubJudge:
+    def __init__(self, family: str, model: str) -> None:
+        self.family = family
+        self.model = model
+
+    @property
+    def judge_id(self) -> str:
+        return f"stub-{self.family}"
+
+    def rate(self, attempt):  # type: ignore[no-untyped-def]
+        raise NotImplementedError("stub — not exercised in registry tests")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_judge_rubric.py
+++ b/scripts/benchmark_runner/tests/test_judge_rubric.py
@@ -1,0 +1,250 @@
+# tests/test_judge_rubric.py — rubric loader tests.
+#
+# Exercises ``load_rubric`` against the real
+# benchmarks/calibration/rubric-default-v1.md plus synthetic fixtures
+# under tmpdir. Covers:
+#   - the four v1 dimensions are extracted in the documented order;
+#   - the prompt template can be ``.format()``'d with the five attempt
+#     placeholders WITHOUT raising on the JSON-example block's literal
+#     curly braces;
+#   - the rendered output contains the per-dimension descriptions +
+#     anchor sentences (the rubric_dimensions_block content);
+#   - missing-section + malformed rubric files raise the documented
+#     errors.
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from benchmark_runner.judge.rubric import (
+    ATTEMPT_PLACEHOLDERS,
+    DEFAULT_RUBRIC_DIR,
+    RubricNotFoundError,
+    RubricParseError,
+    load_rubric,
+)
+
+
+_V1_DIMS = ("idiomaticity", "error_handling", "test_thoughtfulness", "security_hygiene")
+
+
+class TestLoadRubricV1(unittest.TestCase):
+    """Loads the canonical rubric-default-v1.md from disk."""
+
+    def setUp(self) -> None:
+        self.rubric = load_rubric("default-v1")
+
+    def test_name(self) -> None:
+        self.assertEqual(self.rubric.name, "default-v1")
+
+    def test_dimensions_extracted_in_order(self) -> None:
+        self.assertEqual(self.rubric.dimensions, _V1_DIMS)
+
+    def test_template_formattable_without_raising(self) -> None:
+        # THE central invariant: the loader must escape literal curly
+        # braces in the JSON-example block so the judge can call
+        # str.format() with only the five attempt placeholders.
+        rendered = self.rubric.prompt_template.format(
+            task_id="python/leap",
+            benchmark_id="aider-polyglot",
+            prompt="Implement leap.py",
+            diff="diff --git a/leap.py ...\n",
+            verify_output="1 passed\n",
+        )
+        # Substitutions made it through.
+        self.assertIn("python/leap", rendered)
+        self.assertIn("aider-polyglot", rendered)
+        self.assertIn("Implement leap.py", rendered)
+        self.assertIn("diff --git a/leap.py", rendered)
+        self.assertIn("1 passed", rendered)
+
+    def test_template_includes_dimension_descriptions(self) -> None:
+        # rubric_dimensions_block content must be in the rendered prompt
+        # so the judge LLM sees the anchor sentences.
+        rendered = self.rubric.prompt_template.format(
+            task_id="t", benchmark_id="b", prompt="p", diff="d", verify_output="v",
+        )
+        for dim in _V1_DIMS:
+            # Each dimension's "### N. `<name>`" header is in the
+            # rendered prompt.
+            self.assertIn(f"`{dim}`", rendered)
+        # 1-5 anchor sentences carry the pattern "**N — ".
+        self.assertIn("**1 — ", rendered)
+        self.assertIn("**5 — ", rendered)
+
+    def test_template_preserves_literal_json_example(self) -> None:
+        # The rubric's prompt template ends with a JSON example like
+        # ``{"ratings": {"idiomaticity": {...}}}``. After loading +
+        # formatting, those literal braces must still appear in the
+        # rendered text (as ``{`` / ``}``, not ``{{`` / ``}}``).
+        rendered = self.rubric.prompt_template.format(
+            task_id="t", benchmark_id="b", prompt="p", diff="d", verify_output="v",
+        )
+        self.assertIn('"ratings"', rendered)
+        # No leftover double-brace escaping in the rendered output.
+        self.assertNotIn("{{", rendered)
+        self.assertNotIn("}}", rendered)
+
+    def test_attempt_placeholders_constant_matches_format_call(self) -> None:
+        # ATTEMPT_PLACEHOLDERS is the documented set. Any addition or
+        # rename has to update this test deliberately.
+        self.assertEqual(
+            set(ATTEMPT_PLACEHOLDERS),
+            {"task_id", "benchmark_id", "prompt", "diff", "verify_output"},
+        )
+
+
+class TestLoadRubricErrors(unittest.TestCase):
+    """Synthetic rubric files in a tmpdir cover the failure modes."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-rubric-test-")
+        self.tmpdir = Path(self._tmp)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write_rubric(self, name: str, body: str) -> None:
+        (self.tmpdir / f"rubric-{name}.md").write_text(body, encoding="utf-8")
+
+    def test_missing_file_raises_not_found(self) -> None:
+        with self.assertRaises(RubricNotFoundError):
+            load_rubric("does-not-exist", rubric_dir=self.tmpdir)
+
+    def test_missing_dimensions_section_raises_parse_error(self) -> None:
+        self._write_rubric(
+            "broken-1",
+            "# Rubric\n\n## Prompt template\n\n```\nuse {task_id}\n```\n",
+        )
+        with self.assertRaisesRegex(RubricParseError, "Dimensions"):
+            load_rubric("broken-1", rubric_dir=self.tmpdir)
+
+    def test_dimensions_section_without_headers_raises(self) -> None:
+        # Header present, but no '### N. `<dim>`' inside.
+        self._write_rubric(
+            "broken-2",
+            "## Dimensions\n\nSome prose but no recognised headers.\n\n"
+            "## Prompt template\n\n```\nuse {task_id}\n```\n",
+        )
+        with self.assertRaisesRegex(RubricParseError, "dimension headers"):
+            load_rubric("broken-2", rubric_dir=self.tmpdir)
+
+    def test_missing_prompt_template_section_raises(self) -> None:
+        self._write_rubric(
+            "broken-3",
+            "## Dimensions\n\n### 1. `idiomaticity`\n\ndescription\n",
+        )
+        with self.assertRaisesRegex(RubricParseError, "Prompt template"):
+            load_rubric("broken-3", rubric_dir=self.tmpdir)
+
+    def test_prompt_template_without_code_block_raises(self) -> None:
+        self._write_rubric(
+            "broken-4",
+            "## Dimensions\n\n### 1. `idiomaticity`\n\ndescription\n\n"
+            "## Prompt template\n\nNo fenced block here, just prose.\n",
+        )
+        with self.assertRaisesRegex(RubricParseError, "code block"):
+            load_rubric("broken-4", rubric_dir=self.tmpdir)
+
+
+class TestSyntheticRubricRoundtrip(unittest.TestCase):
+    """A minimal rubric written to tmpdir exercises the escape logic."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-rubric-test-")
+        self.tmpdir = Path(self._tmp)
+        body = (
+            "# Mini rubric\n"
+            "\n"
+            "## Dimensions\n"
+            "\n"
+            "### 1. `style`\n"
+            "Code style notes.\n"
+            "\n"
+            "### 2. `safety`\n"
+            "Safety notes.\n"
+            "\n"
+            "## When a dimension does not apply\n"
+            "\n"
+            "Null is reserved for structural inapplicability.\n"
+            "\n"
+            "## Prompt template\n"
+            "\n"
+            "```\n"
+            "Task: {task_id} ({benchmark_id})\n"
+            "PROMPT: {prompt}\n"
+            "DIFF: {diff}\n"
+            "VERIFY: {verify_output}\n"
+            "Dimensions:\n"
+            "{rubric_dimensions_block}\n"
+            "Output JSON:\n"
+            '{\n'
+            '  "ratings": {"style": {"rating": 1, "explanation": "..."}}\n'
+            '}\n'
+            "```\n"
+        )
+        (self.tmpdir / "rubric-mini.md").write_text(body, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_two_dimensions_in_order(self) -> None:
+        r = load_rubric("mini", rubric_dir=self.tmpdir)
+        self.assertEqual(r.dimensions, ("style", "safety"))
+
+    def test_format_produces_literal_json_example(self) -> None:
+        r = load_rubric("mini", rubric_dir=self.tmpdir)
+        rendered = r.prompt_template.format(
+            task_id="t/x",
+            benchmark_id="bench-1",
+            prompt="do-the-thing",
+            diff="diff text",
+            verify_output="ok",
+        )
+        # Substitutions present.
+        self.assertIn("t/x", rendered)
+        self.assertIn("bench-1", rendered)
+        self.assertIn("do-the-thing", rendered)
+        # Literal JSON example survived as plain text with single braces.
+        self.assertIn('"ratings"', rendered)
+        self.assertIn('{\n  "ratings"', rendered)
+        # The dimensions block content was inlined.
+        self.assertIn("`style`", rendered)
+        self.assertIn("`safety`", rendered)
+        self.assertIn("Code style notes", rendered)
+        # And the "When a dimension does not apply" prose, too.
+        self.assertIn("structural inapplicability", rendered)
+
+    def test_format_with_extra_curlies_in_substitutions_is_safe(self) -> None:
+        # A diff containing literal `{`/`}` must survive str.format
+        # — the loader's escaping is for the TEMPLATE, not the
+        # substituted values. (Values pass through .format unchanged
+        # because format doesn't interpret braces in arguments.)
+        r = load_rubric("mini", rubric_dir=self.tmpdir)
+        diff = 'sample = {"key": "value"}\n'
+        rendered = r.prompt_template.format(
+            task_id="t", benchmark_id="b", prompt="p",
+            diff=diff,
+            verify_output="v",
+        )
+        self.assertIn('{"key": "value"}', rendered)
+
+
+class TestDefaultRubricDirIsRepoCalibration(unittest.TestCase):
+    """The default rubric_dir points at benchmarks/calibration/."""
+
+    def test_default_dir_exists(self) -> None:
+        self.assertTrue(
+            DEFAULT_RUBRIC_DIR.exists(),
+            f"default rubric dir not found: {DEFAULT_RUBRIC_DIR}",
+        )
+        self.assertEqual(DEFAULT_RUBRIC_DIR.name, "calibration")
+        self.assertEqual(DEFAULT_RUBRIC_DIR.parent.name, "benchmarks")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_judge_runner.py
+++ b/scripts/benchmark_runner/tests/test_judge_runner.py
@@ -1,0 +1,437 @@
+# tests/test_judge_runner.py — judge runner tests.
+#
+# Stages a synthetic run-dir matching the layout
+# benchmark_runner.run writes (run_dir/<task-slug>/attempt-NN-run-MM/
+# with score.json, run-record.json, diff.patch, prompt.md,
+# verify-output.txt) and drives ``run_judge`` with a stub Judge.
+#
+# THE central invariant under test: score.json is byte-identical
+# before and after each rate() call. A judge that mutates score.json
+# is rejected with ScoreJsonMutatedError.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Mapping, Optional
+
+from benchmark_runner.judge.contracts import (
+    DimensionRating,
+    JudgeInput,
+    JudgeInvocation,
+    JudgeResult,
+    RubricSpec,
+)
+from benchmark_runner.judge.runner import (
+    JUDGE_JSON_SCHEMA_VERSION,
+    RunJudgeStats,
+    ScoreJsonMutatedError,
+    run_judge,
+)
+
+
+_RUBRIC = RubricSpec(
+    name="default-v1",
+    dimensions=("idiomaticity", "error_handling", "test_thoughtfulness", "security_hygiene"),
+    prompt_template="Task: {task_id} ({benchmark_id})\n{prompt}\n{diff}\n{verify_output}\n",
+)
+
+
+def _make_run_dir(tmp_path: Path, attempts: list[dict]) -> Path:
+    """Stage a run-dir matching benchmark_runner.run's layout.
+
+    Each ``attempts`` entry shapes one attempt directory:
+      {
+        "task_slug": "python-bowling",
+        "attempt_id": "attempt-01-run-001",
+        "task_id": "python/bowling",
+        "benchmark_id": "aider-polyglot",
+        "result": "fail",
+        "diff": "diff content\\n",         # default if missing
+        "prompt": "prompt content\\n",     # default if missing
+        "verify_output": "tests ran\\n",   # default if missing
+        "skip_files": {"diff", "score"},   # override which files to write
+      }
+    """
+    run_dir = tmp_path / "20260520T000000Z-aider-polyglot-claude-code-001"
+    run_dir.mkdir()
+    for a in attempts:
+        task_slug = a["task_slug"]
+        attempt_id = a["attempt_id"]
+        task_dir = run_dir / task_slug
+        task_dir.mkdir(exist_ok=True)
+        attempt_dir = task_dir / attempt_id
+        attempt_dir.mkdir()
+        skip = a.get("skip_files", set())
+        if "score" not in skip:
+            score = {
+                "schema_version": "1.0",
+                "benchmark_id": a.get("benchmark_id", "aider-polyglot"),
+                "task_id": a.get("task_id", task_slug.replace("-", "/", 1)),
+                "backend_id": "claude-code",
+                "run_id": "run-001",
+                "attempt": 1,
+                "scores": {
+                    "tests_passed": a.get("result", "fail") == "pass",
+                },
+                "result": a.get("result", "fail"),
+            }
+            (attempt_dir / "score.json").write_text(
+                json.dumps(score, indent=2) + "\n", encoding="utf-8"
+            )
+        if "diff" not in skip:
+            (attempt_dir / "diff.patch").write_text(
+                a.get("diff", "diff content\n"), encoding="utf-8"
+            )
+        if "prompt" not in skip:
+            (attempt_dir / "prompt.md").write_text(
+                a.get("prompt", "prompt content\n"), encoding="utf-8"
+            )
+        if "verify" not in skip:
+            (attempt_dir / "verify-output.txt").write_text(
+                a.get("verify_output", "tests ran\n"), encoding="utf-8"
+            )
+    return run_dir
+
+
+# ── Stub judges ────────────────────────────────────────────────────────
+
+
+class _CannedJudge:
+    """Returns the same canned JudgeResult for every attempt. No I/O."""
+
+    judge_id = "canned-judge"
+
+    def __init__(self, *, rating: Optional[int] = 4) -> None:
+        self._rating = rating
+        self.calls: list[JudgeInput] = []
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        self.calls.append(attempt)
+        return JudgeResult(
+            judge_id=self.judge_id,
+            judge_model="canned",
+            judge_backend_id="canned",
+            rubric_name=attempt.rubric.name,
+            ratings={
+                dim: DimensionRating(
+                    rating=self._rating,
+                    explanation=f"canned rating for {dim}",
+                    prompt_sha256="canned-sha",
+                )
+                for dim in attempt.rubric.dimensions
+            },
+            invocation=JudgeInvocation(model="canned"),
+        )
+
+
+class _ScoreMutatingJudge:
+    """Bad-actor judge that mutates score.json during rate(). Used to
+    prove the additivity invariant guard fires."""
+
+    judge_id = "bad-judge"
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        score_path = attempt.attempt_dir / "score.json"
+        score_path.write_text("MUTATED\n", encoding="utf-8")
+        return JudgeResult(
+            judge_id=self.judge_id,
+            judge_model="bad",
+            judge_backend_id="bad",
+            rubric_name=attempt.rubric.name,
+            ratings={
+                dim: DimensionRating(rating=3, explanation="x", prompt_sha256="y")
+                for dim in attempt.rubric.dimensions
+            },
+            invocation=JudgeInvocation(model="bad"),
+        )
+
+
+class _RaisingJudge:
+    """Raises during rate(). Used to prove per-attempt isolation."""
+
+    judge_id = "raising-judge"
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        raise RuntimeError("simulated rate failure")
+
+
+class _MutateThenRaiseJudge:
+    """Worst-of-both-worlds bad-actor: mutates score.json then raises.
+
+    Without the after-hash check on the exception path, a per-attempt
+    failure would record this as a normal isolated failure, leaving
+    the mutated score.json on disk and letting the runner continue.
+    The guard must trip on BOTH the success and the exception paths.
+    """
+
+    judge_id = "mutate-then-raise-judge"
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult:
+        (attempt.attempt_dir / "score.json").write_text(
+            "MUTATED-BEFORE-RAISE\n", encoding="utf-8"
+        )
+        raise RuntimeError("simulated rate failure AFTER mutating score.json")
+
+
+# ── Walk + write tests ────────────────────────────────────────────────
+
+
+class TestRunJudgeHappyPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-runner-test-")
+        self.tmpdir = Path(self._tmp)
+        self.run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+            {"task_slug": "python-bowling", "attempt_id": "attempt-02-run-001"},
+            {"task_slug": "rust-react", "attempt_id": "attempt-01-run-001"},
+        ])
+        self.judge = _CannedJudge()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_processes_every_attempt(self) -> None:
+        stats = run_judge(self.run_dir, self.judge, _RUBRIC)
+        self.assertEqual(stats.attempts_processed, 3)
+        self.assertEqual(stats.attempts_skipped, 0)
+        self.assertEqual(stats.attempts_failed, 0)
+
+    def test_writes_judge_json_adjacent_to_score_json(self) -> None:
+        run_judge(self.run_dir, self.judge, _RUBRIC)
+        for attempt_dir in sorted(self.run_dir.rglob("attempt-*")):
+            self.assertTrue((attempt_dir / "judge.json").exists())
+            self.assertTrue((attempt_dir / "score.json").exists())
+
+    def test_judge_json_schema_shape(self) -> None:
+        run_judge(self.run_dir, self.judge, _RUBRIC)
+        first = next(self.run_dir.rglob("judge.json"))
+        payload = json.loads(first.read_text(encoding="utf-8"))
+        self.assertEqual(payload["schema_version"], JUDGE_JSON_SCHEMA_VERSION)
+        self.assertEqual(payload["judge_id"], "canned-judge")
+        self.assertEqual(payload["rubric_name"], "default-v1")
+        self.assertEqual(
+            payload["rubric_dimensions"], list(_RUBRIC.dimensions),
+        )
+        for dim in _RUBRIC.dimensions:
+            self.assertIn(dim, payload["ratings"])
+            self.assertEqual(payload["ratings"][dim]["rating"], 4)
+        # Determinism contract serialized through.
+        inv = payload["judge_invocation"]
+        self.assertIsNone(inv["temperature"])
+        self.assertIsNone(inv["seed"])
+        self.assertEqual(inv["temperature_control"], "unsupported")
+        self.assertEqual(inv["seed_control"], "unsupported")
+
+    def test_input_carries_task_and_benchmark_ids_from_score_json(self) -> None:
+        run_judge(self.run_dir, self.judge, _RUBRIC)
+        # The judge stub recorded what it saw; assert task_id roundtrip.
+        seen_tasks = {call.task_id for call in self.judge.calls}
+        self.assertIn("python/bowling", seen_tasks)
+        self.assertIn("rust/react", seen_tasks)
+        seen_bench = {call.benchmark_id for call in self.judge.calls}
+        self.assertEqual(seen_bench, {"aider-polyglot"})
+
+
+# ── Additivity invariant ──────────────────────────────────────────────
+
+
+class TestAdditivityInvariant(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-runner-test-")
+        self.tmpdir = Path(self._tmp)
+        self.run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+            {"task_slug": "python-bowling", "attempt_id": "attempt-02-run-001"},
+        ])
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _snapshot_score_hashes(self) -> Mapping[Path, str]:
+        out: dict[Path, str] = {}
+        for p in self.run_dir.rglob("score.json"):
+            h = hashlib.sha256(p.read_bytes()).hexdigest()
+            out[p] = h
+        return out
+
+    def test_score_json_byte_identical_pre_and_post(self) -> None:
+        # The most load-bearing assertion in this whole subsystem:
+        # judge.json is additive; score.json never changes.
+        before = self._snapshot_score_hashes()
+        run_judge(self.run_dir, _CannedJudge(), _RUBRIC)
+        after = self._snapshot_score_hashes()
+        self.assertEqual(before, after)
+
+    def test_mutating_judge_raises(self) -> None:
+        with self.assertRaises(ScoreJsonMutatedError):
+            run_judge(self.run_dir, _ScoreMutatingJudge(), _RUBRIC)
+
+    def test_mutating_then_raising_judge_raises_score_mutated(self) -> None:
+        # Peer-reviewed gap (2026-05-20): the guard must run on the
+        # exception path too. A judge that mutates score.json and then
+        # raises must NOT be silently swallowed as a per-attempt
+        # failure — the invariant violation is the more serious bug
+        # and takes precedence. Without this test, the runner would
+        # record an isolated failure and continue.
+        with self.assertRaises(ScoreJsonMutatedError):
+            run_judge(self.run_dir, _MutateThenRaiseJudge(), _RUBRIC)
+
+    def test_mutating_then_raising_check_runs_before_failure_record(self) -> None:
+        # And specifically: the guard fires BEFORE the runner records
+        # the rate() exception. We can prove this indirectly by
+        # confirming that ScoreJsonMutatedError surfaces (not the
+        # RuntimeError from rate, not a normal stats summary).
+        try:
+            run_judge(self.run_dir, _MutateThenRaiseJudge(), _RUBRIC)
+        except ScoreJsonMutatedError as exc:
+            # The guard's error message names the offending judge
+            # and the hash transition, so the operator sees the
+            # invariant violation, not just "something failed."
+            self.assertIn("mutate-then-raise-judge", str(exc))
+            self.assertIn("sha256", str(exc).lower())
+        else:
+            self.fail("expected ScoreJsonMutatedError; no exception raised")
+
+
+# ── Skip + failure semantics ──────────────────────────────────────────
+
+
+class TestSkipsAndFailures(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-runner-test-")
+        self.tmpdir = Path(self._tmp)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_skips_attempt_missing_score_json(self) -> None:
+        run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+            {
+                "task_slug": "python-bowling",
+                "attempt_id": "attempt-02-run-001",
+                "skip_files": {"score"},
+            },
+        ])
+        stats = run_judge(run_dir, _CannedJudge(), _RUBRIC)
+        self.assertEqual(stats.attempts_processed, 1)
+        self.assertEqual(stats.attempts_skipped, 1)
+        skipped_key = next(iter(stats.skip_reasons))
+        self.assertIn("attempt-02-run-001", skipped_key)
+        self.assertIn("score.json", stats.skip_reasons[skipped_key])
+
+    def test_skips_attempt_missing_diff(self) -> None:
+        run_dir = _make_run_dir(self.tmpdir, [
+            {
+                "task_slug": "python-bowling",
+                "attempt_id": "attempt-01-run-001",
+                "skip_files": {"diff"},
+            },
+        ])
+        stats = run_judge(run_dir, _CannedJudge(), _RUBRIC)
+        self.assertEqual(stats.attempts_processed, 0)
+        self.assertEqual(stats.attempts_skipped, 1)
+
+    def test_skips_when_judge_json_already_exists_default(self) -> None:
+        run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+        ])
+        # Pre-populate judge.json.
+        existing = (
+            run_dir / "python-bowling" / "attempt-01-run-001" / "judge.json"
+        )
+        existing.write_text('{"sentinel": true}\n', encoding="utf-8")
+        stats = run_judge(run_dir, _CannedJudge(), _RUBRIC)
+        self.assertEqual(stats.attempts_processed, 0)
+        self.assertEqual(stats.attempts_skipped, 1)
+        # Pre-existing content untouched.
+        self.assertEqual(
+            json.loads(existing.read_text(encoding="utf-8")),
+            {"sentinel": True},
+        )
+
+    def test_overwrite_re_rates_existing_judge_json(self) -> None:
+        run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+        ])
+        existing = (
+            run_dir / "python-bowling" / "attempt-01-run-001" / "judge.json"
+        )
+        existing.write_text('{"sentinel": true}\n', encoding="utf-8")
+        stats = run_judge(run_dir, _CannedJudge(), _RUBRIC, overwrite=True)
+        self.assertEqual(stats.attempts_processed, 1)
+        payload = json.loads(existing.read_text(encoding="utf-8"))
+        self.assertEqual(payload["judge_id"], "canned-judge")
+
+    def test_raising_judge_isolates_failure(self) -> None:
+        run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+            {"task_slug": "rust-react", "attempt_id": "attempt-01-run-001"},
+        ])
+        stats = run_judge(run_dir, _RaisingJudge(), _RUBRIC)
+        # All attempts failed; runner continued past each so the
+        # caller can see all failure reasons in one pass.
+        self.assertEqual(stats.attempts_processed, 0)
+        self.assertEqual(stats.attempts_failed, 2)
+        self.assertEqual(len(stats.failure_reasons), 2)
+        for reason in stats.failure_reasons.values():
+            self.assertIn("RuntimeError", reason)
+            self.assertIn("simulated rate failure", reason)
+
+
+# ── Walk semantics ────────────────────────────────────────────────────
+
+
+class TestDiscovery(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-judge-runner-test-")
+        self.tmpdir = Path(self._tmp)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_run_dir_missing_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            run_judge(self.tmpdir / "nope", _CannedJudge(), _RUBRIC)
+
+    def test_ignores_non_attempt_subdirs(self) -> None:
+        # Real run-dirs sometimes carry a top-level "report" or
+        # similar dir. The walker must only recurse into
+        # task-slug/attempt-NN-run-MM.
+        run_dir = _make_run_dir(self.tmpdir, [
+            {"task_slug": "python-bowling", "attempt_id": "attempt-01-run-001"},
+        ])
+        # Add a sibling non-attempt dir + a top-level report dir.
+        (run_dir / "report").mkdir()
+        (run_dir / "report" / "fake.json").write_text("{}\n", encoding="utf-8")
+        (run_dir / "python-bowling" / "scratch").mkdir()
+        (run_dir / "python-bowling" / "scratch" / "file.txt").write_text(
+            "x", encoding="utf-8"
+        )
+        stats = run_judge(run_dir, _CannedJudge(), _RUBRIC)
+        # Still just the one real attempt.
+        self.assertEqual(stats.attempts_processed, 1)
+        self.assertEqual(stats.attempts_skipped, 0)
+
+
+# ── Return-type shape ─────────────────────────────────────────────────
+
+
+class TestRunJudgeStats(unittest.TestCase):
+    def test_default_construction(self) -> None:
+        # The return type is a frozen dataclass — defaults documented.
+        s = RunJudgeStats()
+        self.assertEqual(s.attempts_processed, 0)
+        self.assertEqual(s.attempts_skipped, 0)
+        self.assertEqual(s.attempts_failed, 0)
+        self.assertEqual(s.skip_reasons, {})
+        self.assertEqual(s.failure_reasons, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/benchmark-llm-judge/origin-alignment-2026-05-20-0238.md
+++ b/specs/benchmark-llm-judge/origin-alignment-2026-05-20-0238.md
@@ -1,0 +1,201 @@
+# Origin-Alignment Record — benchmark-llm-judge
+
+Date: 2026-05-20 02:38 UTC
+Gate: plan-approval (Phase A, pre-build)
+Origin: gosha70/code-copilot-team#34 (v3 body, 2026-05-08)
+
+Verdict: aligned (high)
+Confidence: high
+
+Revision 2026-05-20 (post peer review): two P1 review findings
+addressed in-place (sub-issue close-keyword discipline; corrected
+claude-code-judge determinism contract). User confirmed D1=Option B
+(with real numeric sub-issue IDs captured in TB0.4), D4=approved
+four v1 dimensions, D7=`claude-code:sonnet` with the corrected
+determinism contract (temperature/seed recorded as
+null/"unsupported", never silently 0.0). Bundle is now go-gated on
+explicit user "go" only.
+
+## What the user asked for (#34 v3)
+
+Calibrated LLM-judge scoring + rich reports on top of the
+deterministic harness from #32/#33. Five subsystems "deliverable in
+order":
+
+1. Calibration set: ≥50 task-runs spanning ≥2 axes of variation
+   (adapters / backends / models / repeated-runs); per-dimension
+   1–5 human ratings; `benchmarks/calibration/<name>.jsonl` schema
+   (`{run_path, dimension, rating, notes}`).
+2. Judge protocol mirroring the Backend contract from #32; initial
+   `claude-code --model sonnet` judge; per-run `judge.json`.
+3. Calibration validation: per-dimension Spearman correlation;
+   threshold ≥ 0.6 (revisable); uncalibrated dimensions flagged in
+   the report and excluded from winner math.
+4. Rich reports (HTML + static-SVG charts + CSV) — ADDITIVE to
+   the existing Markdown + JSON reports.
+5. Winner-declaration extension on calibrated-judge dimensions
+   using the same `Δ > 2σ AND ≥ threshold` rule with per-dimension
+   threshold.
+
+Explicit ACs (verbatim, abridged): calibration set checked in;
+deterministic across re-runs; calibration script measures Spearman
++ outputs `calibration-report.md`; per-dimension ≥0.6 enforced;
+HTML separates deterministic + calibrated-judge; static
+SVG/PNG charts; CSV exports; deterministic-first ordering (a run
+that fails deterministic tests cannot win on judge-only); no
+dollar-cost figures anywhere; docs for adding a judge / extending
+the rubric / re-running calibration.
+
+Permanently OUT: dollar-cost reporting; replacing deterministic
+scoring with judge scoring; new benchmark adapters (#33); new
+copilot backends (#33); cross-CCT-instance shared calibration sets.
+
+## What the spec/plan commit to
+
+A parallel `scripts/benchmark_runner/judge/` package implementing
+the `Judge` protocol (mirrors `Backend`); a `claude_code_judge`
+that reuses the existing claude-code backend's headless invocation;
+a strictly-additive `judge.json` per-attempt artifact (never
+overwrites `score.json`); a corpus-selection CLI sourcing ≥50
+task-runs from the existing `runs/` archive (1171 attempts on
+disk, NO new benchmark spend required); a calibration-validation
+script computing per-dimension Spearman + emitting
+`calibration-report.md` + `calibrated-dimensions.json`; additive
+HTML + CSV + static-SVG report emitters; a winner-extension that
+reuses `report_winner.declare_winner` unchanged on `judge:<dim>`
+metric names; deterministic-first ordering enforced at the
+winner-extension step (only passing-on-both-sides attempts
+contribute to a calibrated-judge verdict).
+
+The deterministic harness (`run.py`, `score.json`,
+`BackendResult`, `report_winner.py`, `contracts.py`) is **NOT
+modified**. Markdown + JSON reports keep their existing shape (a
+snapshot regression test guards byte-identity modulo timestamps
+when no `judge.json` is present).
+
+## Divergences (recorded; user confirmation pending)
+
+1. **PR-structure: split #34 into sub-issues (Option B,
+   APPROVED 2026-05-20).** The one-PR-per-issue rule (memory
+   `feedback-pr-must-fully-address-issue`, 2026-05-19, derived
+   from PR #38 revert) forbids partial PRs against one issue.
+   #34 has 5 subsystems + a human-labeling dependency (≥50
+   hand-labels) + an empirical research question
+   (per-dimension Spearman ≥ 0.6). A single PR (Option A) would
+   sit open for days/weeks while a human labels the corpus; a
+   maintainer-procedure split (Option C) violates the explicit
+   AC "Calibration set checked in: ≥50 task-runs…". Option B
+   files **five real GitHub issues** in TB0.4 (placeholder
+   labels A–E used in this bundle; real numeric IDs captured
+   into `specs/benchmark-llm-judge/sub-issue-numbers.md` before
+   any PR is opened). #34 closes automatically when sub-issue
+   E's PR merges (its body carries a separate `Closes #34`
+   keyword in addition to `Closes #<E's real id>`, per memory
+   `feedback_github_close_keyword_per_issue` — one keyword per
+   real issue, no shared keyword). Placeholder labels NEVER
+   appear in PR descriptions. This is a STRUCTURAL change to
+   how #34 is closed (the epic closes by linkage to its
+   sub-issues), NOT a scope change — engineering work and ACs
+   are identical to Option A.
+
+2. **Calibration corpus from existing `runs/` archive.** Issue
+   v3 leaves the corpus source open. Inventory (2026-05-20):
+   1171 attempt-records across 50 run-dirs, 5 (backend, model)
+   tuples (claude-code × phi-3 / qwen2.5-coder:7b / qwen3.6:27b
+   / RedHatAI/Qwen3-Coder-Next-NVFP4 / sonnet plus a stub
+   swe-bench-verified), 44 passing total (3.8%), 568 non-passing
+   attempts with file changes. ≥50 task-runs spanning ≥2 axes
+   (model × repeated-runs) are immediately sourcable; NO new
+   benchmark spend is required. This is methodology-honest (the
+   calibration corpus reflects the actual CCT-instance workload)
+   and schedule-honest (no new run campaign before
+   human-labeling).
+
+3. **Judge rates non-passing code too.** Issue v3 framing
+   ("quality differences inside a passing run") implies
+   passing-only rating. The corpus reality (44 passing total,
+   mostly `sonnet`) makes passing-only infeasible at N=50 and
+   collapses the model variation axis. The rubric dimensions
+   (idiomaticity / error_handling / test_thoughtfulness /
+   security_hygiene) are defined for any code the model
+   produced; non-passing attempts get rated. Deterministic-first
+   ordering is enforced separately at the winner-extension step
+   (only passing-on-both-sides samples enter `declare_winner`),
+   which keeps the explicit AC ("a run that fails deterministic
+   tests cannot win on judge-only criteria") satisfied.
+
+4. **Default rubric dimensions.** Issue v3 names four candidates
+   and defers "final dimensions chosen at implementation time."
+   The spec adopts the four named dimensions as v1, pending
+   Phase B0.2 ratification with the user.
+
+5. **No new external Python dependency.** Spearman ρ + SVG
+   emission stay stdlib-only (no scipy, no matplotlib, no
+   templating engine). Matches the existing harness's stdlib-only
+   posture. Recorded as a tooling decision, not a deviation
+   from origin.
+
+## Open questions for the user (gate the plan)
+
+Resolved in peer-review round 2026-05-20:
+
+- **D1 (PR structure):** **APPROVED** — Option B, with real
+  numeric sub-issue IDs filed in TB0.4 and captured in
+  `sub-issue-numbers.md`. Placeholder labels A–E never appear in
+  PR descriptions (close keywords require real numeric IDs).
+- **D4 (rubric v1 dimensions):** **APPROVED** —
+  `idiomaticity`, `error_handling`, `test_thoughtfulness`,
+  `security_hygiene`. 1–5 anchor descriptions to land in
+  `benchmarks/calibration/rubric-default-v1.md` in #34-sub-issue-A.
+- **D7 (judge backend default):** **APPROVED with corrected
+  contract** — `claude-code:sonnet` with `temperature: null` /
+  `seed: null` / `temperature_control: "unsupported"` /
+  `seed_control: "unsupported"`. The local `claude` CLI exposes
+  only `--model`/`--fallback-model`; the judge MUST NOT claim
+  T=0 it cannot enforce. Re-run stability is empirical and
+  surfaced by the calibration Spearman.
+
+## Verification
+
+- `./scripts/validate-spec.sh --feature-id benchmark-llm-judge`:
+  **PASS** (2/2), exit 0 — confirmed on the team-lead session
+  host 2026-05-20, re-confirmed after the peer-review fixes.
+- `./scripts/check-origin-alignment.sh benchmark-llm-judge`:
+  **PASS** (aligned, high), exit 0 — confirmed on the
+  team-lead session host 2026-05-20 after the peer-review
+  fixes (was aligned/medium with the original draft; the two
+  P1 fixes promoted the verdict to high).
+- The corpus-inventory numbers in spec.md were computed by
+  walking `runs/**/run-record.json` + `runs/**/score.json` on
+  the team-lead session host on 2026-05-20. Re-confirmation on
+  the maintainer machine is gated as TB0.1 before any code is
+  written.
+
+## Peer-review revision history
+
+- **Round 1 (2026-05-20).** Original draft; verdict aligned
+  (medium); D1/D4/D7 pending user choice.
+- **Round 2 (2026-05-20).** Two P1 review findings addressed
+  in-place:
+  - **Sub-issue close-keyword discipline.** Plan + tasks
+    rewritten to use placeholder labels A–E in the planning
+    bundle; TB0.4 files five real GitHub issues and captures
+    their numeric IDs into `sub-issue-numbers.md` before any
+    PR is opened. Every PR title uses the captured numeric ID
+    in its `Closes #NN` keyword; placeholder labels never
+    appear in PR descriptions.
+  - **Claude-code judge determinism contract.** Local
+    `claude --help` exposes only `--model` /
+    `--fallback-model` — no `--temperature`, no `--seed`. The
+    judge therefore records `temperature: null` / `seed: null`
+    / `temperature_control: "unsupported"` /
+    `seed_control: "unsupported"`. Re-run stability is
+    empirical and surfaced by the calibration step's Spearman,
+    not silently claimed as T=0. Fixed in spec.md
+    (Interface § Initial judge implementation, the schema
+    example, D7, AC2) and tasks.md (TB1.2).
+- **Round 3 (2026-05-20).** Two P2 review findings addressed:
+  spec.md § D1 table now uses placeholder labels A–E (was
+  `#34a`–`#34e`) with the same B0 numeric-ID note; this
+  alignment record refreshed to reflect resolved D1/D4/D7
+  decisions and actual validation results.

--- a/specs/benchmark-llm-judge/plan.md
+++ b/specs/benchmark-llm-judge/plan.md
@@ -1,0 +1,530 @@
+---
+spec_mode: full
+feature_id: benchmark-llm-judge
+risk_category: integration
+justification: "Adds a parallel `Judge` protocol + scorer (mirrors the existing Backend contract from #32) + a calibration validation pipeline + additive HTML/CSV/SVG reports + a winner-declaration extension on calibrated-judge dimensions. Touches a new `scripts/benchmark_runner/judge/` package, extends `report.py` additively, and reuses `report_winner.declare_winner` unchanged. The deterministic harness — `run.py`, `score.json`, `BackendResult`, `report_winner.declare_winner` — is NOT modified. External integration: the judge invokes an LLM via the existing `claude-code` backend headless path + provider-routing env vars. Empirical research-question component: per-dimension Spearman ≥ 0.6 is an empirical outcome, not a guarantee; the plan defines a path for zero-dimensions-calibrated. Human-labeling dependency: ≥50 task-runs hand-labeled on a multi-dimensional rubric — reviewer hours, not an agent task. D1 PR-structure is open; the team-lead recommendation is Option B (split #34 into sub-issues)."
+status: draft
+date: 2026-05-20
+issue: 34
+origin:
+  issue: gosha70/code-copilot-team#34
+  urls:
+    - https://github.com/gosha70/code-copilot-team/issues/34
+    - https://github.com/gosha70/code-copilot-team/issues/32
+    - https://github.com/gosha70/code-copilot-team/issues/33
+    - https://github.com/Aider-AI/polyglot-benchmark
+    - https://www.swebench.com/verified.html
+  origin_claim: |
+    See spec.md `origin:` block. Issue #34 v3 adds calibrated
+    LLM-judge scoring + rich reports (HTML/CSV/static charts) on top
+    of the deterministic harness from #32/#33. Five subsystems
+    "deliverable in order"; deterministic-first ordering an explicit
+    AC; ≥50 task-runs spanning ≥2 axes for the calibration set;
+    Spearman ≥ 0.6 per dimension; dollar-cost permanently out of
+    scope. Two structural properties (human-labeling dependency +
+    empirical research question) distinguish #34 from #36/#41.
+    Corpus inventory (2026-05-20, recorded in spec.md): 1171
+    attempt-records exist; calibration corpus needs no new
+    benchmark spend. D1 PR-structure is OPEN — team lead recommends
+    Option B (split into sub-issues) to honor the one-PR-per-issue
+    rule (memory `feedback-pr-must-fully-address-issue`).
+---
+
+# Implementation Plan — Calibrated LLM-Judge + Rich Reports (#34)
+
+> **D1 is the gating decision.** This plan describes the engineering
+> work that is invariant across the three D1 options. The per-PR /
+> per-sub-issue partition depends on D1; the **Option-B mapping** is
+> spelled out below as the recommended path, with the Option-A and
+> Option-C deltas listed at the end.
+
+## Approach
+
+The deterministic harness from #32/#33 is **frozen** by this feature:
+`run.py`, `score.json`, `BackendResult`, and `declare_winner` are
+unchanged. The judge subsystem is a parallel package
+(`scripts/benchmark_runner/judge/`) that READS what `run.py` already
+wrote (diff + prompt + verify output per attempt) and WRITES a
+strictly-additive `judge.json` adjacent to `score.json`. The reports
+gain HTML + CSV + SVG-chart emitters additively; the existing
+Markdown + JSON paths are byte-identical (modulo timestamps) when
+no `judge.json` is present.
+
+The plan is staged across two gated phases (this Phase A and Phase
+B implementation) and — under the recommended D1 Option B — across
+five sub-issues, each fully closable by one PR per the
+one-PR-per-issue rule.
+
+## D1 (PR structure) — recommended path: Option B
+
+Five sub-issues, each fully closable by one PR.
+
+> **Labels `A`–`E` below are PLACEHOLDERS, not GitHub close-keyword
+> targets.** GitHub `Closes sub-issue A` does NOT auto-close anything —
+> close keywords require real numeric issue IDs. Phase B0 (TB0.4)
+> files five real issues against `gosha70/code-copilot-team` and
+> captures their assigned numbers into a small table
+> (`specs/benchmark-llm-judge/sub-issue-numbers.md` — committed
+> alongside Phase B1's first commit). Every later PR title /
+> body / branch name MUST use the real numeric ID; `Closes sub-issue A`
+> is a planning shorthand and never appears in a PR description.
+> Memory `feedback_github_close_keyword_per_issue` applies — one
+> `Closes #NN` keyword per real issue, no shared keyword.
+
+The order below is the buildable-dependency order — subsequent
+sub-issues import artifacts from earlier ones but each PR fully
+closes its own issue without partial PRs against the umbrella #34.
+
+| Label | Suggested sub-issue title | Closes when | Depends on |
+|---|---|---|---|
+| **A** | `feat(benchmark): Judge protocol + claude_code judge + corpus-selection CLI` | `Judge` protocol + `claude_code_judge` produce a real `judge.json` per attempt; `./scripts/benchmark calibration-corpus` selects N≥50 from `runs/` across user-specified axes; fake-judge recorded-transcript test green. | — |
+| **B** | `feat(benchmark): calibration validation + per-dimension Spearman gate` | `./scripts/benchmark calibrate` runs the judge against a labeled corpus and emits `calibration-report.md` + `calibrated-dimensions.json`; tested against synthetic labels (no human-labeling required to merge). | A |
+| **C** | `feat(benchmark): HTML + CSV + static-SVG reports (additive)` | `./scripts/benchmark report --html --csv` emits the additive artifacts with the deterministic-block-first / judge-block-second / verdicts-third layout; existing Markdown+JSON byte-identical when no judge.json present (regression-protected by snapshot test). | — (can ship in parallel with A) |
+| **D** | `feat(benchmark): calibrated-judge winner-extension (deterministic-first enforced)` | Calibrated dimensions trigger `declare_winner` calls (reusing `report_winner.py` unchanged) with samples restricted to passing-on-both-sides attempts; uncalibrated dimensions never declare a winner; non-passing ratings appear in the report but never in the verdict. | A, B, C |
+| **E** | `chore(benchmark): land first labeled calibration set + first calibration-report.md` | A real human-labeled `<name>.jsonl` ≥50 records ≥2 axes lands under `benchmarks/calibration/`; `calibrate` is run against it; the resulting `calibration-report.md` + `calibrated-dimensions.json` land in the same PR; reports on this CCT instance now show calibrated verdicts wherever dimensions cleared Spearman 0.6. | A, B, C, D. **All upstream code is already merged before the human-labeling work commits to a final rubric.** |
+
+Each PR's title / body uses the real numeric ID captured in TB0.4,
+e.g. `feat(benchmark): Judge protocol + claude_code judge +
+corpus-selection CLI (Closes #<A's real id>)`. The PR that lands
+the labeled set ALSO writes `Closes #34` in its body (separate
+keyword per the memory above), so #34 the epic closes
+automatically when E's PR merges. If a sub-issue spawns mid-PR
+divergence that demands its own issue, the same numeric-ID
+discipline applies — never refer to a non-existent `#34X` in a
+PR body.
+
+If calibration on the first rubric fails entirely (D6
+zero-dimensions terminal state), E ships the negative calibration
+report; the maintainer files a follow-up issue for rubric v2 if
+they want to try again — that's a new bet, not a re-open of #34.
+
+The full Phase B0–B5 task layout below assumes Option B; deltas for
+Options A and C are at the end of this plan.
+
+## Phase boundaries (Option B)
+
+| Step | Sub-issue | Working slice | Gate |
+|---|---|---|---|
+| Phase A | (this bundle) | spec/plan/tasks + origin-alignment | `validate-spec.sh` + `check-origin-alignment.sh` exit 0; user picks D1 (A/B/C); user "go" |
+| Phase B0 | (pre-sub-issue A) | preflight: corpus inventory locked, rubric v1 dimensions ratified with user, judge backend default ratified, sub-issues filed | spec.md § Calibration-corpus reality check confirmed against current `runs/`; rubric v1 written to `benchmarks/calibration/rubric-default-v1.md`; sub-issues sub-issue A–sub-issue E filed |
+| Phase B1 | sub-issue A | Judge protocol + claude_code judge + corpus-selection CLI | fake-judge suite green; `judge.json` shape stable; `calibration-corpus --target-n 50 --axes model,repeated-runs` produces a valid corpus from existing `runs/` |
+| Phase B2 | sub-issue B | calibration validation + Spearman gate | tested with synthetic labels: spearmanr from `scipy.stats` (or stdlib equivalent — see § Tooling), threshold 0.6, deterministic — synthetic-labels-against-fixed-judge-fixture produces a fixed `calibration-report.md` |
+| Phase B3 | sub-issue C | HTML + CSV + static-SVG reports (additive) | snapshot test: a run with no judge.json produces a Markdown+JSON report byte-identical (modulo timestamps) to the #32/#33 baseline; HTML renders the deterministic-first / judge-second / verdicts-third layout; SVG charts render without JS |
+| Phase B4 | sub-issue D | winner-extension on calibrated dimensions | calibrated-dimensions.json with N dimensions triggers N `declare_winner` calls on `judge:<dim>`; passing-on-both-sides enforced (asserted in a test that injects non-passing samples and asserts they are excluded); uncalibrated dimensions skipped |
+| Phase B5 | sub-issue E | first real labeled calibration set + activated calibration | ≥50 task-runs labeled by a human reviewer; `calibrate` run; report renders calibrated verdicts where dimensions cleared 0.6 (or zero-dimensions-terminal-state per D6) |
+
+Per the one-PR-per-issue rule, each B-step closes its own
+sub-issue with its own PR; #34 closes when sub-issue E (B5) closes.
+
+## Phase B0 — Preflight (no code yet)
+
+1. **Confirm corpus inventory holds** on the maintainer machine:
+   re-run the inventory script in spec.md § Calibration-corpus
+   reality check; numbers in the spec must still match (or the
+   plan adapts).
+2. **Lock rubric v1 dimensions with the user.** The spec names
+   four (idiomaticity / error_handling / test_thoughtfulness /
+   security_hygiene); confirm the names + per-dimension
+   prompt-fragment phrasing before sub-issue A's judge prompt template
+   becomes the API surface a calibration set will be labeled
+   against. Land `benchmarks/calibration/rubric-default-v1.md` in
+   the sub-issue A PR (it is the prompt template + the dimension list +
+   the 1–5 rating anchor descriptions).
+3. **Confirm judge backend default with the user.** `claude-code:sonnet`
+   is the spec's default; if the user prefers a different judge
+   model (e.g. opus, or a local-gateway model so the judge is
+   self-hostable), it lands in sub-issue A.
+4. **File sub-issues sub-issue A–sub-issue E** referencing this spec/plan and
+   their per-AC mapping.
+
+## Phase B1 — sub-issue A — Judge protocol + claude_code judge + corpus-selection CLI
+
+### Files to create
+
+- `scripts/benchmark_runner/judge/__init__.py`
+- `scripts/benchmark_runner/judge/contracts.py` — `Judge` protocol +
+  `JudgeInput`/`JudgeResult` frozen dataclasses (mirror
+  `Backend`/`BackendResult`).
+- `scripts/benchmark_runner/judge/claude_code_judge.py` — initial
+  judge using the `claude-code` backend headless invocation +
+  provider-routing env vars; reads the rubric prompt template,
+  formats with attempt evidence (diff + prompt + verify output),
+  parses model output into a `JudgeResult`.
+- `scripts/benchmark_runner/judge/registry.py` — light registry
+  parallel to `benchmark_runner.registry` for judges.
+- `scripts/benchmark_runner/judge/runner.py` — `run_judge(run_dir,
+  judge_id, rubric_name)`: walks `run_dir`, invokes the judge per
+  attempt directory, writes `judge.json`.
+- `scripts/benchmark_runner/calibration/__init__.py`
+- `scripts/benchmark_runner/calibration/corpus_select.py` —
+  axis-agnostic selector; reads `runs/`'s `run-record.json` +
+  `score.json`, applies the axes filter + target-N, writes
+  `<name>.corpus.jsonl` (selected task-runs) + `<name>.meta.json`
+  (the selection command + axes + per-axis counts).
+- `scripts/benchmark_runner/cli.py` extensions: `judge` subcommand
+  (`./scripts/benchmark judge --run-dir <d> --judge claude-code:sonnet
+  [--rubric default-v1]`) and `calibration-corpus` subcommand.
+- `benchmarks/calibration/rubric-default-v1.md` — the prompt
+  template + dimension list + 1–5 rating anchors.
+- `scripts/benchmark_runner/tests/test_judge_protocol.py` — protocol
+  shape + JudgeInput/JudgeResult immutability.
+- `scripts/benchmark_runner/tests/test_claude_code_judge.py` —
+  recorded-transcript fake-judge shim (mirror codex/aider fake-CLI
+  pattern); no live LLM in tests.
+- `scripts/benchmark_runner/tests/test_corpus_select.py` — fixture
+  `runs/` tree; selection axes; deterministic output.
+- `scripts/benchmark_runner/tests/fixtures/judge/` — recorded
+  judge-output fixtures (success / partial / parse-failure).
+
+### Files to modify
+
+- `scripts/benchmark_runner/_register.py` — judge registration block
+  parallel to backends.
+
+### Files NOT to modify
+
+- `scripts/benchmark_runner/run.py` (D9 invariant)
+- `scripts/benchmark_runner/contracts.py` (Judge contracts live in
+  the new `judge/contracts.py` package, parallel not entangled)
+- `scripts/benchmark_runner/report_winner.py` (D2 invariant)
+
+### Done when (per sub-issue A)
+
+- `Judge` protocol exists; `claude_code_judge` registers; the
+  fake-CLI recorded-transcript suite is green per-module.
+- `./scripts/benchmark calibration-corpus --target-n 50
+  --axes model,repeated-runs` produces a corpus from the live
+  `runs/` archive that satisfies (a) N ≥ 50, (b) ≥ 2 axes
+  represented, (c) `<name>.meta.json` records reproducibly.
+- `./scripts/benchmark judge --run-dir <d>` writes `judge.json`
+  per attempt (live LLM, run by the maintainer; not in CI).
+
+## Phase B2 — sub-issue B — Calibration validation + Spearman gate
+
+### Files to create
+
+- `scripts/benchmark_runner/calibration/validate.py` — reads a
+  labeled `<name>.jsonl` + a run-dir of `judge.json` files,
+  joins on (run_path, dimension), computes per-dimension Spearman
+  ρ + exact-match rate, writes the artifacts.
+- `scripts/benchmark_runner/calibration/spearman.py` — Spearman
+  implementation (see § Tooling: NO new external dependency added
+  — stdlib + the existing `statistics` module are sufficient
+  given small N).
+- `scripts/benchmark_runner/cli.py` extension: `calibrate`
+  subcommand.
+- `scripts/benchmark_runner/tests/test_calibration_validate.py` —
+  fixed-judge fixture × fixed-label fixture → fixed expected
+  Spearman matrix; threshold gating tested at 0.6, 0.7, and 0.59
+  (boundary).
+- `scripts/benchmark_runner/tests/test_spearman.py` — golden
+  numbers for the Spearman implementation against published test
+  vectors.
+
+### Done when (per sub-issue B)
+
+- `./scripts/benchmark calibrate --judge claude-code:sonnet
+  --labels benchmarks/calibration/<name>.jsonl` produces
+  `<name>.calibration-report.md` + `<name>.calibrated-dimensions.json`.
+- The validate suite passes per-module against synthetic labels;
+  no human labeling required to merge this PR.
+
+## Phase B3 — sub-issue C — HTML + CSV + static-SVG reports (additive)
+
+### Files to create / modify
+
+- Extend `scripts/benchmark_runner/report.py` additively with:
+  - `_emit_html(report_data, out_path)` — Jinja-less stdlib HTML
+    rendering (avoid new dependency); deterministic-first /
+    judge-second / verdicts-third layout; explicit visual separator
+    HTML element.
+  - `_emit_csv(report_data, out_dir)` — `report.csv` (per-task)
+    + `report-by-model.csv` (per-(backend, model)).
+  - `_emit_svg_bar(pass_rates, out_path)`, `_emit_svg_hist(...)`,
+    `_emit_svg_forest(...)` — pure-string SVG (no matplotlib
+    dependency unless the user blesses one in B0 preflight).
+- `scripts/benchmark_runner/cli.py` extension: `report --html
+  --csv` flags.
+- `scripts/benchmark_runner/tests/test_report_html.py` — render
+  HTML for a fixture run-dir; assert structure + layout markers
+  + that the deterministic block precedes the judge block.
+- `scripts/benchmark_runner/tests/test_report_csv.py` — fixed
+  fixture → byte-identical CSV.
+- `scripts/benchmark_runner/tests/test_report_svg.py` — fixed
+  fixture → SVG with expected `<rect>` / `<path>` / `<text>`
+  elements.
+- `scripts/benchmark_runner/tests/test_report_no_judge_regression.py`
+  — **THE REGRESSION GUARD**: a fixture run-dir with no
+  `judge.json` files; emit Markdown + JSON; compare to a
+  snapshot baseline; modulo timestamp lines, byte-identical.
+
+### Files NOT to modify
+
+- `scripts/benchmark_runner/report_winner.py`
+- The existing Markdown/JSON emission paths beyond what's needed
+  to surface judge-block content WHEN PRESENT.
+
+### Done when (per sub-issue C)
+
+- HTML + CSV + SVG emit per the flags; snapshot regression test
+  green; static SVGs render without JS (verified by opening in a
+  browser with JS disabled, or equivalent CI gate).
+
+## Phase B4 — sub-issue D — Winner-extension on calibrated dimensions
+
+### Files to create / modify
+
+- `scripts/benchmark_runner/report.py` — additive caller logic that,
+  given a `calibrated-dimensions.json`, builds samples per
+  (backend, model) × dimension from `judge.json` ratings on
+  passing-on-both-sides attempts, calls
+  `declare_winner(MetricSpec(name=f"judge:{dim}", ...), …)`
+  unchanged.
+- `scripts/benchmark_runner/tests/test_report_winner_judge.py` —
+  inject a fixture with two (backend, model) groups, varied judge
+  ratings, mixed pass/fail; assert that:
+  1. Calibrated dimensions emit verdicts; uncalibrated do not.
+  2. Non-passing-on-both-sides samples are filtered out (the
+     deterministic-first gate). Inject a non-passing sample that
+     would swing the verdict if included; assert the verdict does
+     not swing.
+  3. `report_winner.py` is called with `declare_winner` — verified
+     via spy / mock — but not modified (`git diff` clean).
+
+### Files NOT to modify
+
+- `scripts/benchmark_runner/report_winner.py` (D2 invariant —
+  asserted by the spy/mock above + a git diff check in CI).
+
+### Done when (per sub-issue D)
+
+- Calibrated-dimensions winner-extension shipped; deterministic-first
+  gate test green; `report_winner.declare_winner` is reused
+  unchanged.
+
+## Phase B5 — sub-issue E — First labeled calibration set + activate
+
+### Files to create
+
+- `benchmarks/calibration/cct-instance-v1.jsonl` — ≥50 task-runs
+  × 4 dimensions = ≥200 JSONL records (one per (run_path,
+  dimension)); spans ≥2 axes (default: `model` ×
+  `repeated-runs`); labels by a single human reviewer (the
+  maintainer) with notes per record where the rating is
+  borderline.
+- `benchmarks/calibration/cct-instance-v1.meta.json` —
+  reviewer (or reviewers), labeling-session timestamps, the
+  corpus-selection command used (so the selection step is
+  reproducible).
+- `benchmarks/calibration/cct-instance-v1.calibration-report.md`
+  — output of `./scripts/benchmark calibrate
+  --judge claude-code:sonnet --labels …`.
+- `benchmarks/calibration/cct-instance-v1.calibrated-dimensions.json`
+  — output of the same run; consumed by `report.py` at report
+  time.
+- (Optional) `doc_internal/2026-MM-DD-calibration-session.md` —
+  internal notes from the labeling session, NOT committed if the
+  notes contain reviewer fatigue / private commentary.
+
+### Done when (per sub-issue E)
+
+- The labeled set is on disk + the calibrate script has run + the
+  resulting calibration-report is committed.
+- If any dimensions cleared Spearman 0.6: subsequent reports show
+  calibrated verdicts on those dimensions; the AC8
+  deterministic-first invariant holds (asserted by a spot-check
+  against one PR-attached comparison report).
+- If zero dimensions cleared 0.6 (D6 terminal state): the
+  calibration-report.md spells out the negative outcome; the
+  judge-block of subsequent reports renders raw ratings with all
+  dimensions flagged `uncalibrated`; the maintainer files (or
+  declines to file) a rubric-v2 follow-up. #34 still closes;
+  AC1–AC10 are still satisfied, AC4 vacuously (no calibrated
+  dimensions to declare a verdict on).
+
+## Reuse map
+
+Defers to spec.md § Reuse map. Headline:
+
+- `Backend` / `BackendResult` shape → cloned as `Judge` /
+  `JudgeResult` in a parallel `judge/` package; not entangled.
+- `claude_code` backend headless invocation → reused by
+  `claude_code_judge`.
+- `declare_winner` from `report_winner.py` → reused unchanged on
+  the new `judge:<dim>` metric names.
+- `run.py`'s `attempt_dir` / `score.json` write path → READ-ONLY;
+  the judge writes the additive `judge.json` adjacent.
+- `runs/` corpus (1171 attempt-records) → seeds the calibration
+  set.
+
+## Tooling decisions
+
+- **No new external Python dependency.** Spearman ρ on N ≤ 200
+  is trivially implementable in stdlib (`statistics` + rank-by-sort).
+  Avoiding `scipy` keeps the harness's runtime footprint small
+  and matches the existing report's stdlib-only posture.
+- **SVG = pure-string emission.** Bar / histogram / forest plot
+  are small enough that hand-written SVG is more legible and more
+  testable than a matplotlib invocation. Confirms decision D8
+  (additivity) — no plotting-library dependency creeps in.
+- **HTML = stdlib-only.** No Jinja, no Pydantic, no
+  templating-engine dependency.
+
+## Test strategy
+
+Stdlib `unittest`/pytest under
+`scripts/benchmark_runner/tests/` (consistent with #32/#33/#36/#41
+practice). New test modules per Phase B section. Run **per-module**
+— the documented host failures
+(`test_polyglot_adapter`×4, `test_cli_skeleton` hang, stale
+`test_polyglot_dogfood_subset`, `fixtures/**/leap_test.py`
+autocollection) are pre-existing, not regressions
+(memory `project_benchmark_preexisting_env_test_failures`).
+
+Mandatory guard tests:
+- **Additivity regression** (Phase B3): a run with no `judge.json`
+  emits a Markdown+JSON report byte-identical (modulo timestamps)
+  to a snapshot baseline.
+- **Deterministic-first enforcement** (Phase B4): a fixture with a
+  non-passing sample that would swing the verdict if included
+  asserts the verdict does not swing.
+- **`report_winner.py` not-modified** (Phase B4): a CI gate
+  (`git diff --quiet -- scripts/benchmark_runner/report_winner.py`
+  against the merge base) before merging sub-issue D.
+
+No live LLM in tests. Judge tests use recorded-transcript fake-CLI
+fixtures, mirroring the codex/aider pattern.
+
+## Delegation strategy
+
+Single build agent, phase-scoped per sub-issue (under Option B);
+reads spec/plan/tasks before each sub-issue's work; one sub-issue
+per scoped invocation; runs that sub-issue's tests; does not
+advance until green; does not commit (team lead commits with per-step
+user diff approval). No parallel sub-agents — sub-issues sub-issue A and
+sub-issue C CAN proceed in parallel structurally, but a single
+serial pass is preferred to keep the diff-review surface bounded
+(memory `team-lead-efficiency`).
+
+Per-sub-issue agent prompts MUST include:
+- The relevant spec.md § + the sub-issue's task list.
+- The "do not touch" list (D-invariants: `run.py`,
+  `report_winner.py`, etc.).
+- The "verify every code path, not one sampled path" memory
+  (memory `feedback_verify_delegated_build_trace_all_paths`).
+- A reminder that `judge.json` is additive; running `judge` MUST
+  NOT mutate `score.json`.
+
+## Files to create (total, under Option B)
+
+- `scripts/benchmark_runner/judge/{__init__,contracts,claude_code_judge,registry,runner}.py`
+- `scripts/benchmark_runner/calibration/{__init__,corpus_select,validate,spearman}.py`
+- `scripts/benchmark_runner/tests/test_judge_protocol.py`
+- `scripts/benchmark_runner/tests/test_claude_code_judge.py`
+- `scripts/benchmark_runner/tests/test_corpus_select.py`
+- `scripts/benchmark_runner/tests/test_calibration_validate.py`
+- `scripts/benchmark_runner/tests/test_spearman.py`
+- `scripts/benchmark_runner/tests/test_report_html.py`
+- `scripts/benchmark_runner/tests/test_report_csv.py`
+- `scripts/benchmark_runner/tests/test_report_svg.py`
+- `scripts/benchmark_runner/tests/test_report_no_judge_regression.py`
+- `scripts/benchmark_runner/tests/test_report_winner_judge.py`
+- `scripts/benchmark_runner/tests/fixtures/judge/transcript-*.txt`
+- `benchmarks/calibration/rubric-default-v1.md`
+- `benchmarks/calibration/cct-instance-v1.{jsonl,meta.json,calibration-report.md,calibrated-dimensions.json}`
+- `specs/benchmark-llm-judge/{spec,plan,tasks}.md` +
+  `origin-alignment-2026-05-20-0238.md` (this bundle)
+
+## Files to modify
+
+- `scripts/benchmark_runner/cli.py` — `judge`,
+  `calibration-corpus`, `calibrate` subcommands; `report` gains
+  `--html --csv --judge --calibrated-dimensions` flags.
+- `scripts/benchmark_runner/_register.py` — judge registration.
+- `scripts/benchmark_runner/report.py` — additive HTML/CSV/SVG
+  emitters; calibrated-dimensions-aware aggregation; calls into
+  the unchanged `declare_winner` on `judge:<dim>` metrics.
+- `benchmarks/README.md` — judge usage, calibration usage,
+  rubric-extension instructions.
+
+## Files NOT to modify (D-invariants)
+
+- `scripts/benchmark_runner/run.py` (D9)
+- `scripts/benchmark_runner/contracts.py` (D2 — `Backend`,
+  `BackendResult` shape stable)
+- `scripts/benchmark_runner/report_winner.py` (D2 — `declare_winner`
+  shape stable)
+
+## Rollout (Option B)
+
+1. Phase A bundle reviewed; user picks D1.
+2. Phase B0: sub-issues sub-issue A–sub-issue E filed referencing this bundle;
+   rubric v1 + judge default ratified.
+3. Branches `feat/benchmark-llm-judge-a` … `e`, each with its own
+   PR titled `feat(benchmark): … (Closes #<sub-issue real id>)`,
+   using the numeric ID captured in TB0.4 — never the placeholder
+   label.
+4. Per-PR commits: diff shown + explicit user approval before
+   every commit; never push to master.
+5. PRs open only after per-module suites green,
+   `check-origin-alignment.sh benchmark-llm-judge` ≤ 1, and any
+   executable artifacts actually run (fake-judge suite; judge CLI;
+   `report --html` rendered).
+6. The first labeled calibration set (sub-issue E) is the last PR; it
+   merges only after the human-labeling work is complete and the
+   live `calibrate` run has produced its report.
+
+## Option-A delta (if user picks Option A instead)
+
+- Single branch `feat/benchmark-llm-judge`, single PR
+  `Closes #34`.
+- Phase B1–B4 happen in one commit chain; Phase B5 is the
+  PR-merge gate (mirror #41's `_VERIFIED_VERSION` placeholder
+  pattern at scale): a loud constant
+  `CALIBRATION_SET_REQUIRED__DO_NOT_MERGE` in the report's
+  calibrated-dimensions resolver, plus a self-enforcing test
+  `test_calibration_set_present_for_merge`, both lifted only when
+  the real labeled set lands in the same branch before merge.
+- Trade-off: PR sits open for days/weeks while a human labels
+  ≥50 records; large diff to review; merge gates on a single
+  reviewer's calendar.
+- Plan/tasks rewriting required if the user picks A.
+
+## Option-C delta (NOT recommended — violates AC)
+
+- Single PR ships sub-issue A–sub-issue D; sub-issue E becomes a documented maintainer
+  procedure.
+- Violates explicit #34 v3 AC ("Calibration set checked in:
+  ≥50 task-runs spanning ≥2 axes of variation, full per-dimension
+  human ratings"). #41 could ship the leaderboard as a maintainer
+  procedure because the leaderboard run is NOT an AC of #41; the
+  calibration set IS an AC of #34. Option C is therefore a scope
+  regression against an explicit AC — recorded here for
+  completeness, not as a recommended path.
+
+## Risks
+
+1. **Calibration fails on all dimensions (D6 terminal state).**
+   Mitigation: spec.md treats this as a valid terminal outcome,
+   not a build failure. The harness still ships correctly.
+2. **Human labeling is slow / inconsistent.** Mitigation:
+   sub-issue E is its own PR; the upstream code (sub-issue A–d) merges
+   independently and is exercised by synthetic-label tests. The
+   maintainer can iterate on labels without re-running upstream
+   PRs.
+3. **A reviewer-vs-reviewer baseline isn't established before
+   thresholding.** Mitigation: rubric v1 ships with the 0.6
+   threshold; rubric-v2 follow-up could add a small
+   second-reviewer overlap to bound reviewer noise (out of scope
+   for #34).
+4. **The judge's free-text explanations include PII or copilot
+   internals.** Mitigation: explanations are recorded as-is in
+   `judge.json` but the recorded prompt + judge model are also
+   stored, so a reviewer can audit and a future scrubber can
+   re-process if needed. Judge default is `claude-code:sonnet` —
+   the same content the backend already routes through.
+5. **`report_winner.py` ends up needing a change after all.**
+   Mitigation: the spec explicitly forbids it (D2), the plan
+   tests for it (a CI gate against the merge base). If a change
+   is truly required, that's a Phase B4 escalation back to the
+   user — not a unilateral edit.

--- a/specs/benchmark-llm-judge/spec.md
+++ b/specs/benchmark-llm-judge/spec.md
@@ -1,0 +1,729 @@
+---
+feature_id: benchmark-llm-judge
+spec_mode: full
+status: draft
+issue: 34
+origin:
+  issue: gosha70/code-copilot-team#34
+  urls:
+    - https://github.com/gosha70/code-copilot-team/issues/34
+    - https://github.com/gosha70/code-copilot-team/issues/32
+    - https://github.com/gosha70/code-copilot-team/issues/33
+    - https://github.com/Aider-AI/polyglot-benchmark
+    - https://www.swebench.com/verified.html
+  origin_claim: |
+    Issue #34 (v3, 2026-05-08) adds calibrated LLM-judge scoring on top
+    of the deterministic harness from #32/#33, plus rich reports
+    (HTML/CSV/static charts). Five subsystems "deliverable in order":
+    (1) calibration set ≥50 task-runs spanning ≥2 axes of variation
+    (adapters/backends/models/repeated-runs), human 1–5 ratings per
+    rubric dimension; (2) Judge protocol mirroring the Backend contract,
+    `judge.json` per run; (3) calibration validation — per-dimension
+    Spearman ≥ 0.6, uncalibrated dimensions excluded from winner math;
+    (4) rich reports — HTML/static-SVG-charts/CSV, ADDITIVE to the
+    existing Markdown+JSON reports; (5) winner-declaration extension —
+    same `Δ > 2σ AND ≥ threshold` rule on calibrated-judge dimensions
+    with per-dimension threshold; deterministic-first ordering enforced
+    (a run that fails deterministic tests cannot win on judge-only).
+    Permanently out of scope: dollar-cost reporting; replacing
+    deterministic scoring with judge scoring.
+
+    Two properties make #34 structurally unlike #36/#41: (a) a HUMAN
+    LABELING dependency on the calibration set (hours of reviewer
+    work, not an agent task); (b) a RESEARCH QUESTION — the judge is
+    only useful if Spearman ≥ 0.6 on ≥1 dimension, which is an
+    empirical outcome, not a guarantee. The plan treats "the judge
+    fails calibration on some/all dimensions" as a defined-outcome
+    path, not an edge case.
+
+    Corpus inventory finding (2026-05-20, 5 axes inspected): 1171
+    attempt-records exist across 50 run-dirs, 5 (backend, model) tuples
+    (claude-code × {phi-3, qwen2.5-coder:7b, qwen3.6:27b,
+    RedHatAI/Qwen3-Coder-Next-NVFP4, sonnet} + one stub
+    swe-bench-verified). Pass rate is 3.8% (44 passing task-runs); 568
+    non-passing attempts have file changes (judge-ratable). The
+    calibration corpus can be sourced from existing runs (≥2 axes:
+    models × repeated-runs, optionally also benchmarks×backends if
+    #33 Track B lands first); NO additional benchmark spend is
+    required to assemble it. Human labeling time, however, is.
+---
+
+# Calibrated LLM-Judge Scoring + Rich Reports (#34)
+
+> **Judge is secondary; deterministic-first non-negotiable.** A run
+> that fails deterministic tests cannot win on judge-only criteria
+> (issue v3 explicit AC). The judge augments comparison *inside*
+> passing runs (or, in the report layer, surfaces advisory ratings
+> alongside non-passing runs) — it never overrides the deterministic
+> verdict.
+
+## Problem
+
+#32/#33 deliver a benchmark-agnostic harness that compares
+copilots/models on pass/fail, elapsed time, and token usage with a
+calibrated winner-declaration rule (`Δ > 2σ AND ≥ threshold`). What
+that harness cannot tell apart: two passing runs on the same task that
+produce visibly different code (idiomaticity, error handling, test
+thoughtfulness, security hygiene). These are the dimensions human
+reviewers actually disagree about and the dimensions a leaderboard
+score-row never surfaces.
+
+#34 adds an LLM-judge that rates those dimensions — but only after a
+human-labeled calibration set proves the judge's verdict correlates
+with reviewer judgment on this CCT instance's corpus. Without
+calibration, an LLM judge is just another opinion; the winner rule
+must not be widened on uncalibrated signal.
+
+Two structural properties distinguish #34 from #36 (bench driver) and
+#41 (aider backend):
+
+1. **Human-labeling dependency.** ≥50 task-runs must be hand-labeled
+   on a multi-dimensional rubric. This is reviewer time, not an agent
+   task — the analog of #41's recorded-capture gate, but ~50× larger.
+2. **Empirical research question.** The judge is only useful if
+   Spearman ≥ 0.6 on ≥1 rubric dimension. That correlation is an
+   empirical outcome. "All dimensions fail calibration" is a real
+   possible outcome and must have a defined handling path.
+
+## Strategic framing
+
+The deterministic score from #32 is the **primary** signal — what
+merges, what wins. The LLM-judge score is a **secondary** signal that
+augments comparison; it never overrides the deterministic verdict.
+
+This ordering is enforced in three places:
+- **Report layout** — deterministic block first, judge block second,
+  with explicit visual separation (issue v3 AC).
+- **Winner declaration** — calibrated-judge dimensions can declare a
+  winner only when both compared sides pass deterministically (issue
+  v3 AC).
+- **Uncalibrated dimensions** — never declare a winner; raw ratings
+  still appear in the report for reviewer use.
+
+Permanently out of scope (issue v3): dollar-cost reporting; replacing
+deterministic scoring with judge scoring; authoring new adapters
+(#33); adding new backends (#33); cross-CCT-instance shared
+calibration sets (deferred follow-up).
+
+## Calibration-corpus reality check (2026-05-20)
+
+A direct inventory of `runs/` produced numbers that **shape the whole
+plan** and are recorded here so the spec can be re-derived without
+re-running the inventory:
+
+| Backend | Model | Benchmark | Attempts | Passing |
+|---|---|---|---:|---:|
+| claude-code | qwen2.5-coder:7b | aider-polyglot | 567 | 3 |
+| claude-code | phi-3 | aider-polyglot | 513 | 3 |
+| claude-code | RedHatAI/Qwen3-Coder-Next-NVFP4 | aider-polyglot | 39 | 10 |
+| claude-code | sonnet | aider-polyglot | 34 | 27 |
+| claude-code | qwen3.6:27b | aider-polyglot | 14 | 0 |
+| stub | (none) | swe-bench-verified | 3 | 1 |
+| claude-code | sonnet | swe-bench-verified | 1 | 0 |
+| **Total** | | | **1171** | **44** |
+
+Three load-bearing consequences:
+
+1. **The calibration corpus does NOT need new benchmark spend.** ≥50
+   task-runs spanning ≥2 axes of variation (models × repeated-runs;
+   adapters once #33 Track B lands) are already on disk. The corpus
+   build step is a *selection + labeling* exercise, not a *generation*
+   exercise.
+2. **A passing-runs-only calibration corpus is infeasible at N=50.**
+   Only 44 passing runs exist, almost all on `sonnet`. A
+   passing-only set would (a) miss the 50 floor and (b) collapse the
+   "model" variation axis to a single model. The corpus must mix
+   passing and non-passing runs — the rubric dimensions
+   (idiomaticity, error handling, etc.) are *defined for any code
+   the model produced*, not only passing code. 568 non-passing
+   attempts with file changes are available.
+3. **The "deterministic-first cannot win on judge" rule still
+   protects the report.** Even though non-passing attempts are
+   *rated* by the judge, the winner-declaration extension only
+   activates a calibrated-judge verdict when both sides
+   deterministically pass on the same task (interface § Winner
+   extension).
+
+## User Scenarios
+
+1. **Maintainer adds the judge to a fresh comparison run.** A
+   maintainer who already ran
+   `./scripts/benchmark compare --config <cfg>` runs
+   `./scripts/benchmark judge --run-dir runs/<ts>/ [--judge claude-code:sonnet]`.
+   The harness walks every `attempt-NN-run-NN/` under the run-dir,
+   invokes the configured judge against each attempt's diff + prompt
+   + verify output, and writes `judge.json` adjacent to `score.json`
+   in every attempt directory. No existing artifact is overwritten.
+   `score.json` is the authoritative deterministic verdict; the
+   judge can be re-run any number of times without invalidating it.
+
+2. **Reviewer opens the rich HTML report.** Same maintainer runs
+   `./scripts/benchmark report --run-dir runs/<ts>/ --html`. The
+   produced `report.html` (static; no JS required) shows: §
+   Deterministic results (existing table contents, unchanged) →
+   visual separator → § Judge ratings (per-dimension table with
+   calibration-status badge per dimension: `calibrated`/`uncalibrated`)
+   → § Verdicts (deterministic verdicts first; calibrated-judge
+   verdicts appear only for dimensions that passed Spearman ≥ 0.6).
+   Charts (bar/histogram/forest plot) render as embedded static
+   SVG/PNG. The same data also exports to `report.csv` (per-task
+   table) and `report-by-model.csv` (per-(backend, model) table).
+
+3. **Calibration validation succeeds on some dimensions, fails on
+   others.** A maintainer runs
+   `./scripts/benchmark calibrate --judge claude-code:sonnet
+   --labels benchmarks/calibration/<name>.jsonl`. The script invokes
+   the judge against each labeled run, computes per-dimension
+   Spearman + exact-match-rate, writes
+   `benchmarks/calibration/<name>.calibration-report.md`, and updates
+   `benchmarks/calibration/<name>.calibrated-dimensions.json` (the
+   list of dimensions ≥ 0.6 Spearman, consumed by `report.py` and
+   `report_winner.py` at report time). A dimension that scored 0.42
+   appears in the report as `uncalibrated (Spearman 0.42 < 0.6)` and
+   is excluded from winner math.
+
+4. **All dimensions fail calibration.** Same flow as scenario 3,
+   `calibrated-dimensions.json` ends up empty. The HTML report
+   renders the judge block in full (raw ratings still visible for
+   reviewer use) but no calibrated-judge verdict is declared on any
+   dimension. `report.md` / `report.json` carry the same posture.
+   The harness, the judge integration, the reports, and the
+   winner-declaration extension are still correctly built; the only
+   loss is that the empirical research question came back negative
+   on this rubric × this judge × this corpus, and the maintainer
+   either (a) revises the rubric, (b) tries a different judge model,
+   or (c) raises the threshold debate (see § Failure mode below).
+
+5. **CI re-runs the stub-backend smoke without the judge.** A
+   contributor's PR re-runs the stub × stub end-to-end smoke from
+   #32 + #36. The judge subsystem MUST be opt-in — `./scripts/benchmark
+   report` without `--html`/`--judge` produces the existing
+   Markdown+JSON report unchanged. No CI cost change, no new
+   external dependency in the smoke path.
+
+6. **Reviewer audits the judge's verdict.** A reviewer opens
+   `attempt-01-run-001/judge.json` and sees: per-dimension rating
+   (1–5), the judge's full free-text explanation, and the exact
+   prompt + judge model + judge backend used. `judge.json` is
+   reproducible: re-running the judge against the same attempt with
+   the same judge config produces a byte-identical (or
+   semantically-identical, modulo LLM nondeterminism the spec
+   acknowledges and the judge records) verdict.
+
+## Interface
+
+### Judge protocol (mirrors the Backend protocol)
+
+A new `Judge` protocol in
+`scripts/benchmark_runner/judge/contracts.py` (parallel to the
+existing `Backend` protocol in `contracts.py`):
+
+```python
+@runtime_checkable
+class Judge(Protocol):
+    judge_id: str
+
+    def rate(self, attempt: JudgeInput) -> JudgeResult: ...
+```
+
+`JudgeInput` (frozen dataclass) carries: `attempt_dir: Path` (the
+already-written attempt directory), `task_id: str`, `benchmark_id:
+str`, the per-attempt `diff_path` / `prompt_path` / `verify_output`
+that the judge needs as evidence, and a `rubric: RubricSpec`
+(dimensions + per-dimension prompt fragment). The judge does NOT
+re-execute the model — it reads what `run.py` already wrote.
+
+`JudgeResult` (frozen dataclass) carries: per-dimension `rating: int
+∈ {1..5}`, per-dimension `explanation: str`, `judge_model: str`,
+`judge_backend_id: str`, `prompt_sha256: str`, optional
+`tokens_input/output`, optional `seed`. None means "judge did not
+provide"; do not coerce.
+
+### Initial judge implementation
+
+`scripts/benchmark_runner/judge/claude_code_judge.py` — a Judge that
+runs `claude-code` headlessly with a fixed rubric prompt template.
+Reuses the existing `claude_code` backend's headless invocation
+pattern + the same provider-routing env vars (so the judge can route
+to vLLM/Ollama through `ANTHROPIC_BASE_URL`).
+
+**Determinism contract (corrected 2026-05-20 per peer review).** The
+local `claude` CLI surface exposes `--model` / `--fallback-model`
+only — no `--temperature`, no `--seed` flag. The judge therefore
+**cannot pin temperature or seed**. Re-run stability is an empirical
+property, not a guaranteed one. `judge.json` records what the judge
+actually controlled:
+
+- `judge_invocation.model` — the model alias passed via `--model`.
+- `judge_invocation.temperature` — `null` (CLI does not expose the
+  knob; the judge does not assume the model defaults to 0).
+- `judge_invocation.seed` — `null` (same reason).
+- `judge_invocation.provider_endpoint_present` — boolean only.
+- `prompt_sha256` per (dimension, attempt) — what the judge sent,
+  byte-identifiable for audit.
+
+Re-run agreement is a property the calibration step measures (a
+re-run of the judge against the same attempts should produce
+similar ratings; large variance shows up as low Spearman against
+the human labels). The harness does NOT silently claim
+`temperature: 0.0` when the CLI cannot enforce it.
+
+If a future judge backend (or future CLI release) exposes
+temperature / seed, that judge implementation MAY set those fields
+to non-null values; the schema is forward-compatible.
+
+Default judge: `claude-code:sonnet` (model string identical to the
+backend convention). User-overridable via
+`./scripts/benchmark judge --judge claude-code:<model>` and via
+config-file consumers. A maintainer who wants pinnable temperature
++ seed today files a follow-up to add a non-claude-code judge
+backend; that is out of scope for #34.
+
+### `judge.json` schema (additive; never overwrites `score.json`)
+
+Written per attempt at `<attempt_dir>/judge.json`:
+
+```json
+{
+  "schema_version": "1.0",
+  "judge_id": "claude-code-judge",
+  "judge_model": "sonnet",
+  "judge_backend_id": "claude-code",
+  "rubric_name": "default-v1",
+  "rubric_dimensions": ["idiomaticity", "error_handling",
+                        "test_thoughtfulness", "security_hygiene"],
+  "ratings": {
+    "idiomaticity": { "rating": 4, "explanation": "...",
+                      "prompt_sha256": "..." },
+    "error_handling": { "rating": 3, "explanation": "...",
+                        "prompt_sha256": "..." },
+    ...
+  },
+  "judge_invocation": {
+    "model": "sonnet",
+    "temperature": null,
+    "seed": null,
+    "temperature_control": "unsupported",
+    "seed_control": "unsupported",
+    "provider_endpoint_present": true
+  }
+}
+```
+
+Multiple judges can write side-by-side files
+(`judge-<judge_id>.json`); the default file name (`judge.json`)
+points at whichever judge was nominated for winner-extension math.
+
+### Calibration-set schema
+
+`benchmarks/calibration/<name>.jsonl` — one JSONL record per
+(task-run × dimension) pair (issue v3 verbatim):
+
+```json
+{"run_path": "runs/<ts>-…/<task-slug>/attempt-01-run-001",
+ "dimension": "idiomaticity",
+ "rating": 4,
+ "notes": "naming + iteration style idiomatic for Python;
+           one block could use a comprehension"}
+```
+
+A companion `<name>.meta.json` records the human reviewer(s),
+labeling-session timestamps, and the corpus-selection commands so the
+labeled set is reproducible.
+
+### Calibration validation
+
+`./scripts/benchmark calibrate --judge <id> --labels
+benchmarks/calibration/<name>.jsonl [--threshold 0.6]` runs the judge
+against every distinct `run_path` in the labels file, joins judge
+ratings with human ratings on `(run_path, dimension)`, and computes
+per-dimension Spearman ρ + exact-match rate. Writes:
+
+- `benchmarks/calibration/<name>.calibration-report.md` — per-dimension
+  numbers + a scatter-plot SVG per dimension + the threshold +
+  pass/fail per dimension.
+- `benchmarks/calibration/<name>.calibrated-dimensions.json` — the
+  machine-readable list of calibrated dimensions and per-dimension
+  threshold used. THIS is the file that `report.py` and
+  `report_winner.py` consume at report time.
+
+The default threshold is `0.6` (issue v3 verbatim, "starting bar,
+revisable based on observed reviewer-vs-reviewer agreement on the
+calibration set itself"). The threshold lives in the
+`calibrated-dimensions.json` so reports are self-describing: a
+reader can see what threshold gated this verdict without re-running
+calibration.
+
+### Rich-reports surface (ADDITIVE)
+
+`./scripts/benchmark report --run-dir <d> [--html] [--csv]
+[--judge <id>] [--calibrated-dimensions <path>]`:
+
+- Without flags: existing Markdown + JSON only (no regression).
+- `--html`: emit `report.html` with deterministic block first,
+  judge block second, calibrated verdicts third. Charts embedded as
+  static SVG (no JS).
+- `--csv`: emit `report.csv` (per-task table) and
+  `report-by-model.csv` (per-(backend, model) table).
+- `--judge` / `--calibrated-dimensions`: locate the judge.json
+  files (default: `judge.json` per attempt) and the calibrated-dim
+  list (default: nearest `*.calibrated-dimensions.json` under
+  `benchmarks/calibration/`, or none if absent).
+
+Charts:
+- pass-rate bar chart per (backend, model)
+- per-dimension rating histogram per (backend, model)
+- A/B forest plot for winner-declaration verdicts (deterministic +
+  calibrated-judge verdicts in a single plot, with deterministic
+  rows above a visual separator)
+
+### Winner-declaration extension
+
+`report_winner.declare_winner` is reused unchanged for calibrated-judge
+dimensions. New caller logic in `report.py`:
+
+- For each calibrated dimension `d` (Spearman ≥ threshold), build
+  samples-per-(backend, model) from passing-attempt `judge.json`
+  ratings for `d`, then call
+  `declare_winner(MetricSpec(name=f"judge:{d}", kind="continuous",
+                  higher_is_better=True,
+                  continuous_threshold_relative=0.10), …)`.
+  Only passing attempts contribute to the samples — this is the
+  code-level enforcement of issue v3 AC "a run that fails
+  deterministic tests cannot win on judge-only criteria".
+- Uncalibrated dimensions: skipped (no `declare_winner` call); they
+  surface in the report as `uncalibrated (Spearman <observed> <
+  <threshold>)`.
+
+The deterministic verdicts (pass-rate, elapsed-seconds, etc.) keep
+their existing rule and threshold unchanged — `report_winner.py` is
+not modified beyond what's required to make the metric name visible
+in the verdict output.
+
+## Reuse map
+
+- `scripts/benchmark_runner/contracts.py` — `Backend`/`BackendResult`
+  shape that the new `Judge`/`JudgeResult` mirrors.
+- `scripts/benchmark_runner/backends/claude_code.py` — headless
+  invocation + provider-routing env-var pattern reused by the
+  `claude_code_judge`.
+- `scripts/benchmark_runner/run.py` — `attempt_dir` layout +
+  `score.json` write path; `judge.json` lands adjacent and is never
+  overwritten by `run.py`. NO change to `run.py` is required.
+- `scripts/benchmark_runner/report_winner.py` — `declare_winner` is
+  reused unchanged on calibrated-judge dimensions. NO change to
+  `report_winner.py` is required (the verdict ID `"judge:<dim>"` is
+  encoded by the caller).
+- `scripts/benchmark_runner/report.py` — extended with HTML/CSV
+  emitters + judge-aware aggregation; the existing Markdown+JSON
+  paths are NOT changed.
+- `runs/` corpus — 1171 attempt-records seed the calibration set; no
+  new benchmark spend required.
+
+## Design Decisions
+
+> **D1 is open and gates the bundle structure.** Sections below
+> describe the chosen subsystems and decisions that hold across all
+> three D1 options. The Phase B implementation order and the per-PR
+> AC mapping depend on which D1 option the user picks.
+
+### D1 — PR structure (open; team-lead recommends Option B)
+
+#34 has 5 subsystems, an empirical research question, and a
+human-labeling dependency on the calibration set. The
+one-PR-per-issue rule (memory `feedback-pr-must-fully-address-issue`,
+2026-05-19, derived from PR #38 revert) forbids partial PRs against
+one issue. Three options were evaluated; the team lead recommends
+**Option B**.
+
+> **Sub-issue labels A–E are PLACEHOLDERS, not GitHub
+> close-keyword targets.** `Closes #34a` does NOT auto-close
+> anything — close keywords require real numeric issue IDs.
+> Phase B0 (TB0.4) files five real GitHub issues, captures their
+> numeric IDs into `specs/benchmark-llm-judge/sub-issue-numbers.md`,
+> and every later PR uses those numeric IDs in its `Closes #NN`
+> keyword (placeholder labels never appear in a PR description).
+> Memory `feedback_github_close_keyword_per_issue`: one keyword
+> per real issue.
+
+| Option | Shape | Pros | Cons |
+|---|---|---|---|
+| **A — one PR, labeling gate** | All 5 subsystems land in one branch; merge blocked on the labeled calibration set landing (mirror #41's `_VERIFIED_VERSION` placeholder pattern at much larger scale). | Closes #34 in one shot; matches the issue's "deliverable in order" framing literally. | PR sits open for days/weeks while a human labels ≥50 task-runs; large PR is hard to review; the human-labeling step is irreversibly serial with merge. |
+| **B — split #34 into sub-issues (RECOMMENDED)** | File five real GitHub issues, each fully closable in one PR. Suggested split (labels are placeholders until TB0.4 captures numeric IDs): **A** Judge protocol + scorer + corpus-selection CLI (no labels); **B** Calibration validation harness + Spearman gate (no labels yet, tested against synthetic labels); **C** Rich reports — HTML/CSV/SVG (no judge dependency, additive); **D** Winner-extension on calibrated dimensions (depends on A+B); **E** Land the actual labeled calibration set + first `calibration-report.md` + activate calibrated dimensions in CCT's reports. | Each PR fully closes its own issue (rule compliant). Buildable code (A/B/C/D) ships in parallel with the human-labeling work (E). The empirical research question is isolated to E — code can still merge if calibration fails. | Requires filing 5 sub-issues + capturing their numeric IDs before any PRs reference them; mildly contradicts #34's "deliverable in order" framing (the original five subsystems remain the order; they just become separate issues). #34 becomes the epic, closed automatically when the E PR merges (its body carries a separate `Closes #34` keyword in addition to `Closes #<E's real id>`). |
+| **C — one PR for buildable code, calibration as maintainer procedure** | Ship judge + reports + validation harness + winner-ext in one PR; calibration set ≥50 + the actual calibration-report.md are a documented maintainer procedure (mirror #41's leaderboard decision). | One PR; no labeling-gate wait. | Directly violates an explicit #34 AC ("Calibration set checked in: ≥50 task-runs spanning ≥2 axes of variation, full per-dimension human ratings"). #41 could ship the leaderboard as a maintainer procedure because the leaderboard run is NOT an AC of #41; the calibration set IS an AC of #34. Option C is therefore a scope regression against an explicit AC, not a parallel of the #41 pattern. |
+
+**Recommendation: Option B.** Rationale: the one-PR-per-issue rule is
+binding; the calibration set is an explicit AC of #34 (rules out
+Option C); a single-PR gate at the scale of ≥50 hand-labels is the
+exact "schema-phase-ships-with-spec-bundle" anti-pattern the rule
+was written against (rules out Option A). The sub-issue split lines
+up cleanly with the issue's own enumeration of subsystems.
+
+### D2 — Calibration corpus source
+
+Existing `runs/` corpus (1171 attempt-records, 5 (backend, model)
+tuples, mostly aider-polyglot). **No new benchmark spend is required
+to source ≥50 task-runs spanning ≥2 axes.** Variation axes selected
+by default: `model` (5 distinct) × `repeated-runs` (many same-tuple
+re-runs). Additional axes (`adapter`, `backend`) light up if/when
+#33 Track B lands; the corpus-selection CLI MUST be axis-agnostic
+so re-sourcing is a config change, not a code change.
+
+### D3 — Judge rates non-passing code too
+
+The rubric dimensions (idiomaticity, error handling, test
+thoughtfulness, security hygiene) are *defined for any code the
+model produced* — a failing run can still have idiomatic Python with
+a logic bug, or non-idiomatic Python that happens to pass. Rating
+the full corpus (not just passing runs) is necessary because the
+passing-run-only set (44 total, almost all `sonnet`) can't hit N=50
+or span multiple model variation axes.
+
+Deterministic-first ordering is enforced separately, **at the
+winner-extension step**: only passing-on-both-sides attempts
+contribute samples to a calibrated-judge winner verdict (interface
+§ Winner extension). Non-passing-attempt ratings still appear in
+the report's judge block for reviewer use, never in the verdict.
+
+### D4 — Default rubric dimensions
+
+Issue v3 enumerates four candidate dimensions with "final dimensions
+chosen at implementation time":
+**idiomaticity**, **error_handling**, **test_thoughtfulness**,
+**security_hygiene**. The spec adopts these as the v1 default and
+records them in `rubric-default-v1.md`. The rubric is data, not
+code — extending or replacing the rubric requires a new
+`rubric-default-vN.md` + a new calibration-report; no scorer or
+report code change.
+
+### D5 — Spearman threshold default
+
+`0.6` per dimension (issue v3 verbatim). The threshold is stored in
+the calibrated-dimensions JSON the report consumes, so reports are
+self-describing without re-running calibration. Tightening the
+threshold (e.g. raising to 0.7) is a maintainer-side flag at
+calibration time, not a code change.
+
+### D6 — Calibration failure handling (the research-question path)
+
+If a dimension scores Spearman < threshold, `calibrated-dimensions.json`
+omits it. The report still renders raw ratings for that dimension
+(advisory only) and labels it `uncalibrated (Spearman X.XX < 0.6)`.
+**Zero dimensions calibrated is a valid terminal state** — the
+harness is still correctly built; only the calibrated-judge winner
+verdict is empty. The maintainer's recovery options are (a) revise
+the rubric (new `rubric-default-vN.md`), (b) try a different judge
+model, (c) acknowledge the negative result and treat the judge as
+advisory-only on this CCT instance. Choice (c) is a legitimate
+outcome of the empirical research question, NOT a build failure.
+
+### D7 — Judge backend default
+
+`claude-code:sonnet` via the harness `Backend` protocol — same
+headless invocation, same provider-routing env vars
+(`ANTHROPIC_BASE_URL`, etc.), same provider-presence boolean
+recording (never set, never logged values). This means the judge can
+route to vLLM/Ollama through the same gateway the backend uses; no
+new provider-config surface is introduced.
+
+**Determinism caveat (peer-reviewed 2026-05-20).** The local
+`claude` CLI surface exposes `--model` / `--fallback-model` only —
+no `--temperature`, no `--seed`. The claude-code judge therefore
+records `temperature: null` / `seed: null` /
+`temperature_control: "unsupported"` and treats re-run stability as
+an empirical property measured by the calibration step, not a
+guarantee. A maintainer who needs pinned T=0 / seed today must add
+a non-claude-code judge backend (e.g. a direct vLLM HTTP judge);
+that's a follow-up, out of scope for #34. Interface § Initial
+judge implementation and AC2 spell out the corrected contract.
+
+### D8 — Additivity discipline
+
+HTML / CSV / SVG charts are ADDITIVE outputs. Markdown + JSON
+reports from #32/#33 are NOT removed and NOT changed beyond what's
+required to surface judge-block content when present. A run that
+has no `judge.json` files MUST produce a report identical (modulo
+timestamp lines) to the #32 baseline — this is the no-regression
+invariant the contributor smoke test in scenario 5 protects.
+
+### D9 — `score.json` immutability
+
+`judge.json` is a SEPARATE file. `run.py` is NOT modified.
+Calibration / re-running the judge / changing the rubric MUST NOT
+require re-running the underlying benchmark. This is the
+contract that makes the corpus-as-calibration-source plan
+(decision D2) viable: the existing 1171 attempt-records can be
+labeled and judged without any re-execution.
+
+## Requirements
+
+1. **R1 — Judge protocol.** New `scripts/benchmark_runner/judge/`
+   package with `Judge` protocol mirroring `Backend`. `claude_code`
+   judge implementation. `judge.json` written per attempt, additive
+   to `score.json`.
+2. **R2 — Corpus-selection CLI.** `./scripts/benchmark
+   calibration-corpus --axes <axes> --target-n <n>` selects task-runs
+   from the existing `runs/` archive, writes a
+   `<name>.corpus.jsonl` (the unlabeled selection) and a
+   `<name>.meta.json` (the selection command, axes, counts).
+   Axis-agnostic — works for adapter/backend/model/repeated-runs.
+3. **R3 — Calibration set + human-labeling format.**
+   `benchmarks/calibration/<name>.jsonl` schema (issue v3 verbatim),
+   per-(run_path, dimension) records. Companion
+   `<name>.meta.json` records reviewers + corpus-selection
+   reproducibility data.
+4. **R4 — Calibration validation script.** `./scripts/benchmark
+   calibrate` runs the judge against the labeled corpus, computes
+   per-dimension Spearman, writes `<name>.calibration-report.md` +
+   `<name>.calibrated-dimensions.json`. Default threshold 0.6.
+5. **R5 — Rich reports (additive).** `./scripts/benchmark report
+   --html --csv [--judge <id>] [--calibrated-dimensions <p>]`
+   emits HTML + CSV. Static SVG charts (bar, histogram, forest
+   plot). Existing Markdown/JSON unchanged.
+6. **R6 — Deterministic-first ordering enforced.** In the
+   winner-extension caller, calibrated-judge samples include
+   only passing-on-both-sides attempts. Non-passing ratings appear
+   in the report but never in the verdict.
+7. **R7 — Documentation.** "How to add a new judge", "How to
+   extend the rubric", "How to re-run calibration" — three
+   procedure docs landing alongside the code that implements
+   them.
+
+## Constraints / What NOT to Build
+
+1. **No change to `run.py` or `score.json`.** `judge.json` is
+   strictly additive. Calibration / rubric changes must not
+   require re-running the underlying benchmark.
+2. **No change to `report_winner.declare_winner`.** The same
+   function is called on new metric names; no rule, threshold, or
+   significance-gate code is touched.
+3. **No dollar-cost reporting anywhere** (permanently out of scope
+   per #34 v3).
+4. **No removal of Markdown / JSON reports.** HTML / CSV are
+   additive.
+5. **No replacement of deterministic scoring with judge scoring.**
+   Judge is always secondary; uncalibrated dimensions never declare
+   a winner; passing-on-both-sides is required for calibrated-judge
+   verdicts.
+6. **No cross-CCT-instance shared calibration sets** (deferred
+   follow-up per #34 v3 OUT list).
+7. **No new benchmark adapters or copilot backends** (#33's
+   territory; #34 reuses what exists).
+8. **No live LLM in tests.** Judge tests use a recorded-transcript
+   fake-judge shim (mirror the codex/aider fake-CLI pattern); no
+   live judge invocation in CI.
+
+## Key Entities
+
+- **Judge protocol** — the contract every judge implementation
+  satisfies (analog of `Backend`).
+- **`judge.json`** — the additive per-attempt rating artifact.
+- **Rubric (`rubric-default-v1.md`)** — the prompt-template + the
+  list of rated dimensions; data, not code.
+- **Calibration set (`<name>.jsonl` + `<name>.meta.json`)** — the
+  human-labeled corpus the judge is validated against.
+- **`<name>.calibration-report.md` + `<name>.calibrated-dimensions.json`** —
+  the validation artifacts; the JSON is consumed by reports and
+  the winner extension.
+- **Static-SVG charts** — bar / histogram / forest plot rendered
+  without JS, suitable for archived reports and email attachment.
+- **Deterministic-first gate** — the report-side rule that strips
+  non-passing attempts from calibrated-judge verdict samples.
+
+## Success Criteria (mapped to issue v3 AC)
+
+- [ ] **AC1** Calibration set checked in: ≥50 task-runs spanning
+      ≥2 axes of variation; full per-dimension human ratings.
+      *(Phase-B5 deliverable; the labeling work happens after the
+      buildable code lands.)*
+- [ ] **AC2** Judge scorer implemented; `judge.json` per attempt.
+      Determinism contract (peer-reviewed 2026-05-20): the local
+      `claude` CLI does not expose `--temperature` or `--seed`, so
+      the claude-code judge records both as `null` /
+      `temperature_control: "unsupported"` / `seed_control:
+      "unsupported"`. Re-run stability is an empirical property
+      surfaced by the calibration step (Spearman against human
+      labels), not a guarantee from a fixed T=0. Any future judge
+      implementation that can pin temperature/seed populates those
+      fields to non-null.
+- [ ] **AC3** `calibrate` script measures Spearman; emits
+      `calibration-report.md`.
+- [ ] **AC4** Per-dimension calibration threshold (≥0.6 default)
+      enforced; uncalibrated dimensions flagged in report, excluded
+      from winner math.
+- [ ] **AC5** HTML report renders deterministic + calibrated-judge
+      scores with explicit visual separation.
+- [ ] **AC6** Charts (bar / histogram / forest plot) render as
+      static SVG/PNG (no JS).
+- [ ] **AC7** CSV exports for per-task and per-(backend, model)
+      tables.
+- [ ] **AC8** Deterministic-first ordering enforced in code: a run
+      that fails deterministic tests cannot win on judge-only
+      criteria (= no non-passing-attempt sample enters a
+      calibrated-judge `declare_winner` call).
+- [ ] **AC9** No dollar-cost estimate in any report.
+- [ ] **AC10** Documentation: how to add a judge / extend rubric /
+      re-run calibration.
+- [ ] **Origin gate** `check-origin-alignment.sh benchmark-llm-judge`
+      exits ≤ 1; `validate-spec.sh --feature-id benchmark-llm-judge`
+      exits 0.
+- [ ] **Additivity invariant** A run with no `judge.json` files
+      produces a Markdown+JSON report byte-identical (modulo
+      timestamps) to the #32/#33 baseline. Regression-protected by
+      a snapshot test in `report.py`'s test module.
+
+## Deviation from origin
+
+1. **#34 split into sub-issues (Option B recommendation; PENDING
+   user approval).** The issue body frames 5 subsystems "deliverable
+   in order" as a single deliverable. The team-lead recommendation
+   is to file 5 sub-issues so each PR fully closes its own issue
+   per the one-PR-per-issue rule. This is a structural change to
+   how #34 is closed (the epic closes by linkage to its
+   sub-issues), not a scope change. Spec / plan / tasks below
+   describe the same engineering work whichever D1 option the user
+   picks; only the per-PR AC partitioning differs.
+2. **Calibration corpus from existing `runs/` archive.** Issue v3
+   leaves the corpus source open. The corpus-inventory finding
+   above (1171 attempt-records on disk) means no new benchmark
+   spend is needed. This is methodology-honest (the calibration
+   corpus reflects the actual CCT-instance workload) and
+   schedule-honest (no new run campaign before the human-labeling
+   step). Recorded explicitly so a future reader doesn't assume a
+   freshly-generated corpus is required.
+3. **Judge rates non-passing code too.** Issue v3 implies the
+   judge runs on passing runs only ("quality differences inside a
+   passing run"). The corpus-inventory finding (only 44 passing
+   runs total, almost all on `sonnet`) makes a passing-only
+   calibration set infeasible at N=50 and collapses the model
+   variation axis. The spec extends the judge to rate every
+   attempt with file changes, with the deterministic-first
+   ordering enforced separately at the winner-extension step. This
+   is consistent with issue v3 AC ("Deterministic-first ordering
+   enforced: a run that fails deterministic tests cannot win on
+   judge-only criteria") — the AC governs the verdict, not the
+   rating.
+
+## Sources
+
+- `issue: gosha70/code-copilot-team#34` — v3 body (calibration
+  arithmetic copilot-count-agnostic; deterministic-first explicit;
+  per-(backend, model) reporting; variation axes broadened).
+- `path: scripts/benchmark_runner/contracts.py` — `Backend` /
+  `BackendResult` shape the `Judge` mirrors.
+- `path: scripts/benchmark_runner/run.py` — `attempt_dir` +
+  `score.json` layout; the `judge.json` adjacent write path.
+- `path: scripts/benchmark_runner/report_winner.py` —
+  `declare_winner` reused unchanged on calibrated-judge metric
+  names.
+- `path: scripts/benchmark_runner/report.py` — additive HTML/CSV
+  emitters; baseline that the no-regression invariant protects.
+- `path: runs/` — 1171 attempt-records on disk (corpus inventory
+  2026-05-20).
+- `specs/benchmark-harness/spec.md` — backend-vs-provider
+  distinction; per-(backend, model) verdict shape.
+- `specs/benchmark-aider-backend/spec.md` — the "verification
+  artifact must really exist before merge" pattern that the
+  labeling gate mirrors at larger scale.
+- `memory: feedback-pr-must-fully-address-issue` (2026-05-19) —
+  the one-PR-per-issue rule driving the Option-B recommendation.

--- a/specs/benchmark-llm-judge/sub-issue-numbers.md
+++ b/specs/benchmark-llm-judge/sub-issue-numbers.md
@@ -1,0 +1,42 @@
+# Sub-issue numeric IDs — epic #34 (benchmark-llm-judge)
+
+Filed via `gh issue create --body-file …` on 2026-05-20 per Phase
+B0 TB0.4. Every later PR uses the numeric ID column below in its
+`Closes #NN` keyword; the placeholder labels A–E never appear in
+a PR description. Sub-issue E's closing PR carries a separate
+`Closes #34` keyword in addition to `Closes #<E's id>` so the
+epic auto-closes when E merges (per memory
+`feedback_github_close_keyword_per_issue`: one keyword per real
+issue, no shared keyword).
+
+| Label | Numeric ID | Title |
+|-------|-----------:|-------|
+| A     | #48        | feat(benchmark): Judge protocol + claude_code judge + corpus-selection CLI |
+| B     | #49        | feat(benchmark): calibration validation + per-dimension Spearman gate |
+| C     | #50        | feat(benchmark): HTML + CSV + static-SVG reports (additive) |
+| D     | #51        | feat(benchmark): calibrated-judge winner-extension (deterministic-first enforced) |
+| E     | #52        | chore(benchmark): land first labeled calibration set + first calibration-report.md |
+
+Epic: #34 (`feat(benchmark): add calibrated LLM-judge scoring and
+rich reports`). Auto-closes via the `Closes #34` keyword in
+issue-E's (#52) closing PR.
+
+Dependency graph (informational; enforced by per-PR review, not
+automation):
+
+- A (#48) → no prerequisites.
+- B (#49) → A (#48).
+- C (#50) → no prerequisites; can ship in parallel with A/B.
+- D (#51) → A (#48), B (#49), C (#50).
+- E (#52) → A (#48), B (#49), C (#50), D (#51). E is the
+  human-labeling step; its PR is calendar-gated but does NOT
+  block the upstream PRs from merging.
+
+Label set: `enhancement` only (no `benchmark` label exists on
+the repo; the standard nine-label set was verified via
+`gh label list` 2026-05-20 before filing).
+
+This file is committed alongside sub-issue A's (#48) first
+commit in Phase B1; it persists across the cycle so any future
+session can identify the sub-issue group without re-querying
+GitHub.

--- a/specs/benchmark-llm-judge/tasks.md
+++ b/specs/benchmark-llm-judge/tasks.md
@@ -1,0 +1,337 @@
+# Tasks — Calibrated LLM-Judge + Rich Reports (#34)
+
+Each task is bounded and independently verifiable. AC map: spec.md
+§ Success Criteria ←→ tasks below. Under the recommended D1 Option B,
+each Phase B step corresponds to its own sub-issue and its own PR;
+under Option A, the same step list collapses into a single PR's
+commit chain (see plan.md § Option-A delta).
+
+Pre-existing-failure note (memories
+`project_benchmark_preexisting_env_test_failures`,
+`project_polyglot_dogfood_subset_stale`): run suites **per-module**;
+`test_polyglot_adapter`×4, `test_cli_skeleton` hang, the stale
+`test_polyglot_dogfood_subset` `*/leap` list, and pytest
+auto-collecting `fixtures/**/leap_test.py` are known host noise, NOT
+regressions.
+
+## Phase A — SDD bundle (gated; STOP after)
+
+### TA.1 — Bundle + alignment record
+- **Output:** `specs/benchmark-llm-judge/{spec,plan,tasks}.md` +
+  `origin-alignment-2026-05-20-0238.md`, mirroring the
+  `specs/benchmark-aider-backend/` / `specs/benchmark-bench-driver/`
+  format. Captures: D1 PR-structure analysis (A/B/C with
+  recommendation), corpus-inventory finding (1171 attempts on
+  disk, 44 passing), human-labeling dependency, research-question
+  failure path (D6 zero-dimensions terminal state).
+- **Done when:** `validate-spec.sh --feature-id benchmark-llm-judge`
+  and `check-origin-alignment.sh benchmark-llm-judge` both exit ≤ 1;
+  reported to user; **explicit "go" + D1 (A/B/C) choice received
+  before any Phase-B task.**
+
+## Phase B0 — Preflight (no code yet)
+
+### TB0.1 — Confirm corpus inventory holds on the maintainer machine
+- **Output:** re-run the corpus-inventory script (spec.md §
+  Calibration-corpus reality check) on the maintainer machine; the
+  numbers (1171 / 44 passing / 5 (backend, model) tuples) must
+  hold or the plan adapts. If new runs landed since 2026-05-20,
+  update the table in spec.md.
+- **Done when:** numbers reconciled; spec.md updated if necessary.
+
+### TB0.2 — Ratify rubric v1 dimensions with user
+- **Output:** confirm the four dimensions —
+  **idiomaticity / error_handling / test_thoughtfulness /
+  security_hygiene** — and the 1–5 anchor descriptions with the
+  user. Draft `benchmarks/calibration/rubric-default-v1.md` (the
+  prompt template + dimension list + 1–5 anchor sentences) ready
+  for the sub-issue A PR to land.
+- **Done when:** user has explicitly approved the rubric dimensions
+  and 1–5 anchors; rubric-default-v1.md drafted.
+
+### TB0.3 — Ratify judge backend default with user
+- **Output:** confirm `claude-code:sonnet` as the default judge,
+  or accept a user override (e.g. opus, or a local-gateway model
+  for self-hosting). Record the choice in spec.md if it changes
+  from the recorded default.
+- **Done when:** explicit user confirmation.
+
+### TB0.4 — File sub-issues + capture numeric IDs (Option B only)
+- **Output:** five real GitHub issues filed under
+  gosha70/code-copilot-team via `gh issue create`, each
+  referencing this spec/plan with the per-AC mapping from plan.md
+  § D1 (labels A–E). For each created issue, capture the assigned
+  numeric ID into a new file
+  `specs/benchmark-llm-judge/sub-issue-numbers.md` with a small
+  table:
+
+  ```
+  | Label | Numeric ID | Title |
+  |-------|------------|-------|
+  | A     | #<NN>      | feat(benchmark): Judge protocol + …  |
+  | B     | #<NN>      | feat(benchmark): calibration validation … |
+  | C     | #<NN>      | feat(benchmark): HTML + CSV + static-SVG … |
+  | D     | #<NN>      | feat(benchmark): calibrated-judge winner-extension … |
+  | E     | #<NN>      | chore(benchmark): land first labeled calibration set … |
+  ```
+
+  Post a comment on #34 listing the five numeric IDs as its
+  closing-link block ("This epic closes when #<E's id> merges").
+  Every subsequent PR title / body uses the captured numeric ID
+  in its `Closes #NN` keyword — the placeholder label `A`/`B`/…
+  never appears in a PR description (memory
+  `feedback_github_close_keyword_per_issue`: one `Closes #NN` per
+  real issue; the E PR also writes a separate `Closes #34`
+  keyword so the epic closes automatically).
+- **Done when:** five issues open; `sub-issue-numbers.md` committed
+  alongside Phase B1's first commit; #34 epic-comment posted.
+
+## Phase B1 — sub-issue A — Judge protocol + claude_code judge + corpus-selection CLI
+
+### TB1.1 — `judge/contracts.py`
+- **Output:** `Judge` protocol + `JudgeInput`/`JudgeResult` frozen
+  dataclasses; mirrors `Backend`/`BackendResult` shape. Module
+  docstring explicitly names the additivity invariant (this
+  artifact never overwrites `score.json`).
+- **Done when:** protocol-shape unit test green;
+  `isinstance(claude_code_judge, Judge)` holds.
+
+### TB1.2 — `judge/claude_code_judge.py`
+- **Output:** Judge using the `claude-code` backend headless
+  invocation + provider-routing env vars. Reads
+  `rubric-default-v1.md`, formats with attempt evidence
+  (diff + prompt + verify output), invokes the model, parses
+  output into a `JudgeResult` with per-dimension rating +
+  explanation. Records the corrected `judge_invocation` block
+  (peer review 2026-05-20): `model` set; `temperature: null`;
+  `seed: null`; `temperature_control: "unsupported"`;
+  `seed_control: "unsupported"`; `provider_endpoint_present`
+  boolean. The local `claude` CLI exposes only `--model` /
+  `--fallback-model` — no `--temperature`, no `--seed`. **The
+  judge MUST NOT claim T=0 it cannot enforce.** Re-run stability
+  is empirical, surfaced by the calibration step's Spearman.
+- **Done when:** recorded-transcript fake-judge suite green
+  (including an explicit assertion that `judge_invocation`
+  contains the corrected null/`"unsupported"` fields, not a
+  silent `0.0`); no live LLM in tests.
+
+### TB1.3 — `judge/runner.py` + `cli.py` `judge` subcommand
+- **Output:** `run_judge(run_dir, judge_id, rubric_name)` walks
+  `run_dir`, invokes the judge per attempt, writes `judge.json`
+  adjacent to `score.json`. CLI wires it as
+  `./scripts/benchmark judge --run-dir <d> --judge claude-code:sonnet
+  [--rubric default-v1]`.
+- **Done when:** end-to-end against the fake-judge shim writes one
+  `judge.json` per attempt; `score.json` byte-identical pre/post
+  (asserted).
+
+### TB1.4 — `calibration/corpus_select.py` + `calibration-corpus` CLI
+- **Output:** axis-agnostic corpus selector. Reads
+  `runs/**/run-record.json` + `score.json`; applies the requested
+  axes filter (`--axes model,repeated-runs[,adapter,backend]`)
+  and target-N (`--target-n 50`); writes
+  `<name>.corpus.jsonl` (selected task-runs, one per line) and
+  `<name>.meta.json` (selection command + axes + per-axis
+  counts). Deterministic ordering (sorted by `run_path`) so the
+  selection is reproducible.
+- **Done when:** unit test on a fixture `runs/` tree picks the
+  expected task-runs; `--target-n 50 --axes model,repeated-runs`
+  against the live `runs/` produces a corpus that satisfies (a)
+  N ≥ 50, (b) ≥ 2 axes represented.
+
+### TB1.5 — Registry + `_register.py`
+- **Output:** `judge/registry.py` parallel to the backend
+  registry; one-line registration block in `_register.py` after
+  the backend registrations.
+- **Done when:** `python3 -m benchmark_runner list-judges` (or the
+  chosen surface) shows `claude-code-judge`.
+
+### TB1.6 — sub-issue A closeout
+- **Output:** spec → AC2 (partial: protocol + judge.json),
+  corpus-selection capability, fake-judge suite green; PR opened.
+- **Done when:** per-module suite green;
+  `check-origin-alignment.sh benchmark-llm-judge` ≤ 1; diff shown
+  + explicit approval per commit; PR `feat(benchmark): Judge
+  protocol + claude_code judge + corpus-selection CLI
+  (Closes #<sub-issue A's real id, from sub-issue-numbers.md>)`.
+
+## Phase B2 — sub-issue B — Calibration validation + Spearman gate
+
+### TB2.1 — `calibration/spearman.py`
+- **Output:** Spearman ρ implementation in stdlib (`statistics` +
+  rank-by-sort). No new external dependency.
+- **Done when:** golden-numbers test against published vectors
+  green; tied-rank handling tested.
+
+### TB2.2 — `calibration/validate.py` + `calibrate` CLI
+- **Output:** reads a labeled `<name>.jsonl` + a `judge.json`
+  directory tree, joins on (run_path, dimension), computes
+  per-dimension Spearman + exact-match-rate, writes:
+    - `<name>.calibration-report.md` (numbers + per-dimension
+      scatter SVG + threshold + per-dimension pass/fail),
+    - `<name>.calibrated-dimensions.json` (machine-readable list
+      of calibrated dimensions + threshold used).
+  Default threshold 0.6, overridable via `--threshold`.
+- **Done when:** synthetic-labels test produces the expected
+  calibration-report against a fixed judge fixture; threshold
+  boundary tested at 0.59, 0.6, 0.7.
+
+### TB2.3 — sub-issue B closeout
+- **Output:** spec → AC3, AC4 (the per-dimension threshold
+  enforced + uncalibrated flagged).
+- **Done when:** per-module suite green; PR
+  `feat(benchmark): calibration validation + Spearman gate
+  (Closes #<sub-issue B's real id>)`.
+
+## Phase B3 — sub-issue C — HTML + CSV + static-SVG reports (additive)
+
+### TB3.1 — Additivity snapshot regression test
+- **Output:** **WRITTEN FIRST.**
+  `test_report_no_judge_regression.py` — a fixture run-dir with
+  no `judge.json` files; emit Markdown + JSON; compare to a
+  snapshot baseline (committed under tests/fixtures); modulo
+  timestamp lines, byte-identical.
+- **Done when:** the test passes before any HTML/CSV/SVG emitter
+  code is added; this is the safety net for the rest of B3.
+
+### TB3.2 — `report.py` `_emit_html`
+- **Output:** stdlib-only HTML renderer; deterministic-first /
+  judge-second / verdicts-third layout; explicit visual separator
+  element. `report --html` flag in `cli.py`.
+- **Done when:** `test_report_html.py` asserts structural markers
+  + layout ordering; the byte-stream contains no JS.
+
+### TB3.3 — `report.py` `_emit_csv`
+- **Output:** `report.csv` (per-task) + `report-by-model.csv`
+  (per-(backend, model)). `report --csv` flag.
+- **Done when:** fixed fixture → byte-identical CSV
+  (`test_report_csv.py`).
+
+### TB3.4 — `report.py` `_emit_svg_*`
+- **Output:** pure-string SVG bar / histogram / forest plot.
+  Embedded into HTML; also written as standalone `*.svg` files
+  alongside the HTML.
+- **Done when:** `test_report_svg.py` asserts expected
+  `<rect>` / `<path>` / `<text>` elements; opens in a browser
+  with JS disabled (manual spot-check, recorded in PR
+  description).
+
+### TB3.5 — sub-issue C closeout
+- **Output:** spec → AC5, AC6, AC7. AC9 (no dollar-cost) and
+  AC10 (docs) partial: the HTML/CSV emitters surface no cost
+  figures; docs land alongside in benchmarks/README.md.
+- **Done when:** per-module suite green; PR
+  `feat(benchmark): HTML + CSV + static-SVG reports
+  (Closes #<sub-issue C's real id>)`.
+
+## Phase B4 — sub-issue D — Winner-extension on calibrated dimensions
+
+### TB4.1 — `report.py` calibrated-judge caller
+- **Output:** additive caller logic that, given a
+  `calibrated-dimensions.json`, builds samples per (backend, model)
+  × dimension from `judge.json` ratings on
+  **passing-on-both-sides** attempts and calls
+  `report_winner.declare_winner(MetricSpec(name=f"judge:{dim}",
+  kind="continuous", higher_is_better=True,
+  continuous_threshold_relative=0.10), …)` unchanged.
+- **Done when:** test injects a fixture with two (backend, model)
+  groups, varied ratings, mixed pass/fail; asserts:
+  (a) calibrated dimensions emit verdicts; uncalibrated do not.
+  (b) Non-passing-on-both-sides samples are filtered out — a
+      non-passing sample that would swing the verdict if included
+      is asserted to NOT swing the verdict.
+  (c) `declare_winner` is called (verified via spy / mock), and
+      `report_winner.py` source is unchanged (git diff gate
+      below).
+
+### TB4.2 — `report_winner.py` not-modified CI gate
+- **Output:** a per-PR check (`git diff --quiet
+  scripts/benchmark_runner/report_winner.py` against the merge
+  base) blocking merge of sub-issue D if `report_winner.py` was
+  touched.
+- **Done when:** the CI gate runs and passes; documented in
+  benchmarks/README.md.
+
+### TB4.3 — sub-issue D closeout
+- **Output:** spec → AC4 (winner math excludes uncalibrated) +
+  AC8 (deterministic-first ordering enforced in code).
+- **Done when:** per-module suite green; PR
+  `feat(benchmark): calibrated-judge winner-extension
+  (Closes #<sub-issue D's real id>)`.
+
+## Phase B5 — sub-issue E — First labeled calibration set + activate
+
+### TB5.1 — Select the corpus
+- **Output:** `./scripts/benchmark calibration-corpus --target-n 50
+  --axes model,repeated-runs --name cct-instance-v1` writes
+  `benchmarks/calibration/cct-instance-v1.corpus.jsonl` +
+  `.meta.json`.
+- **Done when:** corpus N ≥ 50; ≥ 2 axes represented; reviewer
+  agrees the selection is representative (no all-failures, no
+  all-sonnet, etc.).
+
+### TB5.2 — Label the corpus (the human-labeling step)
+- **Output:** `benchmarks/calibration/cct-instance-v1.jsonl` —
+  one record per (run_path, dimension); ≥50 × 4 = ≥200 records;
+  notes per record where the rating was borderline.
+- **Done when:** human reviewer (the maintainer, or a documented
+  multi-reviewer effort) has labeled every (run_path, dimension)
+  pair. Calendar time, not agent time — gates merge of sub-issue E but
+  does NOT block sub-issues A–D.
+
+### TB5.3 — Run calibration + commit reports
+- **Output:**
+  `./scripts/benchmark calibrate --judge claude-code:sonnet
+  --labels benchmarks/calibration/cct-instance-v1.jsonl` ;
+  resulting `calibration-report.md` +
+  `calibrated-dimensions.json` committed under
+  `benchmarks/calibration/`.
+- **Done when:** the artifacts are on disk; if any dimensions
+  cleared 0.6, a follow-up `./scripts/benchmark report --html
+  --calibrated-dimensions benchmarks/calibration/cct-instance-v1.calibrated-dimensions.json
+  --run-dir <a representative run-dir>` is rendered and
+  spot-checked against AC5/AC8; if zero dimensions cleared 0.6
+  (D6 terminal state), the calibration-report.md spells out the
+  negative outcome and the maintainer decides whether to file a
+  rubric-v2 follow-up.
+
+### TB5.4 — sub-issue E closeout (which closes #34)
+- **Output:** spec → AC1 (labeled set) + AC4 (calibrated
+  dimensions activated in reports) + AC10 (docs land alongside).
+- **Done when:** per-module suite green; PR
+  `chore(benchmark): land first labeled calibration set + first
+  calibration-report (Closes #<sub-issue E's real id>, Closes #34)`
+  (memory
+  `feedback_github_close_keyword_per_issue`: each Closes keyword
+  on its own).
+
+## Cross-cutting tasks (apply to every PR)
+
+### TC.1 — Diff-shown-and-approved gate
+- Every commit: `git status` + `git diff` shown to the user;
+  explicit "yes" / "go" / "commit" before staging; commit message
+  via heredoc; per memory `feedback_review_before_commit` +
+  `feedback_commit_messages_with_backticks_use_F_file` (use
+  `git commit -F <file>` for messages containing backticks).
+
+### TC.2 — Never push to master
+- All work on feature branches (`feat/benchmark-llm-judge-{a,b,c,d,e}`
+  under Option B; `feat/benchmark-llm-judge` under Option A);
+  per memory `feedback_never_push_to_master` +
+  `feedback_no_push_without_review`.
+
+### TC.3 — Origin-alignment record refreshed before PR
+- Fresh `origin-alignment-<date>-<time>.md` per sub-issue at
+  PR-open time; `check-origin-alignment.sh benchmark-llm-judge`
+  exits ≤ 1 before merge.
+
+### TC.4 — Run.py / report_winner.py / contracts.py untouched
+- Pre-PR `git diff --quiet
+  scripts/benchmark_runner/{run,report_winner,contracts}.py`
+  against the merge base; if any of those files were touched,
+  STOP and escalate to user before proceeding.
+
+### TC.5 — No live LLM in tests
+- All judge tests use the recorded-transcript fake-judge fixture
+  pattern (mirror codex/aider). Live judge invocations are a
+  maintainer / Phase-B5 step, not a CI step.


### PR DESCRIPTION
## Summary

Sub-issue A of epic #34 (calibrated LLM-judge scoring + rich reports). Ships the buildable foundation that lets a user invoke a calibrated LLM-judge against a completed run-dir end-to-end, plus the calibration-corpus selector that sources ≥50 task-runs from the existing `runs/` archive. Sibling sub-issues #49–#52 (calibration validation, rich reports, winner-extension, first labeled corpus) ride on top of what this PR lands.

Five commit-chained slices (TB1.1–TB1.5), each gated by the per-commit diff-review discipline; no live LLM in CI; SDD bundle + four peer-review rounds in `specs/benchmark-llm-judge/`.

Closes #48.

## What's in this PR

- **Judge protocol** (`scripts/benchmark_runner/judge/contracts.py`) — frozen dataclasses (`RubricSpec`, `JudgeInput`, `DimensionRating`, `JudgeInvocation`, `JudgeResult`) + `runtime_checkable` `Judge` Protocol. `DimensionRating.__post_init__` enforces `rating ∈ {None, 1..5}` (rejects bools, floats, out-of-range integers).
- **claude-code judge** (`judge/claude_code_judge.py`) — initial Judge wrapping the existing `claude -p` headless invocation. Argv contract `claude -p --output-format json --tools "" [--bare] [--model <m>]`. Subprocess hardening (`start_new_session=True` + `os.killpg`) mirrors the backend's Bug #6 fix.
- **Rubric loader** (`judge/rubric.py`) — reads `benchmarks/calibration/rubric-<name>.md`. Escapes literal `{`/`}` in the JSON-example block; un-escapes the five attempt placeholders; pre-renders `{rubric_dimensions_block}` from the rubric file's content.
- **Judge runner** (`judge/runner.py`) — walks `<run-dir>/<task-slug>/attempt-NN-run-MM/`, invokes the judge per attempt, writes `judge.json` adjacent to `score.json`. sha256-guarded score.json — `ScoreJsonMutatedError` fires on both the success and exception paths.
- **Corpus selector** (`scripts/benchmark_runner/calibration/corpus_select.py`) — axis-agnostic stratified round-robin over the existing `runs/` archive. Deterministic + reproducible (stable sort, explicit metadata, no randomness). Missing/malformed records reported as skips, never silently dropped or fatal. Repair logic re-validates all requested axes; refuses to silently degrade.
- **Registry** (`judge/registry.py` + `_register.py`) — both SDD-canonical `claude-code` and the internal-judge_id alias `claude-code-judge` registered under the same factory. Tolerates shared-factory aliasing; raises on different-factory collisions.
- **CLI subcommands** — `./scripts/benchmark judge` and `./scripts/benchmark calibration-corpus`. `./scripts/benchmark list` payload gains `"judges"` (deterministically sorted).
- **SDD bundle** (`specs/benchmark-llm-judge/`) — spec.md / plan.md / tasks.md / origin-alignment / sub-issue-numbers.md. Four peer-review rounds; aligned/high.
- **Approved v1 rubric** (`benchmarks/calibration/rubric-default-v1.md`) — four dimensions (idiomaticity / error_handling / test_thoughtfulness / security_hygiene) with 1–5 anchor descriptions and the structurally-inapplicable null discipline.

## Determinism contract (peer-reviewed correction)

The local `claude` CLI exposes only `--model` / `--fallback-model` — no `--temperature`, no `--seed`. The judge therefore records `temperature: null` / `seed: null` / `temperature_control: "unsupported"` / `seed_control: "unsupported"` in every `judge.json`. Re-run stability is an empirical property surfaced by the calibration step's Spearman against human labels (sub-issue #49), NOT a guarantee from a fixed T=0. The contract is asserted in tests (`test_no_temperature_or_seed_flags_in_argv`, `test_judge_invocation_records_unsupported_determinism`) so a future contributor cannot quietly bring back a silent T=0.

## Additivity invariant (load-bearing)

The judge writes `judge.json` adjacent to `score.json`. `score.json` is NEVER overwritten. Running the judge against a run-dir does NOT re-execute the benchmark. Enforced in `run_judge` by snapshotting sha256(score.json) before each `rate()` call and re-checking AFTER — on both the success and the exception paths. A mutating judge (whether or not it then raises) fires `ScoreJsonMutatedError` and aborts the run. The CLI surfaces this as `EXIT_RUNTIME`. Covered by `test_score_json_byte_identical_pre_and_post`, `test_mutating_judge_raises`, `test_mutating_then_raising_judge_raises_score_mutated`, and `test_runtime_error_on_score_mutation` (CLI-level).

## D-invariant (deterministic-first)

The three deterministic-harness files — `scripts/benchmark_runner/run.py`, `scripts/benchmark_runner/contracts.py`, `scripts/benchmark_runner/report_winner.py` — are **untouched** across all five commits in this PR. Verified pre-PR:

```
$ git diff master..HEAD --stat -- \
    scripts/benchmark_runner/run.py \
    scripts/benchmark_runner/contracts.py \
    scripts/benchmark_runner/report_winner.py
(zero output)
```

This guarantees the judge subsystem cannot perturb deterministic scoring — the rule "a run that fails deterministic tests cannot win on judge-only criteria" is structurally protected.

## Live evidence

- `./scripts/benchmark list` now includes `judges: ["claude-code", "claude-code-judge"]` (deterministically sorted).
- `./scripts/benchmark calibration-corpus --target-n 50 --axes model,repeated-runs --name <n>` produces a corpus from the maintainer's `runs/` archive satisfying the issue #34 v3 acceptance: 50 attempts, 6 distinct models, 10 repeated-run tuples, candidate pool 1171, 15 skips with reasons.
- `./scripts/benchmark judge --run-dir <d> --judge claude-code:sonnet` end-to-end against the fake-CLI shim in CI (no live LLM); live invocation works on a maintainer machine.

## Test plan

- [x] Per-module `pytest` on the six new test files — 154/154 passed:
  - `test_judge_protocol.py` (27)
  - `test_claude_code_judge.py` (36)
  - `test_judge_rubric.py` (16)
  - `test_judge_runner.py` (15)
  - `test_cli_judge.py` (7)
  - `test_corpus_select.py` (38, including a live-runs acceptance gate at target_n=50)
  - `test_judge_registry.py` (15)
- [x] Adjacent regression sweep — 157 passed, 3 subtests:
  - `test_contracts.py`, `test_claude_code_backend.py`, `test_report.py`, `test_report_winner.py`, `test_run_orchestration.py`, `test_compare.py`, `test_bench_cli.py`.
- [x] `test_list_default_includes_stub` in `test_cli_skeleton.py` — augmented with a `judges` assertion; passes.
- [x] D-invariant `git diff --quiet` against `master` on `run.py` / backend `contracts.py` / `report_winner.py` — exit 0.
- [x] Live `./scripts/benchmark list` — shows judges with both tokens.
- [x] Live `./scripts/benchmark calibration-corpus --target-n 50 --axes model,repeated-runs` — actual_n=50, model + repeated-runs satisfied, skips reported.
- [x] `./scripts/check-origin-alignment.sh benchmark-llm-judge` — aligned/high, exit 0.
- [x] `./scripts/validate-spec.sh --feature-id benchmark-llm-judge` — 2/2 PASS.

## Out of scope (deferred to sibling sub-issues)

- #49 — calibration validation + per-dimension Spearman gate.
- #50 — rich reports (HTML + CSV + static SVG charts).
- #51 — calibrated-judge winner-extension on `declare_winner` (deterministic-first enforced).
- #52 — first labeled calibration set + first `calibration-report.md` (the human-labeling step; its closing PR carries a second close-keyword pointing at #34 so the epic auto-closes when #52 merges — NOT this PR).

This PR does NOT execute the labeling step or the validation run; it ships the buildable code (and a corpus-selection CLI) that those depend on. Epic #34 stays open until #52 merges.

## SDD bundle

- `specs/benchmark-llm-judge/spec.md` — problem, scenarios, decisions (D1–D9 with the user-approved D1=Option B / D4=four-dimensions / D7=claude-code:sonnet-with-corrected-contract), Acceptance Criteria.
- `specs/benchmark-llm-judge/plan.md` — phase boundaries, files-to-create / NOT-to-modify, risks.
- `specs/benchmark-llm-judge/tasks.md` — TB0–TB5 task layout.
- `specs/benchmark-llm-judge/origin-alignment-2026-05-20-0238.md` — verdict aligned/high after four review rounds.
- `specs/benchmark-llm-judge/sub-issue-numbers.md` — captured numeric IDs (#48–#52) for the epic split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
