### PR TITLE
feat(benchmark): calibration validation + per-dimension Spearman gate (Closes #49)

### DIFF
--- a/scripts/benchmark_runner/calibration/spearman.py
+++ b/scripts/benchmark_runner/calibration/spearman.py
@@ -1,0 +1,163 @@
+# benchmark_runner.calibration.spearman — stdlib-only Spearman ρ.
+#
+# Spearman's rank correlation coefficient: Pearson correlation
+# computed on the RANKS of the values rather than the values
+# themselves. Captures monotonic agreement (not just linear) — the
+# right metric for "does the judge order attempts the same way a
+# human reviewer does," which is what the calibration step measures.
+#
+# Tie handling: average rank (a.k.a. "fractional rank"). When two
+# values tie, both receive the average of the ranks they'd occupy
+# under a stable arbitrary tiebreak. This is the standard variant
+# scipy.stats.spearmanr uses; matches the published vectors the
+# golden-numbers test pins against.
+#
+# Why stdlib-only: the harness already has a no-new-Python-dependency
+# posture (see benchmark_runner.report's existing stdlib stats use).
+# Spearman on N ≤ a few hundred labels is trivial without scipy.
+#
+# Pure function, no I/O. Exposed entry points: ``spearman``,
+# ``exact_match_rate``, ``rank_average_ties``.
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+
+def spearman(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Return Spearman's ρ for two parallel sequences.
+
+    Raises ``ValueError`` if the sequences have different lengths,
+    if either is empty, or if either has fewer than two distinct
+    values (ρ is undefined when all ranks tie — the "no variation"
+    degenerate case).
+
+    Returns a float in ``[-1.0, 1.0]``. ``1.0`` is perfect
+    monotonic agreement; ``-1.0`` is perfect monotonic disagreement;
+    ``0.0`` is no monotonic relationship.
+    """
+    if len(xs) != len(ys):
+        raise ValueError(
+            f"spearman: sequences must be parallel; "
+            f"got len(xs)={len(xs)}, len(ys)={len(ys)}"
+        )
+    n = len(xs)
+    if n < 2:
+        raise ValueError(
+            f"spearman: need at least 2 paired observations; got {n}"
+        )
+
+    rx = rank_average_ties(xs)
+    ry = rank_average_ties(ys)
+
+    # If either side has zero variation (all ranks identical),
+    # Spearman is undefined (division by zero on the Pearson
+    # denominator). The calibration step treats "no variation" as
+    # "judge didn't differentiate" or "human didn't differentiate"
+    # — both produce no useful correlation signal and must be
+    # surfaced as such, not silently coerced to 0.0.
+    if _all_equal(rx) or _all_equal(ry):
+        raise ValueError(
+            "spearman: undefined when either sequence has no variation "
+            "(all ranks identical). Caller should treat as 'no signal' "
+            "and exclude this dimension from calibration."
+        )
+
+    return _pearson(rx, ry)
+
+
+def rank_average_ties(xs: Sequence[float]) -> list[float]:
+    """Return the rank of each element of ``xs`` (smallest = rank 1).
+
+    Ties receive the average of the ranks they'd occupy under any
+    stable tiebreak. E.g. ``rank_average_ties([10, 20, 20, 30])`` →
+    ``[1.0, 2.5, 2.5, 4.0]`` (the two 20s share ranks 2 and 3, so
+    each gets the average 2.5).
+
+    Pure function. Returns a NEW list; input is not mutated.
+    """
+    n = len(xs)
+    # Build (value, original_index) and sort by value; stable sort
+    # preserves original order within ties so the tie-averaging
+    # below sees groups as contiguous runs.
+    indexed = sorted(range(n), key=lambda i: xs[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        # Find the end of a run of equal values starting at i.
+        j = i
+        while j + 1 < n and xs[indexed[j + 1]] == xs[indexed[i]]:
+            j += 1
+        # Ranks i+1, i+2, ..., j+1 (1-indexed); average them.
+        avg_rank = (i + 1 + j + 1) / 2.0
+        for k in range(i, j + 1):
+            ranks[indexed[k]] = avg_rank
+        i = j + 1
+    return ranks
+
+
+def exact_match_rate(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Return the fraction of paired observations where xs[i] == ys[i].
+
+    Calibration uses this alongside Spearman ρ as a sanity check:
+    high ρ + low exact-match means the judge ranks consistently
+    with the human but on a shifted scale; low ρ + high exact-match
+    is statistically impossible (would imply matches without
+    monotonic agreement) and indicates a parser/join bug.
+
+    Raises ``ValueError`` on mismatched / empty inputs.
+    """
+    if len(xs) != len(ys):
+        raise ValueError(
+            f"exact_match_rate: sequences must be parallel; "
+            f"got len(xs)={len(xs)}, len(ys)={len(ys)}"
+        )
+    n = len(xs)
+    if n == 0:
+        raise ValueError("exact_match_rate: empty input")
+    matches = sum(1 for a, b in zip(xs, ys) if a == b)
+    return matches / n
+
+
+# ── Internals ─────────────────────────────────────────────────────────
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> float:
+    """Pearson correlation on two parallel sequences.
+
+    Assumes len(xs) == len(ys) >= 2 and neither side is constant
+    (callers — only ``spearman`` here — guarantee this).
+    """
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    cov = 0.0
+    var_x = 0.0
+    var_y = 0.0
+    for x, y in zip(xs, ys):
+        dx = x - mean_x
+        dy = y - mean_y
+        cov += dx * dy
+        var_x += dx * dx
+        var_y += dy * dy
+    denom = math.sqrt(var_x * var_y)
+    # Defensive: if the caller bypassed the _all_equal guard, surface
+    # the divide-by-zero as a clear error rather than producing nan.
+    if denom == 0:
+        raise ValueError(
+            "_pearson: zero variance in one or both sequences "
+            "(divide-by-zero); spearman's _all_equal guard should "
+            "have caught this — programmer error"
+        )
+    return cov / denom
+
+
+def _all_equal(xs: Sequence[float]) -> bool:
+    if not xs:
+        return True
+    first = xs[0]
+    for x in xs[1:]:
+        if x != first:
+            return False
+    return True

--- a/scripts/benchmark_runner/calibration/validate.py
+++ b/scripts/benchmark_runner/calibration/validate.py
@@ -1,0 +1,629 @@
+# benchmark_runner.calibration.validate — calibration orchestration.
+#
+# Given a human-labeled JSONL corpus + judge.json files on disk, this
+# module:
+#
+#   1. Loads labels (label = {run_path, dimension, rating, notes}).
+#   2. Loads the corresponding judge.json files (one per run_path).
+#   3. Joins per (run_path, dimension) on integer ratings, dropping
+#      pairs where either side is null (structurally inapplicable per
+#      the rubric) or where the join failed (missing judge.json,
+#      missing dimension, judge_id mismatch).
+#   4. For each dimension: computes Spearman ρ + exact-match rate,
+#      classifies as "calibrated" / "uncalibrated" / "no_signal".
+#   5. Writes <name>.calibration-report.md (human-readable) and
+#      <name>.calibrated-dimensions.json (machine-readable; consumed
+#      by report.py + report_winner.py in sub-issue C/D).
+#
+# Threshold: per-dimension Spearman >= threshold (default 0.6 per
+# issue #34 v3) → calibrated; otherwise uncalibrated. The threshold
+# is stored in the JSON output so reports are self-describing
+# without re-running calibration.
+#
+# Determinism: deterministic ordering throughout. Labels are sorted
+# by (run_path, dimension); dimensions in outputs sorted; per-pair
+# sample arrays sorted by run_path. Same inputs → byte-identical
+# outputs (modulo the generated_at timestamp).
+
+from __future__ import annotations
+
+import datetime
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from .spearman import exact_match_rate, spearman
+
+
+# Spearman ρ is bounded in [-1, 1]; the threshold gates "calibrated"
+# dimensions, so the practical domain is [0, 1] — a negative
+# threshold would mean "calibrated if anti-correlated," which is
+# nonsensical for the calibration step. NaN/inf are rejected
+# because (a) they'd produce non-standard JSON in the output,
+# and (b) NaN comparisons silently fail-open (any rho < NaN is
+# False, so a NaN threshold would mark every dimension as
+# uncalibrated without surfacing the misconfiguration).
+THRESHOLD_MIN = 0.0
+THRESHOLD_MAX = 1.0
+
+
+CALIBRATED_DIMENSIONS_SCHEMA_VERSION = "1.0"
+DEFAULT_THRESHOLD = 0.6
+DEFAULT_JUDGE_OUTPUT_NAME = "judge.json"
+
+# Dimension status sentinels (use these everywhere instead of bare
+# strings so a rename is a NameError not a silent miss).
+STATUS_CALIBRATED = "calibrated"
+STATUS_UNCALIBRATED = "uncalibrated"
+STATUS_NO_SIGNAL = "no_signal"
+
+
+# ── Errors ────────────────────────────────────────────────────────────
+
+
+class LabelsParseError(ValueError):
+    """Labels JSONL malformed beyond what per-line skips can absorb."""
+
+
+class NoLabelsError(RuntimeError):
+    """Labels file present but contained zero parseable records."""
+
+
+# ── Data shapes ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Label:
+    """One human label record: (run_path, dimension, rating, notes)."""
+
+    run_path: str
+    dimension: str
+    rating: Optional[int]  # None = structurally inapplicable per the rubric
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class DimensionResult:
+    """Per-dimension calibration outcome."""
+
+    dimension: str
+    n_paired: int
+    spearman: Optional[float]
+    exact_match_rate: Optional[float]
+    status: str  # one of STATUS_*
+    reason: str = ""  # diagnostic for no_signal/uncalibrated
+
+
+@dataclass(frozen=True)
+class DataQuality:
+    """Counts of labels + judge-output records that didn't enter samples."""
+
+    labels_total: int = 0
+    labels_with_null_rating: int = 0
+    labels_for_missing_judge_output: int = 0
+    labels_for_unparseable_judge_output: int = 0
+    labels_for_judge_id_mismatch: int = 0
+    labels_for_missing_dimension: int = 0
+    labels_for_null_judge_rating: int = 0
+    labels_for_malformed_judge_rating: int = 0
+    labels_for_out_of_range_judge_rating: int = 0
+    judge_output_skip_reasons: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """End-to-end output of validate_corpus."""
+
+    results: tuple[DimensionResult, ...]
+    threshold: float
+    data_quality: DataQuality
+
+
+# ── Loading ────────────────────────────────────────────────────────────
+
+
+def load_labels(path: Path) -> list[Label]:
+    """Parse a labels JSONL file.
+
+    Each line is a JSON object with required fields ``run_path``,
+    ``dimension``, ``rating`` (int 1..5 or null), optional ``notes``.
+    Lines that are blank or comment-shaped (start with ``//`` or
+    ``#``) are skipped silently. Malformed lines raise
+    ``LabelsParseError`` with the offending line number — strict
+    parsing because a typo in labels would otherwise silently drop
+    a sample.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"labels file not found: {path}")
+    out: list[Label] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, raw in enumerate(f, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("//") or stripped.startswith("#"):
+                continue
+            try:
+                rec = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise LabelsParseError(
+                    f"{path}:{lineno}: JSON parse error: {exc}"
+                ) from exc
+            if not isinstance(rec, dict):
+                raise LabelsParseError(
+                    f"{path}:{lineno}: expected JSON object; got "
+                    f"{type(rec).__name__}"
+                )
+            for field_name in ("run_path", "dimension"):
+                if field_name not in rec:
+                    raise LabelsParseError(
+                        f"{path}:{lineno}: missing required field "
+                        f"{field_name!r}"
+                    )
+            if "rating" not in rec:
+                raise LabelsParseError(
+                    f"{path}:{lineno}: missing required field 'rating' "
+                    f"(use null for structurally inapplicable)"
+                )
+            rating = rec["rating"]
+            if rating is not None:
+                if isinstance(rating, bool) or not isinstance(rating, int):
+                    raise LabelsParseError(
+                        f"{path}:{lineno}: rating must be int 1..5 or null; "
+                        f"got {type(rating).__name__} {rating!r}"
+                    )
+                if not (1 <= rating <= 5):
+                    raise LabelsParseError(
+                        f"{path}:{lineno}: rating out of range; "
+                        f"got {rating} (expected 1..5 or null)"
+                    )
+            out.append(Label(
+                run_path=str(rec["run_path"]),
+                dimension=str(rec["dimension"]),
+                rating=rating,
+                notes=str(rec.get("notes", "") or ""),
+            ))
+    return out
+
+
+def load_judge_output(path: Path) -> Optional[dict]:
+    """Parse a single judge.json file. Returns the parsed dict, or
+    ``None`` if the file is missing/unparseable. Callers record a
+    skip reason; this function does not raise."""
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+# ── Per-dimension evaluation ──────────────────────────────────────────
+
+
+def evaluate_dimension(
+    dimension: str,
+    paired: list[tuple[int, int]],
+    *,
+    threshold: float,
+) -> DimensionResult:
+    """Compute Spearman ρ + exact-match rate for a dimension's paired
+    samples; classify as calibrated/uncalibrated/no_signal.
+
+    ``paired`` is a list of ``(human_rating, judge_rating)`` tuples,
+    both integers (caller has already filtered out nulls). Spearman
+    needs n >= 2 + variation on both sides; either condition not
+    met → no_signal with a reason.
+    """
+    n = len(paired)
+    if n < 2:
+        return DimensionResult(
+            dimension=dimension,
+            n_paired=n,
+            spearman=None,
+            exact_match_rate=None if n == 0 else exact_match_rate(
+                [p[0] for p in paired], [p[1] for p in paired],
+            ),
+            status=STATUS_NO_SIGNAL,
+            reason=f"n_paired={n} (need >= 2)",
+        )
+    xs = [p[0] for p in paired]
+    ys = [p[1] for p in paired]
+    em = exact_match_rate(xs, ys)
+    try:
+        rho = spearman(xs, ys)
+    except ValueError as exc:
+        # "no variation" path from spearman — surface verbatim.
+        return DimensionResult(
+            dimension=dimension,
+            n_paired=n,
+            spearman=None,
+            exact_match_rate=em,
+            status=STATUS_NO_SIGNAL,
+            reason=str(exc),
+        )
+    status = STATUS_CALIBRATED if rho >= threshold else STATUS_UNCALIBRATED
+    reason = "" if status == STATUS_CALIBRATED else (
+        f"Spearman {rho:.4f} < threshold {threshold}"
+    )
+    return DimensionResult(
+        dimension=dimension,
+        n_paired=n,
+        spearman=rho,
+        exact_match_rate=em,
+        status=status,
+        reason=reason,
+    )
+
+
+# ── Orchestrator ──────────────────────────────────────────────────────
+
+
+def validate_threshold(threshold: float) -> None:
+    """Raise ``ValueError`` if ``threshold`` is not a finite number in
+    ``[THRESHOLD_MIN, THRESHOLD_MAX]``.
+
+    Defense-in-depth: the CLI does the same check before calling
+    into this module, but a direct caller that bypasses the CLI
+    still gets the safety net. The error message names the
+    constraint that failed.
+    """
+    if math.isnan(threshold) or math.isinf(threshold):
+        raise ValueError(
+            f"threshold must be a finite number; got {threshold!r}"
+        )
+    if not (THRESHOLD_MIN <= threshold <= THRESHOLD_MAX):
+        raise ValueError(
+            f"threshold must be in [{THRESHOLD_MIN}, {THRESHOLD_MAX}] "
+            f"(Spearman ρ domain for calibration); got {threshold}"
+        )
+
+
+def validate_corpus(
+    labels: Iterable[Label],
+    *,
+    runs_root: Path,
+    judge_family_model: str,
+    threshold: float = DEFAULT_THRESHOLD,
+    judge_output_name: str = DEFAULT_JUDGE_OUTPUT_NAME,
+) -> ValidationResult:
+    """Join labels with judge outputs, compute per-dimension calibration.
+
+    Pure-ish: reads judge.json files from disk but does not write.
+    The writer (``write_calibration_artifacts``) takes the
+    ValidationResult and produces the on-disk artifacts.
+    """
+    validate_threshold(threshold)
+    labels_list = list(labels)
+
+    # Counts for the data-quality block.
+    dq_labels_with_null_rating = 0
+    dq_labels_for_missing_judge_output = 0
+    dq_labels_for_unparseable_judge_output = 0
+    dq_labels_for_judge_id_mismatch = 0
+    dq_labels_for_missing_dimension = 0
+    dq_labels_for_null_judge_rating = 0
+    dq_labels_for_malformed_judge_rating = 0
+    dq_labels_for_out_of_range_judge_rating = 0
+    judge_output_skip_reasons: dict[str, str] = {}
+
+    # Cache judge outputs per run_path (one judge.json file may carry
+    # ratings for multiple dimensions of the same attempt).
+    judge_cache: dict[str, Optional[dict]] = {}
+
+    # Per-dimension paired samples (deterministically ordered by
+    # iterating labels in sorted (run_path, dimension) order).
+    per_dim_samples: dict[str, list[tuple[int, int]]] = {}
+    dimensions_seen: set[str] = set()
+    for label in sorted(labels_list, key=lambda l: (l.run_path, l.dimension)):
+        dimensions_seen.add(label.dimension)
+        if label.rating is None:
+            dq_labels_with_null_rating += 1
+            continue
+        if label.run_path not in judge_cache:
+            judge_path = runs_root / label.run_path / judge_output_name
+            loaded = load_judge_output(judge_path)
+            judge_cache[label.run_path] = loaded
+            if loaded is None:
+                if judge_path.exists():
+                    judge_output_skip_reasons[label.run_path] = (
+                        f"{judge_output_name} unparseable"
+                    )
+                else:
+                    judge_output_skip_reasons[label.run_path] = (
+                        f"{judge_output_name} missing"
+                    )
+        judge_doc = judge_cache[label.run_path]
+        if judge_doc is None:
+            reason = judge_output_skip_reasons.get(label.run_path, "missing")
+            if "unparseable" in reason:
+                dq_labels_for_unparseable_judge_output += 1
+            else:
+                dq_labels_for_missing_judge_output += 1
+            continue
+        # judge_id + judge_model assertion — calibration is meaningful
+        # only against the specified judge.
+        actual = (
+            f"{judge_doc.get('judge_backend_id', judge_doc.get('judge_id', '?'))}"
+            f":{judge_doc.get('judge_model', '?')}"
+        )
+        # The judge_id-style "<backend>:<model>" identification has
+        # two acceptable shapes depending on how the producer chose
+        # to identify itself; tolerate both vs the user-supplied
+        # form.
+        if not _judge_matches(judge_doc, judge_family_model):
+            dq_labels_for_judge_id_mismatch += 1
+            continue
+        ratings_block = judge_doc.get("ratings") or {}
+        if label.dimension not in ratings_block:
+            dq_labels_for_missing_dimension += 1
+            continue
+        judge_rating = ratings_block[label.dimension].get("rating") \
+            if isinstance(ratings_block[label.dimension], dict) else None
+        if judge_rating is None:
+            dq_labels_for_null_judge_rating += 1
+            continue
+        if isinstance(judge_rating, bool) or not isinstance(judge_rating, int):
+            # Malformed type (bool, float, str, …). The judge runner's
+            # DimensionRating.__post_init__ should have rejected this
+            # at write-time; the validator can't trust that — a
+            # hand-edited judge.json could re-introduce it.
+            dq_labels_for_malformed_judge_rating += 1
+            continue
+        if not (1 <= judge_rating <= 5):
+            # Out-of-band integer rating (0, 6, 99, -1, …). Same
+            # defense as above: DimensionRating.__post_init__ enforces
+            # the band at write-time, but a malformed or hand-edited
+            # judge.json could carry an out-of-range value. Treat it
+            # as a skip in its own data-quality bucket so the report
+            # surfaces the misconfiguration rather than letting a
+            # bogus pair enter the Spearman sample.
+            dq_labels_for_out_of_range_judge_rating += 1
+            continue
+        per_dim_samples.setdefault(label.dimension, []).append(
+            (label.rating, judge_rating)
+        )
+
+    # Evaluate each dimension that appeared in the labels.
+    results: list[DimensionResult] = []
+    for dim in sorted(dimensions_seen):
+        results.append(evaluate_dimension(
+            dim,
+            per_dim_samples.get(dim, []),
+            threshold=threshold,
+        ))
+
+    data_quality = DataQuality(
+        labels_total=len(labels_list),
+        labels_with_null_rating=dq_labels_with_null_rating,
+        labels_for_missing_judge_output=dq_labels_for_missing_judge_output,
+        labels_for_unparseable_judge_output=dq_labels_for_unparseable_judge_output,
+        labels_for_judge_id_mismatch=dq_labels_for_judge_id_mismatch,
+        labels_for_missing_dimension=dq_labels_for_missing_dimension,
+        labels_for_null_judge_rating=dq_labels_for_null_judge_rating,
+        labels_for_malformed_judge_rating=dq_labels_for_malformed_judge_rating,
+        labels_for_out_of_range_judge_rating=dq_labels_for_out_of_range_judge_rating,
+        judge_output_skip_reasons=judge_output_skip_reasons,
+    )
+    return ValidationResult(
+        results=tuple(results),
+        threshold=threshold,
+        data_quality=data_quality,
+    )
+
+
+def _judge_matches(judge_doc: dict, expected: str) -> bool:
+    """Does ``judge_doc``'s identity match the user-supplied ``--judge``?
+
+    Accepts both ``<judge_backend_id>:<judge_model>`` and
+    ``<judge_id>:<judge_model>`` forms, since the spec's CLI surface
+    uses the SDD-canonical ``claude-code`` (the backend id) while
+    judge.json records ``judge_id: "claude-code-judge"`` (the
+    internal id) plus ``judge_backend_id: "claude-code"``.
+    """
+    if ":" not in expected:
+        return False
+    fam, _, model = expected.partition(":")
+    actual_model = judge_doc.get("judge_model", "")
+    if actual_model != model:
+        return False
+    judge_backend_id = judge_doc.get("judge_backend_id", "")
+    judge_id = judge_doc.get("judge_id", "")
+    return fam in (judge_backend_id, judge_id)
+
+
+# ── Writers ───────────────────────────────────────────────────────────
+
+
+def write_calibration_artifacts(
+    result: ValidationResult,
+    *,
+    name: str,
+    judge_family_model: str,
+    labels_path: Path,
+    runs_root: Path,
+    output_dir: Path,
+) -> tuple[Path, Path]:
+    """Write <name>.calibration-report.md + <name>.calibrated-dimensions.json.
+
+    Returns ``(report_path, json_path)``. Creates ``output_dir`` if
+    missing. Never writes under ``runs_root``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / f"{name}.calibration-report.md"
+    json_path = output_dir / f"{name}.calibrated-dimensions.json"
+
+    generated_at = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    # ── JSON ──
+    payload: dict[str, Any] = {
+        "schema_version": CALIBRATED_DIMENSIONS_SCHEMA_VERSION,
+        "name": name,
+        "judge": judge_family_model,
+        "threshold": result.threshold,
+        "labels_path": str(labels_path.resolve()),
+        "runs_root": str(runs_root.resolve()),
+        "generated_at": generated_at,
+        "calibrated": [],
+        "uncalibrated": [],
+        "no_signal": [],
+        "data_quality": _serialize_data_quality(result.data_quality),
+    }
+    for r in result.results:
+        entry = {
+            "dimension": r.dimension,
+            "n_paired": r.n_paired,
+            "spearman": r.spearman,
+            "exact_match_rate": r.exact_match_rate,
+        }
+        if r.status == STATUS_CALIBRATED:
+            payload["calibrated"].append(entry)
+        elif r.status == STATUS_UNCALIBRATED:
+            entry["reason"] = r.reason
+            payload["uncalibrated"].append(entry)
+        else:
+            entry["reason"] = r.reason
+            payload["no_signal"].append(entry)
+    json_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+    # ── Markdown ──
+    report_path.write_text(
+        _render_report_md(
+            name=name,
+            judge_family_model=judge_family_model,
+            labels_path=labels_path,
+            runs_root=runs_root,
+            generated_at=generated_at,
+            result=result,
+        ),
+        encoding="utf-8",
+    )
+    return report_path, json_path
+
+
+def _serialize_data_quality(dq: DataQuality) -> dict:
+    return {
+        "labels_total": dq.labels_total,
+        "labels_with_null_rating": dq.labels_with_null_rating,
+        "labels_for_missing_judge_output": dq.labels_for_missing_judge_output,
+        "labels_for_unparseable_judge_output": dq.labels_for_unparseable_judge_output,
+        "labels_for_judge_id_mismatch": dq.labels_for_judge_id_mismatch,
+        "labels_for_missing_dimension": dq.labels_for_missing_dimension,
+        "labels_for_null_judge_rating": dq.labels_for_null_judge_rating,
+        "labels_for_malformed_judge_rating": dq.labels_for_malformed_judge_rating,
+        "labels_for_out_of_range_judge_rating": dq.labels_for_out_of_range_judge_rating,
+        "judge_output_skip_reasons": dict(sorted(dq.judge_output_skip_reasons.items())),
+    }
+
+
+def _render_report_md(
+    *,
+    name: str,
+    judge_family_model: str,
+    labels_path: Path,
+    runs_root: Path,
+    generated_at: str,
+    result: ValidationResult,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"# Calibration Report — `{name}`")
+    lines.append("")
+    lines.append(f"- Generated: `{generated_at}`")
+    lines.append(f"- Judge: `{judge_family_model}`")
+    lines.append(f"- Threshold (Spearman ≥): `{result.threshold}`")
+    lines.append(f"- Labels: `{labels_path}`")
+    lines.append(f"- Runs root: `{runs_root}`")
+    lines.append("")
+    lines.append("## Per-dimension results")
+    lines.append("")
+    lines.append("| Dimension | n (paired) | Spearman ρ | Exact-match | Status | Notes |")
+    lines.append("|---|---:|---:|---:|---|---|")
+    for r in result.results:
+        rho_cell = "—" if r.spearman is None else f"{r.spearman:.4f}"
+        em_cell = "—" if r.exact_match_rate is None else f"{r.exact_match_rate:.4f}"
+        lines.append(
+            f"| `{r.dimension}` | {r.n_paired} | {rho_cell} | {em_cell} | "
+            f"{r.status} | {r.reason or ''} |"
+        )
+    lines.append("")
+    n_cal = sum(1 for r in result.results if r.status == STATUS_CALIBRATED)
+    n_unc = sum(1 for r in result.results if r.status == STATUS_UNCALIBRATED)
+    n_nosig = sum(1 for r in result.results if r.status == STATUS_NO_SIGNAL)
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Calibrated: **{n_cal}**")
+    lines.append(f"- Uncalibrated: **{n_unc}**")
+    lines.append(f"- No-signal: **{n_nosig}**")
+    if n_cal == 0:
+        lines.append("")
+        lines.append(
+            "> Zero dimensions cleared the threshold. Per spec.md D6 "
+            "(zero-dimensions-calibrated terminal state), this is a "
+            "valid empirical outcome — reports continue to render raw "
+            "ratings advisory-only, and no calibrated-judge verdict "
+            "is declared. Maintainer recovery options: revise the "
+            "rubric (new `rubric-default-vN.md`), try a different "
+            "judge model, or accept the negative result."
+        )
+    lines.append("")
+    lines.append("## Data quality")
+    lines.append("")
+    dq = result.data_quality
+    lines.append(f"- Labels total: {dq.labels_total}")
+    lines.append(f"- Labels with null human rating (structurally inapplicable): {dq.labels_with_null_rating}")
+    lines.append(f"- Labels with missing judge.json: {dq.labels_for_missing_judge_output}")
+    lines.append(f"- Labels with unparseable judge.json: {dq.labels_for_unparseable_judge_output}")
+    lines.append(f"- Labels with judge-id mismatch: {dq.labels_for_judge_id_mismatch}")
+    lines.append(f"- Labels whose dimension was missing from the judge output: {dq.labels_for_missing_dimension}")
+    lines.append(f"- Labels with null judge rating (judge declared inapplicable): {dq.labels_for_null_judge_rating}")
+    lines.append(f"- Labels with malformed judge rating (non-int / bool / float): {dq.labels_for_malformed_judge_rating}")
+    lines.append(f"- Labels with out-of-range judge rating (not in 1..5): {dq.labels_for_out_of_range_judge_rating}")
+    if dq.judge_output_skip_reasons:
+        lines.append("")
+        lines.append("### Judge-output skip reasons")
+        lines.append("")
+        for run_path, reason in sorted(dq.judge_output_skip_reasons.items()):
+            lines.append(f"- `{run_path}`: {reason}")
+    return "\n".join(lines) + "\n"
+
+
+# ── High-level entrypoint for the CLI ────────────────────────────────
+
+
+def validate_and_write(
+    *,
+    labels_path: Path,
+    runs_root: Path,
+    judge_family_model: str,
+    name: str,
+    output_dir: Path,
+    threshold: float = DEFAULT_THRESHOLD,
+    judge_output_name: str = DEFAULT_JUDGE_OUTPUT_NAME,
+) -> tuple[Path, Path, ValidationResult]:
+    """Convenience wrapper for the CLI: load → validate → write."""
+    labels = load_labels(labels_path)
+    if not labels:
+        raise NoLabelsError(f"labels file empty or contains zero records: {labels_path}")
+    result = validate_corpus(
+        labels,
+        runs_root=runs_root,
+        judge_family_model=judge_family_model,
+        threshold=threshold,
+        judge_output_name=judge_output_name,
+    )
+    report_path, json_path = write_calibration_artifacts(
+        result,
+        name=name,
+        judge_family_model=judge_family_model,
+        labels_path=labels_path,
+        runs_root=runs_root,
+        output_dir=output_dir,
+    )
+    return report_path, json_path, result

--- a/scripts/benchmark_runner/cli.py
+++ b/scripts/benchmark_runner/cli.py
@@ -196,6 +196,62 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Where to write the corpus files (default benchmarks/calibration/).",
     )
 
+    # ── calibrate ─────────────────────────────────────────────────
+    p_calibrate = sub.add_parser(
+        "calibrate",
+        help=(
+            "Validate a labeled calibration corpus against a judge's "
+            "judge.json outputs. Computes per-dimension Spearman ρ + "
+            "exact-match rate; writes <name>.calibration-report.md + "
+            "<name>.calibrated-dimensions.json under --output-dir. "
+            "Never mutates runs/."
+        ),
+    )
+    p_calibrate.add_argument(
+        "--labels",
+        required=True,
+        type=Path,
+        help="Path to the labels JSONL (one {run_path,dimension,rating,notes} record per line).",
+    )
+    p_calibrate.add_argument(
+        "--judge",
+        required=True,
+        help=(
+            "Judge identity to validate against, '<family>:<model>' "
+            "(e.g. 'claude-code:sonnet'). The script reads each "
+            "judge.json and asserts its judge_id/judge_backend_id + "
+            "judge_model match; mismatches are recorded as skips."
+        ),
+    )
+    p_calibrate.add_argument(
+        "--name",
+        required=True,
+        help="Calibration name; outputs land at <output-dir>/<name>.{calibration-report.md,calibrated-dimensions.json}.",
+    )
+    p_calibrate.add_argument(
+        "--runs-root",
+        type=Path,
+        default=Path("runs"),
+        help="Root that label run_paths are relative to (default ./runs).",
+    )
+    p_calibrate.add_argument(
+        "--threshold",
+        type=float,
+        default=0.6,
+        help="Spearman threshold for 'calibrated' (default 0.6 per issue #34 v3).",
+    )
+    p_calibrate.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("benchmarks/calibration"),
+        help="Where to write the report + JSON (default benchmarks/calibration/).",
+    )
+    p_calibrate.add_argument(
+        "--judge-output-name",
+        default="judge.json",
+        help="Filename of the judge output per attempt directory (default judge.json).",
+    )
+
     # ── compare ───────────────────────────────────────────────────────
     p_compare = sub.add_parser(
         "compare",
@@ -647,6 +703,92 @@ def _cmd_calibration_corpus(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_calibrate(args: argparse.Namespace) -> int:
+    if not args.labels.exists():
+        print(
+            f"benchmark: labels file not found: {args.labels}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if not args.runs_root.exists():
+        print(
+            f"benchmark: runs-root not found: {args.runs_root}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+    if ":" not in args.judge:
+        print(
+            f"benchmark: --judge must be '<family>:<model>'; got {args.judge!r}",
+            file=sys.stderr,
+        )
+        return EXIT_USAGE
+
+    from .calibration.validate import (
+        LabelsParseError,
+        NoLabelsError,
+        STATUS_CALIBRATED,
+        STATUS_NO_SIGNAL,
+        STATUS_UNCALIBRATED,
+        validate_and_write,
+        validate_threshold,
+    )
+
+    # Validate --threshold up front so the CLI surfaces a clear usage
+    # error instead of failing inside validate_corpus (which would map
+    # to the catch-all EXIT_RUNTIME branch + a less-readable message).
+    # The library-level guard in validate_threshold remains as defense
+    # in depth for direct callers.
+    try:
+        validate_threshold(args.threshold)
+    except ValueError as exc:
+        print(f"benchmark: --threshold: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        report_path, json_path, result = validate_and_write(
+            labels_path=args.labels,
+            runs_root=args.runs_root,
+            judge_family_model=args.judge,
+            name=args.name,
+            output_dir=args.output_dir,
+            threshold=args.threshold,
+            judge_output_name=args.judge_output_name,
+        )
+    except FileNotFoundError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except LabelsParseError as exc:
+        print(f"benchmark: labels parse error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except NoLabelsError as exc:
+        print(f"benchmark: {exc}", file=sys.stderr)
+        return EXIT_RUNTIME
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"benchmark: calibration failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return EXIT_RUNTIME
+
+    n_cal = sum(1 for r in result.results if r.status == STATUS_CALIBRATED)
+    n_unc = sum(1 for r in result.results if r.status == STATUS_UNCALIBRATED)
+    n_nos = sum(1 for r in result.results if r.status == STATUS_NO_SIGNAL)
+    print(json.dumps({
+        "report_path": str(report_path),
+        "json_path": str(json_path),
+        "name": args.name,
+        "judge": args.judge,
+        "threshold": args.threshold,
+        "n_dimensions": len(result.results),
+        "calibrated": n_cal,
+        "uncalibrated": n_unc,
+        "no_signal": n_nos,
+        "labels_total": result.data_quality.labels_total,
+    }, indent=2))
+    return EXIT_OK
+
+
 _HANDLERS = {
     "list": _cmd_list,
     "run": _cmd_run,
@@ -655,6 +797,7 @@ _HANDLERS = {
     "dogfood": _cmd_dogfood,
     "judge": _cmd_judge,
     "calibration-corpus": _cmd_calibration_corpus,
+    "calibrate": _cmd_calibrate,
 }
 
 

--- a/scripts/benchmark_runner/tests/test_calibration_validate.py
+++ b/scripts/benchmark_runner/tests/test_calibration_validate.py
@@ -1,0 +1,811 @@
+# tests/test_calibration_validate.py — calibration orchestrator tests.
+#
+# Synthetic-only: stages a tmpdir runs-root with hand-crafted
+# judge.json files + a labels JSONL, runs validate_and_write (or
+# the CLI handler), asserts the resulting calibrated-dimensions.json
+# matches the predicted Spearman matrix. No live LLM, no human
+# labeling required to merge.
+#
+# Three layers:
+#   1. load_labels parsing (well-formed + malformed lines).
+#   2. validate_corpus + evaluate_dimension pure functions.
+#   3. End-to-end (validate_and_write) including writers + threshold
+#      boundary @ 0.59 / 0.60 / 0.70 per issue #49 AC.
+#   4. CLI handler smoke (error paths + happy path).
+
+from __future__ import annotations
+
+import io
+import json
+import math
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from benchmark_runner.calibration.validate import (
+    CALIBRATED_DIMENSIONS_SCHEMA_VERSION,
+    DEFAULT_THRESHOLD,
+    Label,
+    LabelsParseError,
+    NoLabelsError,
+    STATUS_CALIBRATED,
+    STATUS_NO_SIGNAL,
+    STATUS_UNCALIBRATED,
+    evaluate_dimension,
+    load_labels,
+    validate_and_write,
+    validate_corpus,
+    validate_threshold,
+)
+from benchmark_runner.cli import EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, main
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────
+
+
+def _write_labels(path: Path, records: list[dict]) -> None:
+    """Write a JSONL labels file from a list of dicts."""
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _write_judge_json(
+    attempt_dir: Path,
+    *,
+    ratings: dict[str, int | None],
+    judge_backend_id: str = "claude-code",
+    judge_model: str = "sonnet",
+    judge_id: str = "claude-code-judge",
+) -> None:
+    """Stage one attempt's judge.json. Dimensions absent from the
+    ``ratings`` dict are omitted from the produced judge output
+    entirely (mirrors how the real judge handles missing dimensions).
+    """
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    ratings_block = {
+        dim: {
+            "rating": r,
+            "explanation": f"canned for {dim}",
+            "prompt_sha256": "stub",
+        }
+        for dim, r in ratings.items()
+    }
+    doc = {
+        "schema_version": "1.0",
+        "judge_id": judge_id,
+        "judge_model": judge_model,
+        "judge_backend_id": judge_backend_id,
+        "rubric_name": "default-v1",
+        "rubric_dimensions": list(ratings_block.keys()),
+        "ratings": ratings_block,
+        "judge_invocation": {
+            "model": judge_model,
+            "temperature": None,
+            "seed": None,
+            "temperature_control": "unsupported",
+            "seed_control": "unsupported",
+            "provider_endpoint_present": False,
+        },
+        "tokens_input": None,
+        "tokens_output": None,
+        "judge_metadata": {},
+    }
+    (attempt_dir / "judge.json").write_text(
+        json.dumps(doc, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+# ── load_labels parsing ───────────────────────────────────────────────
+
+
+class TestLoadLabels(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-calib-test-")
+        self.tmp = Path(self._tmp)
+        self.labels_path = self.tmp / "labels.jsonl"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_well_formed_round_trip(self) -> None:
+        _write_labels(self.labels_path, [
+            {"run_path": "a/attempt-01-run-001", "dimension": "idiomaticity", "rating": 4, "notes": "ok"},
+            {"run_path": "a/attempt-01-run-001", "dimension": "security_hygiene", "rating": None, "notes": "n/a"},
+        ])
+        labels = load_labels(self.labels_path)
+        self.assertEqual(len(labels), 2)
+        self.assertEqual(labels[0].rating, 4)
+        self.assertIsNone(labels[1].rating)
+
+    def test_skips_blank_and_comment_lines(self) -> None:
+        self.labels_path.write_text(
+            '\n'
+            '# this is a comment\n'
+            '// also a comment\n'
+            '{"run_path":"a","dimension":"x","rating":3}\n'
+            '\n',
+            encoding="utf-8",
+        )
+        labels = load_labels(self.labels_path)
+        self.assertEqual(len(labels), 1)
+
+    def test_missing_file_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            load_labels(self.tmp / "nope.jsonl")
+
+    def test_malformed_json_raises_with_line_number(self) -> None:
+        self.labels_path.write_text(
+            '{"run_path":"a","dimension":"x","rating":3}\n'
+            'not JSON\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(LabelsParseError, ":2:"):
+            load_labels(self.labels_path)
+
+    def test_missing_required_field_raises(self) -> None:
+        self.labels_path.write_text(
+            '{"run_path":"a","rating":3}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(LabelsParseError, "dimension"):
+            load_labels(self.labels_path)
+
+    def test_rating_out_of_range_raises(self) -> None:
+        self.labels_path.write_text(
+            '{"run_path":"a","dimension":"x","rating":6}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(LabelsParseError, "out of range"):
+            load_labels(self.labels_path)
+
+    def test_rating_bool_rejected(self) -> None:
+        # JSON ``true`` deserializes as Python True (int subclass);
+        # the contract requires real ints, so this must reject.
+        self.labels_path.write_text(
+            '{"run_path":"a","dimension":"x","rating":true}\n',
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(LabelsParseError, "must be int"):
+            load_labels(self.labels_path)
+
+
+# ── evaluate_dimension pure-function tests ────────────────────────────
+
+
+class TestEvaluateDimension(unittest.TestCase):
+    def test_calibrated_perfect_correlation(self) -> None:
+        paired = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+        r = evaluate_dimension("d", paired, threshold=0.6)
+        self.assertEqual(r.status, STATUS_CALIBRATED)
+        self.assertEqual(r.spearman, 1.0)
+        self.assertEqual(r.exact_match_rate, 1.0)
+
+    def test_uncalibrated_below_threshold(self) -> None:
+        # Spearman ρ = 0 here (no monotonic relationship).
+        paired = [(1, 3), (2, 1), (3, 4), (4, 2), (5, 5)]
+        r = evaluate_dimension("d", paired, threshold=0.6)
+        self.assertEqual(r.status, STATUS_UNCALIBRATED)
+        self.assertLess(r.spearman, 0.6)
+        self.assertIn("threshold", r.reason)
+
+    def test_no_signal_n_too_small(self) -> None:
+        r = evaluate_dimension("d", [(1, 1)], threshold=0.6)
+        self.assertEqual(r.status, STATUS_NO_SIGNAL)
+        self.assertEqual(r.n_paired, 1)
+        self.assertIsNone(r.spearman)
+        # exact-match still reported when n>=1.
+        self.assertEqual(r.exact_match_rate, 1.0)
+
+    def test_no_signal_zero_paired(self) -> None:
+        r = evaluate_dimension("d", [], threshold=0.6)
+        self.assertEqual(r.status, STATUS_NO_SIGNAL)
+        self.assertEqual(r.n_paired, 0)
+        self.assertIsNone(r.exact_match_rate)
+
+    def test_no_signal_no_variation_on_one_side(self) -> None:
+        # Constant judge ratings → Spearman undefined → no_signal.
+        paired = [(1, 3), (2, 3), (3, 3), (4, 3), (5, 3)]
+        r = evaluate_dimension("d", paired, threshold=0.6)
+        self.assertEqual(r.status, STATUS_NO_SIGNAL)
+        self.assertIn("no variation", r.reason)
+
+
+# ── Threshold boundary tests (issue #49 AC) ──────────────────────────
+
+
+class TestThresholdBoundary(unittest.TestCase):
+    """The exact AC text from sub-issue B: 'Threshold boundary tested
+    at 0.59, 0.60, 0.70 — a dimension scoring 0.59 is omitted from
+    calibrated-dimensions.json at default threshold; one scoring
+    0.60 is included.'"""
+
+    @staticmethod
+    def _evaluate_at(rho_target: float) -> str:
+        # Construct a paired vector whose Spearman ρ equals rho_target
+        # exactly. We bypass paired-rating construction and instead
+        # mock the evaluation by directly testing the threshold logic
+        # against the documented sentinels.
+        # rho_target == 0.60 → calibrated
+        # rho_target == 0.59 → uncalibrated
+        # rho_target == 0.70 → calibrated
+        if rho_target >= DEFAULT_THRESHOLD:
+            return STATUS_CALIBRATED
+        return STATUS_UNCALIBRATED
+
+    def test_threshold_059_uncalibrated(self) -> None:
+        # Construct a vector with Spearman = 0.6 - epsilon
+        # (paired ratings designed for exact ρ < 0.6).
+        # Easiest: 5 pairs with two swaps → ρ = 1 - 6*4/(5*24) = 0.8
+        # That's above 0.6. Let me hand-construct ρ < 0.6:
+        # 5 pairs, ranks rx = [1,2,3,4,5], ry permuted:
+        # rx = [1,2,3,4,5], ry = [3,1,2,4,5] → d² = 4+1+1+0+0 = 6
+        # ρ = 1 - 6*6/(5*24) = 1 - 36/120 = 0.7  (still > 0.6)
+        # Try ry = [3,1,4,2,5] → d² = 4+1+1+4+0 = 10
+        # ρ = 1 - 60/120 = 0.5  ✓ below 0.6
+        paired = [(1, 3), (2, 1), (3, 4), (4, 2), (5, 5)]
+        r = evaluate_dimension("d", paired, threshold=DEFAULT_THRESHOLD)
+        self.assertEqual(r.status, STATUS_UNCALIBRATED)
+        self.assertLess(r.spearman, DEFAULT_THRESHOLD)
+
+    def test_threshold_060_inclusive_calibrated(self) -> None:
+        # Construct ρ = 0.6 exactly:
+        # 5 pairs, rx = [1..5], ry permuted:
+        # ry = [2,1,3,4,5] → d² = 1+1+0+0+0 = 2 → ρ = 1-12/120 = 0.9
+        # ry = [1,3,2,5,4] → d² = 0+1+1+1+1 = 4 → ρ = 1-24/120 = 0.8
+        # ry = [1,2,5,3,4] → d² = 0+0+4+1+0 = wait that's d=[(1-1),(2-2),(3-5),(4-3),(5-4)] → d²=[0,0,4,1,1]=6 → ρ=1-36/120 = 0.7
+        # ry = [2,3,1,4,5] → d=[-1,-1,2,0,0] d²=[1,1,4,0,0]=6 → ρ=0.7
+        # ry = [1,3,4,2,5] → d=[0,-1,-1,2,0] d²=[0,1,1,4,0]=6 → ρ=0.7
+        # ry = [2,1,4,3,5] → d=[-1,1,-1,1,0] d²=[1,1,1,1,0]=4 → ρ=0.8
+        # Need d²=8 → ρ = 1-48/120 = 0.6 exactly.
+        # ry = [3,2,1,4,5] → d=[-2,0,2,0,0] d²=[4,0,4,0,0]=8 → ρ=0.6 ✓
+        paired = [(1, 3), (2, 2), (3, 1), (4, 4), (5, 5)]
+        r = evaluate_dimension("d", paired, threshold=DEFAULT_THRESHOLD)
+        # ρ = 0.6 exactly. Status must be CALIBRATED (the `>=`
+        # boundary in spec.md / issue #34 v3).
+        self.assertAlmostEqual(r.spearman, 0.6, places=12)
+        self.assertEqual(r.status, STATUS_CALIBRATED)
+
+    def test_threshold_070_calibrated(self) -> None:
+        # ρ = 0.7 from earlier hand-computation: ry = [1,2,5,3,4].
+        paired = [(1, 1), (2, 2), (3, 5), (4, 3), (5, 4)]
+        r = evaluate_dimension("d", paired, threshold=DEFAULT_THRESHOLD)
+        self.assertAlmostEqual(r.spearman, 0.7, places=12)
+        self.assertEqual(r.status, STATUS_CALIBRATED)
+
+    def test_custom_threshold_overrides_default(self) -> None:
+        # ρ = 0.7 calibrated at default 0.6, but uncalibrated at
+        # 0.8 — the --threshold CLI knob takes effect.
+        paired = [(1, 1), (2, 2), (3, 5), (4, 3), (5, 4)]
+        r = evaluate_dimension("d", paired, threshold=0.8)
+        self.assertAlmostEqual(r.spearman, 0.7, places=12)
+        self.assertEqual(r.status, STATUS_UNCALIBRATED)
+
+
+# ── End-to-end: validate_and_write ───────────────────────────────────
+
+
+class TestValidateAndWrite(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-calib-e2e-")
+        self.tmp = Path(self._tmp)
+        self.runs_root = self.tmp / "runs"
+        self.runs_root.mkdir()
+        self.output_dir = self.tmp / "out"
+        self.labels_path = self.tmp / "labels.jsonl"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _stage_corpus(self) -> None:
+        """5 attempts × 4 dimensions. idiomaticity ρ=1.0 (calibrated),
+        error_handling ρ=0.6 (calibrated boundary), test_thoughtfulness
+        ρ=0 (uncalibrated), security_hygiene all null (no_signal).
+        """
+        attempts = [
+            ("attempt-01-run-001", {"idiomaticity": 1, "error_handling": 1, "test_thoughtfulness": 3, "security_hygiene": None}),
+            ("attempt-02-run-001", {"idiomaticity": 2, "error_handling": 2, "test_thoughtfulness": 1, "security_hygiene": None}),
+            ("attempt-03-run-001", {"idiomaticity": 3, "error_handling": 3, "test_thoughtfulness": 4, "security_hygiene": None}),
+            ("attempt-04-run-001", {"idiomaticity": 4, "error_handling": 4, "test_thoughtfulness": 2, "security_hygiene": None}),
+            ("attempt-05-run-001", {"idiomaticity": 5, "error_handling": 5, "test_thoughtfulness": 5, "security_hygiene": None}),
+        ]
+        # Judge ratings: idiomaticity matches exactly (ρ=1.0).
+        # error_handling: human ranks [1,2,3,4,5], judge [3,2,1,4,5] → ρ=0.6.
+        # test_thoughtfulness: human ranks [3,1,4,2,5], judge same → ρ=1.0 — let me
+        #   pick something else. ρ=0 requires careful design. Let me use
+        #   human=[3,1,4,2,5] paired with judge=[1,3,2,4,5]; we want ρ low.
+        judge_ratings = {
+            "attempt-01-run-001": {"idiomaticity": 1, "error_handling": 3, "test_thoughtfulness": 1, "security_hygiene": None},
+            "attempt-02-run-001": {"idiomaticity": 2, "error_handling": 2, "test_thoughtfulness": 3, "security_hygiene": None},
+            "attempt-03-run-001": {"idiomaticity": 3, "error_handling": 1, "test_thoughtfulness": 2, "security_hygiene": None},
+            "attempt-04-run-001": {"idiomaticity": 4, "error_handling": 4, "test_thoughtfulness": 4, "security_hygiene": None},
+            "attempt-05-run-001": {"idiomaticity": 5, "error_handling": 5, "test_thoughtfulness": 5, "security_hygiene": None},
+        }
+        # Write judge.json per attempt.
+        for slug, ratings in judge_ratings.items():
+            _write_judge_json(self.runs_root / slug, ratings=ratings)
+        # Write labels JSONL.
+        label_records = []
+        for slug, ratings in attempts:
+            for dim, rating in ratings.items():
+                label_records.append({
+                    "run_path": slug,
+                    "dimension": dim,
+                    "rating": rating,
+                    "notes": "",
+                })
+        _write_labels(self.labels_path, label_records)
+
+    def test_produces_both_artifacts(self) -> None:
+        self._stage_corpus()
+        report_path, json_path, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="e2e-test",
+            output_dir=self.output_dir,
+        )
+        self.assertTrue(report_path.exists())
+        self.assertTrue(json_path.exists())
+        self.assertEqual(report_path.name, "e2e-test.calibration-report.md")
+        self.assertEqual(json_path.name, "e2e-test.calibrated-dimensions.json")
+
+    def test_json_classifies_dimensions_correctly(self) -> None:
+        self._stage_corpus()
+        _, json_path, _ = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="e2e-test",
+            output_dir=self.output_dir,
+        )
+        doc = json.loads(json_path.read_text(encoding="utf-8"))
+        self.assertEqual(doc["schema_version"], CALIBRATED_DIMENSIONS_SCHEMA_VERSION)
+        self.assertEqual(doc["threshold"], 0.6)
+        # idiomaticity → ρ=1.0 → calibrated.
+        cal_dims = {e["dimension"] for e in doc["calibrated"]}
+        self.assertIn("idiomaticity", cal_dims)
+        # error_handling → ρ=0.6 → calibrated (boundary inclusive).
+        self.assertIn("error_handling", cal_dims)
+        # security_hygiene → all null → no_signal.
+        nosig_dims = {e["dimension"] for e in doc["no_signal"]}
+        self.assertIn("security_hygiene", nosig_dims)
+
+    def test_report_md_is_human_readable(self) -> None:
+        self._stage_corpus()
+        report_path, _, _ = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="e2e-test",
+            output_dir=self.output_dir,
+        )
+        text = report_path.read_text(encoding="utf-8")
+        self.assertIn("# Calibration Report", text)
+        self.assertIn("idiomaticity", text)
+        self.assertIn("Threshold (Spearman ≥)", text)
+        self.assertIn("Summary", text)
+
+    def test_runs_root_never_mutated(self) -> None:
+        self._stage_corpus()
+        before = {
+            p: p.read_bytes()
+            for p in self.runs_root.rglob("*") if p.is_file()
+        }
+        validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="e2e-test",
+            output_dir=self.output_dir,
+        )
+        after = {
+            p: p.read_bytes()
+            for p in self.runs_root.rglob("*") if p.is_file()
+        }
+        self.assertEqual(before.keys(), after.keys())
+        for p, content in before.items():
+            self.assertEqual(after[p], content)
+
+    def test_judge_id_mismatch_recorded_as_skip(self) -> None:
+        self._stage_corpus()
+        # Run calibrate against a different judge spec.
+        _, json_path, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:opus",  # judge.json has sonnet
+            name="mismatch-test",
+            output_dir=self.output_dir,
+        )
+        self.assertGreater(
+            result.data_quality.labels_for_judge_id_mismatch, 0,
+        )
+
+    def test_missing_judge_output_recorded_as_skip(self) -> None:
+        # Stage labels referencing run_paths that have no judge.json.
+        _write_labels(self.labels_path, [
+            {"run_path": "missing/attempt-01-run-001", "dimension": "idiomaticity", "rating": 4},
+        ])
+        _, _, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="missing-test",
+            output_dir=self.output_dir,
+        )
+        self.assertGreater(
+            result.data_quality.labels_for_missing_judge_output, 0,
+        )
+
+    def test_zero_dimensions_calibrated_terminal_state(self) -> None:
+        # Per spec.md D6: when no dimension clears the threshold,
+        # the report MUST still produce a valid artifact (raw ratings
+        # advisory-only; no calibrated-judge verdict).
+        # Stage 5 attempts where judge disagrees on every dim.
+        for i in range(1, 6):
+            _write_judge_json(
+                self.runs_root / f"attempt-{i:02d}-run-001",
+                ratings={"idiomaticity": (6 - i)},  # reverse of human
+            )
+        labels = []
+        for i in range(1, 6):
+            labels.append({
+                "run_path": f"attempt-{i:02d}-run-001",
+                "dimension": "idiomaticity",
+                "rating": i,  # ascending; judge gave descending
+            })
+        _write_labels(self.labels_path, labels)
+        _, json_path, _ = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="negative-result",
+            output_dir=self.output_dir,
+        )
+        doc = json.loads(json_path.read_text(encoding="utf-8"))
+        self.assertEqual(doc["calibrated"], [])
+        # The single dimension was uncalibrated (ρ=-1.0).
+        self.assertEqual(len(doc["uncalibrated"]), 1)
+        self.assertAlmostEqual(doc["uncalibrated"][0]["spearman"], -1.0)
+
+
+# ── Out-of-range judge rating (P2.1 reviewer fix) ────────────────────
+
+
+class TestOutOfRangeJudgeRating(unittest.TestCase):
+    """Reviewer-flagged P2: a judge.json with rating=6 (or any
+    out-of-band integer) must NOT enter the calibration sample —
+    treat it as a data-quality skip with its own bucket so the
+    misconfiguration is surfaced, not silently averaged away.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-calib-oob-")
+        self.tmp = Path(self._tmp)
+        self.runs_root = self.tmp / "runs"
+        self.runs_root.mkdir()
+        self.output_dir = self.tmp / "out"
+        self.labels_path = self.tmp / "labels.jsonl"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_judge_rating_six_skipped_with_data_quality_count(self) -> None:
+        # Stage three attempts. Judge rates the third as 6
+        # (out-of-band). Without the P2 fix, the (3, 6) pair would
+        # enter the sample and produce ρ = 1.0 — wrongly calibrated.
+        # With the fix, it's a skip; only 2 valid pairs remain and
+        # the dimension is no_signal (n=2 + variation — actually ρ=1.0
+        # on 2 pairs, calibrated). The key assertion: the skip count
+        # increments.
+        _write_judge_json(self.runs_root / "attempt-01-run-001", ratings={"idiomaticity": 1})
+        _write_judge_json(self.runs_root / "attempt-02-run-001", ratings={"idiomaticity": 2})
+        _write_judge_json(self.runs_root / "attempt-03-run-001", ratings={"idiomaticity": 6})
+        _write_labels(self.labels_path, [
+            {"run_path": "attempt-01-run-001", "dimension": "idiomaticity", "rating": 1},
+            {"run_path": "attempt-02-run-001", "dimension": "idiomaticity", "rating": 2},
+            {"run_path": "attempt-03-run-001", "dimension": "idiomaticity", "rating": 3},
+        ])
+        _, json_path, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="oob-test",
+            output_dir=self.output_dir,
+        )
+        self.assertEqual(result.data_quality.labels_for_out_of_range_judge_rating, 1)
+        # The valid (1,1) and (2,2) pairs entered the sample → ρ=1.0
+        # on n=2 → calibrated. The (3,6) pair did NOT.
+        doc = json.loads(json_path.read_text(encoding="utf-8"))
+        idi = next((e for e in doc["calibrated"] if e["dimension"] == "idiomaticity"), None)
+        self.assertIsNotNone(idi)
+        self.assertEqual(idi["n_paired"], 2)
+        # Data-quality block surfaces the out-of-range count.
+        self.assertEqual(doc["data_quality"]["labels_for_out_of_range_judge_rating"], 1)
+
+    def test_judge_rating_zero_skipped(self) -> None:
+        # The symmetric case: 0 is below the band.
+        _write_judge_json(self.runs_root / "attempt-01-run-001", ratings={"idiomaticity": 1})
+        _write_judge_json(self.runs_root / "attempt-02-run-001", ratings={"idiomaticity": 0})
+        _write_labels(self.labels_path, [
+            {"run_path": "attempt-01-run-001", "dimension": "idiomaticity", "rating": 1},
+            {"run_path": "attempt-02-run-001", "dimension": "idiomaticity", "rating": 2},
+        ])
+        _, _, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="zero-test",
+            output_dir=self.output_dir,
+        )
+        self.assertEqual(result.data_quality.labels_for_out_of_range_judge_rating, 1)
+
+    def test_judge_rating_malformed_type_distinct_bucket(self) -> None:
+        # bool and float are MALFORMED (distinct bucket from out-of-
+        # range). Hand-craft a judge.json with float rating.
+        attempt_dir = self.runs_root / "attempt-01-run-001"
+        attempt_dir.mkdir(parents=True)
+        (attempt_dir / "judge.json").write_text(
+            json.dumps({
+                "judge_id": "claude-code-judge",
+                "judge_model": "sonnet",
+                "judge_backend_id": "claude-code",
+                "rubric_name": "default-v1",
+                "ratings": {
+                    "idiomaticity": {
+                        "rating": 3.5,  # float, malformed type
+                        "explanation": "x",
+                        "prompt_sha256": "y",
+                    },
+                },
+                "judge_invocation": {
+                    "model": "sonnet", "temperature": None, "seed": None,
+                    "temperature_control": "unsupported",
+                    "seed_control": "unsupported",
+                    "provider_endpoint_present": False,
+                },
+            }) + "\n",
+            encoding="utf-8",
+        )
+        _write_labels(self.labels_path, [
+            {"run_path": "attempt-01-run-001", "dimension": "idiomaticity", "rating": 3},
+        ])
+        _, _, result = validate_and_write(
+            labels_path=self.labels_path,
+            runs_root=self.runs_root,
+            judge_family_model="claude-code:sonnet",
+            name="malformed-test",
+            output_dir=self.output_dir,
+        )
+        self.assertEqual(result.data_quality.labels_for_malformed_judge_rating, 1)
+        # Distinct bucket — out-of-range count stays 0.
+        self.assertEqual(result.data_quality.labels_for_out_of_range_judge_rating, 0)
+
+
+# ── Threshold validation (P2.2 reviewer fix) ─────────────────────────
+
+
+class TestThresholdValidation(unittest.TestCase):
+    """validate_threshold rejects NaN, inf, and values outside [0, 1].
+    The CLI surfaces these as EXIT_USAGE; the library raises ValueError."""
+
+    def test_nan_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            validate_threshold(float("nan"))
+
+    def test_inf_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            validate_threshold(float("inf"))
+        with self.assertRaisesRegex(ValueError, "finite"):
+            validate_threshold(float("-inf"))
+
+    def test_negative_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"\[0\.0, 1\.0\]"):
+            validate_threshold(-0.1)
+        with self.assertRaisesRegex(ValueError, r"\[0\.0, 1\.0\]"):
+            validate_threshold(-1.0)
+
+    def test_above_one_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"\[0\.0, 1\.0\]"):
+            validate_threshold(1.5)
+        with self.assertRaisesRegex(ValueError, r"\[0\.0, 1\.0\]"):
+            validate_threshold(2.0)
+
+    def test_boundary_values_accepted(self) -> None:
+        validate_threshold(0.0)
+        validate_threshold(1.0)
+        validate_threshold(0.6)  # the default
+
+    def test_validate_corpus_propagates_threshold_check(self) -> None:
+        # Defense-in-depth: validate_corpus also calls validate_threshold.
+        with self.assertRaisesRegex(ValueError, "finite"):
+            validate_corpus(
+                [],
+                runs_root=Path("/tmp"),
+                judge_family_model="claude-code:sonnet",
+                threshold=float("nan"),
+            )
+
+
+# ── No-labels error ───────────────────────────────────────────────────
+
+
+class TestNoLabelsError(unittest.TestCase):
+    def test_empty_labels_file_raises_no_labels(self) -> None:
+        tmp = Path(tempfile.mkdtemp(prefix="cct-calib-empty-"))
+        try:
+            (tmp / "labels.jsonl").write_text("\n\n# comment-only\n", encoding="utf-8")
+            runs_root = tmp / "runs"
+            runs_root.mkdir()
+            with self.assertRaises(NoLabelsError):
+                validate_and_write(
+                    labels_path=tmp / "labels.jsonl",
+                    runs_root=runs_root,
+                    judge_family_model="claude-code:sonnet",
+                    name="empty",
+                    output_dir=tmp / "out",
+                )
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ── CLI subcommand ────────────────────────────────────────────────────
+
+
+class TestCliCalibrate(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="cct-cli-calib-")
+        self.tmp = Path(self._tmp)
+        self.runs_root = self.tmp / "runs"
+        self.runs_root.mkdir()
+        self.labels_path = self.tmp / "labels.jsonl"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _invoke(self, *argv: str) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(list(argv))
+        return code, out.getvalue(), err.getvalue()
+
+    def _stage_minimal_corpus(self) -> None:
+        # 2 attempts × 1 dimension with perfect agreement (ρ=1.0).
+        for i in (1, 2):
+            _write_judge_json(
+                self.runs_root / f"attempt-{i:02d}-run-001",
+                ratings={"idiomaticity": i},
+            )
+        _write_labels(self.labels_path, [
+            {"run_path": "attempt-01-run-001", "dimension": "idiomaticity", "rating": 1},
+            {"run_path": "attempt-02-run-001", "dimension": "idiomaticity", "rating": 2},
+        ])
+
+    def test_labels_missing_returns_usage(self) -> None:
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.tmp / "nope.jsonl"),
+            "--judge", "claude-code:sonnet",
+            "--name", "x",
+            "--runs-root", str(self.runs_root),
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("labels file not found", err)
+
+    def test_judge_arg_without_colon_returns_usage(self) -> None:
+        self._stage_minimal_corpus()
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code-no-colon",
+            "--name", "x",
+            "--runs-root", str(self.runs_root),
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("<family>:<model>", err)
+
+    def test_runs_root_missing_returns_usage(self) -> None:
+        self._stage_minimal_corpus()
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "x",
+            "--runs-root", str(self.tmp / "no-runs"),
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("runs-root not found", err)
+
+    def test_happy_path(self) -> None:
+        self._stage_minimal_corpus()
+        code, stdout, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "cli-test",
+            "--runs-root", str(self.runs_root),
+            "--output-dir", str(self.tmp / "out"),
+        )
+        self.assertEqual(code, EXIT_OK, msg=f"stderr: {err}")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["calibrated"], 1)
+        self.assertEqual(payload["uncalibrated"], 0)
+        self.assertEqual(payload["no_signal"], 0)
+        self.assertEqual(payload["judge"], "claude-code:sonnet")
+        self.assertTrue(Path(payload["report_path"]).exists())
+        self.assertTrue(Path(payload["json_path"]).exists())
+
+    def test_malformed_labels_returns_usage(self) -> None:
+        self.labels_path.write_text(
+            '{"run_path":"a","dimension":"d","rating":4}\n'
+            'not JSON\n',
+            encoding="utf-8",
+        )
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "bad",
+            "--runs-root", str(self.runs_root),
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("labels parse error", err)
+
+    def test_empty_labels_returns_runtime(self) -> None:
+        # File present but contains only blanks/comments → EXIT_RUNTIME
+        # (distinct from "file missing" which is EXIT_USAGE).
+        self.labels_path.write_text("\n# nothing here\n\n", encoding="utf-8")
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "empty",
+            "--runs-root", str(self.runs_root),
+        )
+        self.assertEqual(code, EXIT_RUNTIME)
+
+    def test_threshold_nan_returns_usage(self) -> None:
+        self._stage_minimal_corpus()
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "nan",
+            "--runs-root", str(self.runs_root),
+            "--threshold", "nan",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("--threshold", err)
+        self.assertIn("finite", err)
+
+    def test_threshold_negative_returns_usage(self) -> None:
+        self._stage_minimal_corpus()
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "neg",
+            "--runs-root", str(self.runs_root),
+            "--threshold", "-0.5",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("--threshold", err)
+
+    def test_threshold_above_one_returns_usage(self) -> None:
+        self._stage_minimal_corpus()
+        code, _, err = self._invoke(
+            "calibrate",
+            "--labels", str(self.labels_path),
+            "--judge", "claude-code:sonnet",
+            "--name", "above",
+            "--runs-root", str(self.runs_root),
+            "--threshold", "1.5",
+        )
+        self.assertEqual(code, EXIT_USAGE)
+        self.assertIn("--threshold", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmark_runner/tests/test_spearman.py
+++ b/scripts/benchmark_runner/tests/test_spearman.py
@@ -1,0 +1,202 @@
+# tests/test_spearman.py — Spearman ρ + helpers (stdlib-only).
+#
+# Golden vectors come from two sources so a regression has to fail
+# both before slipping through:
+#   1. Wikipedia "Spearman's rank correlation coefficient" worked
+#      example (IQ vs TV-hours, n=10, no ties).
+#   2. Hand-computed three-point examples (perfect ±1, single-tie
+#      case where the rank averaging is the only thing the test
+#      can be measuring).
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from benchmark_runner.calibration.spearman import (
+    exact_match_rate,
+    rank_average_ties,
+    spearman,
+)
+
+
+# ── rank_average_ties ─────────────────────────────────────────────────
+
+
+class TestRankAverageTies(unittest.TestCase):
+    def test_strictly_ascending(self) -> None:
+        self.assertEqual(rank_average_ties([10, 20, 30, 40]), [1.0, 2.0, 3.0, 4.0])
+
+    def test_strictly_descending(self) -> None:
+        # The HIGHEST-value element ranks last (rank 4); the LOWEST
+        # ranks first (rank 1). Order in the input is preserved in
+        # the output, which means ranks come out reversed.
+        self.assertEqual(rank_average_ties([40, 30, 20, 10]), [4.0, 3.0, 2.0, 1.0])
+
+    def test_pair_of_ties(self) -> None:
+        # Two 20s share ranks 2 and 3 → both get the average 2.5.
+        self.assertEqual(rank_average_ties([10, 20, 20, 30]), [1.0, 2.5, 2.5, 4.0])
+
+    def test_triple_tie(self) -> None:
+        # Three 20s share ranks 2, 3, 4 → each gets the average 3.0.
+        self.assertEqual(
+            rank_average_ties([10, 20, 20, 20, 50]),
+            [1.0, 3.0, 3.0, 3.0, 5.0],
+        )
+
+    def test_all_tied(self) -> None:
+        # All four elements share ranks 1..4 → each gets 2.5.
+        # ``spearman`` later rejects all-tied inputs as undefined,
+        # but the rank helper itself is well-defined here.
+        self.assertEqual(rank_average_ties([7, 7, 7, 7]), [2.5, 2.5, 2.5, 2.5])
+
+    def test_empty_returns_empty(self) -> None:
+        self.assertEqual(rank_average_ties([]), [])
+
+    def test_single_element_rank_is_one(self) -> None:
+        self.assertEqual(rank_average_ties([42.0]), [1.0])
+
+    def test_does_not_mutate_input(self) -> None:
+        xs = [3, 1, 2]
+        _ = rank_average_ties(xs)
+        self.assertEqual(xs, [3, 1, 2])
+
+
+# ── spearman: hand-computed and published vectors ─────────────────────
+
+
+class TestSpearman(unittest.TestCase):
+    def test_perfect_positive_correlation(self) -> None:
+        # Strict monotonic increase → ρ = 1.0 exactly.
+        self.assertEqual(spearman([1, 2, 3, 4, 5], [10, 20, 30, 40, 50]), 1.0)
+
+    def test_perfect_negative_correlation(self) -> None:
+        # Strict monotonic decrease → ρ = -1.0 exactly.
+        self.assertEqual(spearman([1, 2, 3, 4, 5], [5, 4, 3, 2, 1]), -1.0)
+
+    def test_two_point_correlation(self) -> None:
+        # n=2 is the smallest allowed case. With distinct values on
+        # both sides, ρ is either +1.0 or -1.0.
+        self.assertEqual(spearman([1, 2], [10, 20]), 1.0)
+        self.assertEqual(spearman([1, 2], [20, 10]), -1.0)
+
+    def test_wikipedia_iq_tv_example(self) -> None:
+        # From en.wikipedia.org/wiki/Spearman%27s_rank_correlation_coefficient
+        # IQ vs TV-hours/week worked example (n=10, no ties in either
+        # vector). Expected ρ = -0.17575757575757575.
+        iq = [86, 97, 99, 100, 101, 103, 106, 110, 112, 113]
+        tv = [0, 20, 28, 27, 50, 29, 7, 17, 6, 12]
+        expected = 1 - 6 * 194 / (10 * (100 - 1))  # -0.175757575...
+        self.assertAlmostEqual(spearman(iq, tv), expected, places=12)
+
+    def test_single_pair_tie_hand_computed(self) -> None:
+        # xs=[1,2,3], ys=[10,20,20].
+        # rx = [1, 2, 3]; ry = [1, 2.5, 2.5].
+        # cov = 1.5, var_x = 2, var_y = 1.5; denom = sqrt(3).
+        # ρ = 1.5/sqrt(3) = sqrt(3)/2 ≈ 0.8660254037844386.
+        self.assertAlmostEqual(
+            spearman([1, 2, 3], [10, 20, 20]),
+            math.sqrt(3) / 2,
+            places=12,
+        )
+
+    def test_ties_on_both_sides_hand_computed(self) -> None:
+        # xs=[1,1,2,3], ys=[10,20,20,30].
+        # rx = [1.5, 1.5, 3.0, 4.0]; ry = [1.0, 2.5, 2.5, 4.0].
+        # mean_x = 2.5, mean_y = 2.5.
+        # dx = [-1.0, -1.0, 0.5, 1.5]; dy = [-1.5, 0.0, 0.0, 1.5].
+        # cov = 1.5 + 0 + 0 + 2.25 = 3.75.
+        # var_x = 1.0 + 1.0 + 0.25 + 2.25 = 4.5.
+        # var_y = 2.25 + 0 + 0 + 2.25 = 4.5.
+        # denom = sqrt(4.5 * 4.5) = 4.5.
+        # ρ = 3.75 / 4.5 = 0.8333333...
+        self.assertAlmostEqual(
+            spearman([1, 1, 2, 3], [10, 20, 20, 30]),
+            3.75 / 4.5,
+            places=12,
+        )
+
+    def test_result_clamped_to_unit_interval(self) -> None:
+        # Sanity invariant of Spearman: result must be in [-1, 1].
+        for xs, ys in (
+            ([1, 2, 3], [3, 2, 1]),
+            ([1, 2, 3, 4], [4, 1, 3, 2]),
+            ([5, 3, 7, 1, 9], [2, 8, 4, 6, 0]),
+        ):
+            r = spearman(xs, ys)
+            self.assertGreaterEqual(r, -1.0, msg=f"out of range for {xs}, {ys}")
+            self.assertLessEqual(r, 1.0, msg=f"out of range for {xs}, {ys}")
+
+
+# ── spearman: error paths ─────────────────────────────────────────────
+
+
+class TestSpearmanErrors(unittest.TestCase):
+    def test_mismatched_lengths_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parallel"):
+            spearman([1, 2, 3], [10, 20])
+
+    def test_empty_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "at least 2"):
+            spearman([], [])
+
+    def test_single_pair_raises(self) -> None:
+        # n=1 has undefined variance; ρ is meaningless. Surface as
+        # an error rather than NaN — calibration callers want to
+        # treat "too few points" as "no signal," not as 0.0.
+        with self.assertRaisesRegex(ValueError, "at least 2"):
+            spearman([7.0], [42.0])
+
+    def test_all_xs_equal_raises(self) -> None:
+        # Zero variation on one side → undefined. The judge-side
+        # equivalent is "judge gave every attempt the same rating";
+        # the human-side equivalent is "reviewer gave every attempt
+        # the same rating." Either way, no signal — must surface.
+        with self.assertRaisesRegex(ValueError, "no variation"):
+            spearman([5, 5, 5, 5], [1, 2, 3, 4])
+
+    def test_all_ys_equal_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "no variation"):
+            spearman([1, 2, 3, 4], [5, 5, 5, 5])
+
+    def test_both_constant_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "no variation"):
+            spearman([3, 3, 3], [4, 4, 4])
+
+
+# ── exact_match_rate ──────────────────────────────────────────────────
+
+
+class TestExactMatchRate(unittest.TestCase):
+    def test_all_match(self) -> None:
+        self.assertEqual(exact_match_rate([1, 2, 3], [1, 2, 3]), 1.0)
+
+    def test_none_match(self) -> None:
+        self.assertEqual(exact_match_rate([1, 2, 3], [4, 5, 6]), 0.0)
+
+    def test_partial_match(self) -> None:
+        # 2/4 match → 0.5.
+        self.assertEqual(exact_match_rate([1, 2, 3, 4], [1, 9, 3, 9]), 0.5)
+
+    def test_float_equality(self) -> None:
+        # Both sides come from the calibration step as int ratings
+        # 1..5, but the helper accepts floats too. Exact equality
+        # is fine for our use (ratings are integers).
+        self.assertEqual(exact_match_rate([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]), 1.0)
+
+    def test_single_pair(self) -> None:
+        # n=1 is allowed for exact_match_rate (no variance needed).
+        self.assertEqual(exact_match_rate([5], [5]), 1.0)
+        self.assertEqual(exact_match_rate([5], [4]), 0.0)
+
+    def test_mismatched_lengths_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "parallel"):
+            exact_match_rate([1, 2], [1, 2, 3])
+
+    def test_empty_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "empty"):
+            exact_match_rate([], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Sub-issue B of epic #34 (calibrated LLM-judge scoring + rich reports). Ships the calibration validation pipeline that turns a labeled corpus + the judge.json artifacts from sub-issue A into the two outputs downstream sub-issues consume: a human-readable `<name>.calibration-report.md` and the machine-readable `<name>.calibrated-dimensions.json` that report.py + report_winner.py will read in sub-issues C / D.

Two commit-chained slices (TB2.1 + TB2.2), each gated by the per-commit diff-review discipline; no live LLM in CI; the audit script landed via PR #54 ran clean against this branch's commit messages + body.

Closes #49.

## What's in this PR

- **Spearman ρ + helpers** (`scripts/benchmark_runner/calibration/spearman.py`) — stdlib-only implementation with average-rank tie handling (the scipy.stats.spearmanr variant). Exposes `spearman()`, `rank_average_ties()`, `exact_match_rate()`. Raises `ValueError` on n<2, mismatched lengths, or all-constant input (the "no signal" cases — surfaced explicitly rather than silently NaN).
- **Validation orchestrator** (`scripts/benchmark_runner/calibration/validate.py`) — `load_labels()` (strict JSONL parsing with line numbers on errors); `evaluate_dimension()` (status classification); `validate_corpus()` (join labels with judge.json, compute per-dimension stats); `write_calibration_artifacts()` (Markdown + JSON writers).
- **`calibrate` CLI subcommand** — `./scripts/benchmark calibrate --labels <jsonl> --judge claude-code:sonnet --name <n> [--threshold 0.6] [--runs-root ./runs] [--output-dir benchmarks/calibration/]`. Threshold input validated to be a finite number in `[0.0, 1.0]`; invalid values → `EXIT_USAGE` with the constraint that failed.
- **67 new tests** (28 spearman + 39 validate/CLI) — golden numbers, threshold boundary at the issue #49 AC sentinels (0.59 / 0.60 / 0.70), out-of-range judge-rating skip, threshold input validation, judge-id alias acceptance, D6 zero-dimensions terminal state.

## Status classification

Each labeled dimension lands in one of three buckets in `calibrated-dimensions.json`:

| Bucket | Meaning |
|---|---|
| **calibrated** | ρ ≥ threshold (computed; n ≥ 2 + variation on both sides) — passes to the winner-extension in sub-issue D |
| **uncalibrated** | ρ < threshold (computed) — surfaces in reports advisory-only; never declares a winner |
| **no_signal** | n < 2 after null-filter OR no variation on either side — Spearman undefined; surfaced explicitly rather than silently NaN |

Threshold default `0.6` (issue #34 v3 verbatim, inclusive `≥`). Boundary cases pinned in the test suite: ρ=0.50 → uncal; ρ=0.60 → cal; ρ=0.70 → cal; ρ=0.70 + `--threshold 0.8` → uncal.

## Data-quality buckets (every skip surfaced with a count)

Each label that didn't enter the calibration sample lands in one of eight bucket counts in the report + JSON output, so a maintainer can see exactly why:

- `labels_with_null_rating` — human said the dimension is structurally inapplicable.
- `labels_for_missing_judge_output` — no judge.json at the expected path.
- `labels_for_unparseable_judge_output` — judge.json present but malformed JSON.
- `labels_for_judge_id_mismatch` — judge.json's identity doesn't match `--judge` (both `claude-code:sonnet` and the alias `claude-code-judge:sonnet` are accepted, mirroring the TB1.5 registry contract).
- `labels_for_missing_dimension` — judge.json doesn't carry a rating for this dimension.
- `labels_for_null_judge_rating` — judge declared this dimension structurally inapplicable.
- `labels_for_malformed_judge_rating` — judge rating is the wrong type (bool, float, str) — defense-in-depth even though `DimensionRating.__post_init__` from TB1.1 catches it at write-time.
- `labels_for_out_of_range_judge_rating` — integer rating outside 1..5. Peer-reviewed P2 fix: without this check, a hand-edited or malformed judge.json with `rating: 6` could enter a Spearman sample and silently mark a dimension as calibrated.

## Zero-dimensions-calibrated terminal state (spec.md D6)

When no dimension clears the threshold, the artifact still produces correctly: `calibrated: []`, every dimension in `uncalibrated` or `no_signal`, and the report carries a paragraph documenting maintainer recovery options (revise the rubric, try a different judge model, or accept the negative result as advisory-only). Covered by a dedicated end-to-end test.

## D-invariant (deterministic-first)

The three deterministic-harness files — `scripts/benchmark_runner/run.py`, `scripts/benchmark_runner/contracts.py`, `scripts/benchmark_runner/report_winner.py` — are **untouched** across both commits in this PR. Verified pre-PR:

```
$ git diff master..HEAD --stat -- \
    scripts/benchmark_runner/run.py \
    scripts/benchmark_runner/contracts.py \
    scripts/benchmark_runner/report_winner.py
(zero output)
```

The calibration step computes correlations over existing judge/human data — it has no business touching deterministic scoring, and this guarantee is verifiable in the diff, not just asserted.

## Acceptance criteria (issue #49)

- [x] `./scripts/benchmark calibrate --judge claude-code:sonnet --labels <path>` produces `<name>.calibration-report.md` + `<name>.calibrated-dimensions.json` against a synthetic label set — covered by `TestValidateAndWrite::test_produces_both_artifacts` and `TestCliCalibrate::test_happy_path`.
- [x] Threshold boundary tested at 0.59, 0.60, 0.70 — a dimension scoring 0.59 is omitted at default threshold; one scoring 0.60 is included — covered by `TestThresholdBoundary` (3 boundary tests + custom-threshold override).
- [x] Golden-numbers test for the Spearman implementation against published vectors — `TestSpearman::test_wikipedia_iq_tv_example` pins against the Wikipedia n=10 worked example; additional hand-computed tied-ratings cases.
- [x] `scripts/benchmark_runner/{run,report_winner,contracts}.py` unchanged — D-invariant diff above.

## Test plan

- [x] `pytest test_spearman.py test_calibration_validate.py -q` → 67 passed.
- [x] Full judge + corpus + registry + calibration subsystem → **224 passed in 79.49s**.
- [x] Adjacent regression sweep (`test_contracts` / `test_claude_code_backend` / `test_report` / `test_report_winner`) → 84 passed, 3 subtests — no regression.
- [x] `scripts/pre-pr-check.sh --closes 49 --title "feat(benchmark): … (Closes #49)" --body-file <this body>` → passes cleanly (commit-message audit + body audit + title gate).
- [x] D-invariant `git diff --quiet` on the three protected files → exit 0.

## Out of scope (deferred to sibling sub-issues)

- **#50** — rich reports (HTML + CSV + static SVG charts). The SVG scatter-plots per dimension that the spec originally placed in `calibration-report.md` are deferred to sub-issue C per scope confirmation 2026-05-20; the Markdown report this PR ships is text-only.
- **#51** — calibrated-judge winner-extension on `declare_winner` (deterministic-first enforced).
- **#52** — first labeled calibration set + first calibration-report; the PR for that sub-issue also auto-closes epic #34 via a separate close-keyword in its own body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
