### PR TITLE
fix(ci): least-privilege permissions for benchmark-smoke workflow

### DIFF
--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -15,6 +15,12 @@ on:
 # (init -> run -> score -> report) without invoking any LLM. Wall-time
 # target: <90s on GitHub free runners.
 
+# Least-privilege GITHUB_TOKEN: this workflow only reads the repo
+# (checkout + run tests + read generated files). No write scopes
+# needed. Mirrors wiki-lint.yml / sync-check.yml.
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves the CodeQL `actions/missing-workflow-permissions` alert (#4, medium severity) in `.github/workflows/benchmark-smoke.yml`.

The workflow declared no top-level `permissions:` block, so its `GITHUB_TOKEN` defaulted to the repository's broad default scope. The `smoke` job only reads the repo — checkout, run the unittest suite, exercise the stub adapter, read generated report files. No write scopes are needed.

## Change

Adds a top-level least-privilege block:

```yaml
permissions:
  contents: read
```

Mirrors the convention already in `wiki-lint.yml`, `sync-check.yml`, and `wiki-ingest-tests.yml`.

## Verification

- 6-line additive change, no logic touched.
- Once merged to the analyzed branch, CodeQL re-scans and auto-dismisses alert #4 (the repo uses CodeQL default setup — alerts clear on the fix landing, not via in-repo suppression).